### PR TITLE
refactor(logger): adminとfuneral関連のconsole.logをpino loggerに置き換え

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,266 +1,937 @@
-# AGENTS.md - 香典帳アプリ開発ガイドライン
-
-## プロジェクト概要
-
-このプロジェクトは香典帳管理アプリケーションです。Next.js + TypeScript + Supabase + Tailwind CSS + shadcn/uiの技術スタックを使用しています。
-
-## 基本原則
-
-### 🚫 絶対に守るべきルール
-
-1. **TypeScriptの`any`型は絶対に使用禁止**
-   - 型安全性を損なう`any`は一切使用しない
-   - 不明な型は`unknown`を使用し、適切な型ガードを実装する
-   - 外部APIレスポンスも必ず型定義を行う
-
-2. **その場しのぎの実装禁止**
-   - 根本的な問題解決を優先する
-   - 将来的な拡張性を考慮した設計を行う
-   - 技術的負債を蓄積させない
-
-3. **日本語テキストの徹底**
-   - ユーザーに表示される全てのテキストは日本語で記述
-   - エラーメッセージ、ラベル、プレースホルダーなど全て含む
-   - 日本の慣習に合わせた丁寧語を使用
-
-## 技術スタック・アーキテクチャ
-
-### フロントエンド
-- **Next.js 15** (App Router)
-- **TypeScript+**
-- **React 19** (Server Components & Client Components適切に使い分け)
-- **Tailwind CSS v4** (スタイリング)
-- **shadcn/ui** (UIコンポーネント)
-
-### バックエンド・データベース
-- **Supabase** (認証・データベース・リアルタイム機能)
-- **PostgreSQL** (メインデータベース)
-- **Row Level Security (RLS)** (セキュリティ)
-- **Bun** (パッケージマネージャー)
-
-### 状態管理・データフェッチング
-- **Jotai** (クライアント状態管理)
-- **Supabase Client** (データフェッチング)
-- **React Query/TanStack Query** (サーバー状態管理)
-
-## コーディング規則
-
-### 型定義・TypeScript
-
-```typescript
-// ❌ 悪い例
-function processData(data: any) {
-  return data.someProperty;
-}
-
-// ✅ 良い例
-interface UserData {
-  id: string;
-  name: string;
-  email: string;
-}
-
-function processData(data: UserData): string {
-  return data.name;
-}
-```
-
-- **すべての関数に型注釈を必須とする**
-- **interfaceとtypeの使い分けを明確にする**
-  - 拡張可能なオブジェクト型: `interface`
-  - Union型、計算型: `type`
-- **Genericsを積極的に活用する**
-- **null/undefinedの扱いを明確にする**
-
-### コンポーネント設計
-
-```typescript
-// ✅ 良いコンポーネント例
-interface KoudenEntryProps {
-  entry: KoudenEntry;
-  onUpdate: (entry: KoudenEntry) => Promise<void>;
-  isEditable?: boolean;
-}
-
-export const KoudenEntryCard: React.FC<KoudenEntryProps> = ({
-  entry,
-  onUpdate,
-  isEditable = false
-}) => {
-  // 実装
-};
-```
-
-- **Props型を必ず定義する**
-- **デフォルト値は型定義内で明記する**
-- **単一責任の原則を守る**
-- **Server ComponentsとClient Componentsを適切に使い分ける**
-
-### エラーハンドリング
-
-```typescript
-// ✅ 適切なエラーハンドリング
-async function createKoudenEntry(data: CreateKoudenEntryInput) {
-  try {
-    const { data: entry, error } = await supabase
-      .from('kouden_entries')
-      .insert(data)
-      .select()
-      .single();
-
-    if (error) {
-      throw new Error(`記帳の作成に失敗しました: ${error.message}`);
-    }
-
-    return { success: true, data: entry };
-  } catch (error) {
-    console.error('記帳作成エラー:', error);
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : '不明なエラーが発生しました'
-    };
-  }
-}
-```
-
-- **すべての非同期処理にエラーハンドリングを実装**
-- **ユーザーフレンドリーなエラーメッセージを提供**
-- **Supabaseエラーを適切にキャッチ・変換する**
-
-### パフォーマンス最適化
-
-- **React.memo、useMemo、useCallbackを適切に使用**
-- **不要な再レンダリングを防ぐ**
-- **画像の最適化（next/image使用）**
-- **Suspenseとロケーティングスタイルを活用**
-- **スケルトンコンポーネントでkeyにindexを使用する場合は必ずuseMemoで最適化**
-
-```typescript
-// ✅ スケルトンコンポーネントの正しい実装例
-const SkeletonList: React.FC<{ count: number }> = ({ count }) => {
-  const skeletons = useMemo(
-    () => Array.from({ length: count }, (_, index) => (
-      <div key={index} className="animate-pulse">
-        <div className="h-4 bg-gray-200 rounded mb-2" />
-        <div className="h-3 bg-gray-200 rounded w-3/4" />
-      </div>
-    )),
-    [count]
-  );
-
-  return <div className="space-y-4">{skeletons}</div>;
-};
-
-// ❌ 悪い例（毎回新しい配列を生成）
-const BadSkeletonList: React.FC<{ count: number }> = ({ count }) => {
-  return (
-    <div className="space-y-4">
-      {Array.from({ length: count }, (_, index) => (
-        <div key={index} className="animate-pulse">
-          <div className="h-4 bg-gray-200 rounded mb-2" />
-          <div className="h-3 bg-gray-200 rounded w-3/4" />
-        </div>
-      ))}
-    </div>
-  );
-};
-```
-
-### データベース・セキュリティ
-
-- **Row Level Security (RLS) を必ず有効にする**
-- **SQL インジェクション対策を徹底**
-- **適切な認可チェックを実装**
-- **センシティブデータの暗号化**
-
-## ファイル構成・命名規則
-
-### ディレクトリ構造
-```
-src/
-├── app/                 # Next.js App Router
-│   ├── (public)/       # 認証不要ページ
-│   ├── (protected)/    # 認証必要ページ
-│   └── (system)/       # 管理者専用ページ
-├── components/         # 再利用可能コンポーネント
-├── hooks/             # カスタムフック
-├── lib/               # ユーティリティ・設定
-├── stores/            # Zustand stores
-├── types/             # 型定義
-└── utils/             # ヘルパー関数
-```
-
-### 命名規則
-- **ファイル名**: kebab-case (`kouden-entry-form.tsx`)
-- **コンポーネント名**: PascalCase (`KoudenEntryForm`)
-- **関数名**: camelCase (`createKoudenEntry`)
-- **定数**: SCREAMING_SNAKE_CASE (`MAX_ENTRY_COUNT`)
-- **型名**: PascalCase (`KoudenEntry`)
-
-## 特定ドメイン規則（香典帳アプリ）
-
-### 金額の扱い
-```typescript
-// ✅ 金額は必ずnumber型で統一
-interface KoudenEntry {
-  amount: number; // 円単位
-  created_at: string;
-  guest_name: string;
-}
-
-// 表示時のフォーマット
-const formatCurrency = (amount: number): string => {
-  return `¥${amount.toLocaleString('ja-JP')}`;
-};
-```
-
-### 日本の慣習への対応
-- **敬語・丁寧語の適切な使用**
-- **日本の住所形式に対応**
-- **和暦・西暦両対応**
-- **日本の電話番号フォーマット**
-
-### データ検証
-```typescript
-// ✅ 香典金額のバリデーション例
-const validateKoudenAmount = (amount: number): boolean => {
-  // 香典の一般的な金額範囲をチェック
-  return amount >= 1000 && amount <= 1000000 && amount % 1000 === 0;
-};
-```
-
-## テスト戦略
-
-- **単体テスト**: Vitest + Testing Library
-- **E2Eテスト**: Playwright
-- **型チェック**: TypeScript strict mode
-- **リント**: ESLint + Biome
-
-## デプロイ・運用
-
-- **環境変数の適切な管理**
-- **本番環境でのエラー監視**
-- **パフォーマンス監視**
-- **セキュリティ監査**
-
-## 禁止事項
-
-1. `any`型の使用
-2. `console.log`の本番環境への残存
-3. ハードコーディングされた文字列（i18n対応必須）
-4. セキュリティを考慮しないデータベースアクセス
-5. 適切でないエラーハンドリング
-6. 未使用のimport文
-7. 型安全でないキャスト
-
-## 推奨ライブラリ
-
-- **フォームバリデーション**: react-hook-form + zod
-- **日付処理**: date-fns
-- **アイコン**: lucide-react
-- **PDF生成**: react-pdf
-- **通知**: sonner
+あなたは優秀なAIコーディングエージェントです。
+以下のLegible Softwareの原則に則って実装作業を行なってください。
 
 ---
 
-**注意**: このガイドラインに従わない実装は受け入れられません。不明な点がある場合は、必ず確認してから実装を進めてください。 
+## 概要
+
+### このフレームワークの目的
+
+このフレームワークは、「Legible Software」の**Concept（概念）**と**Synchronization（同期）**の原則を中核に据えます。以下の目的を達成します：
+
+- **AIにとって理解しやすい**: 変更対象のConceptやSynchronizationという限定的なコンテキストのみを理解すれば、安全で精度の高いコード生成が可能
+- **人間にとって把握しやすい**: システムの全体像が把握しやすく、変更の影響範囲が明確
+- **変更に強い**: 関心事の分離により、一箇所の変更が他に波及しにくい構造
+
+### ConceptとSynchronizationの基本概念
+
+*   **Concept**: アプリケーションの機能単位。自己完結しており、自身の状態とそれを操作するロジックのみを持つ。他のConceptを直接参照しない。
+*   **Synchronization**: 複数のConceptを連携させるためのルールセット。「何が起きたら(when)、何をする(then)」を記述する。状態を持たず、Concept間の仲介役に徹する。
+
+---
+
+## 基本原則
+
+### Legible Softwareの原則
+
+1. **Conceptの独立性**: Conceptは、他のいかなるConceptも直接`import`してはならない。完全に独立した単位として設計する。
+2. **状態の単一所有**: 状態は必ず単一のConceptに属する。Synchronizationは状態を持たない。
+3. **Synchronizationの仲介役**: Concept間の連携は、Synchronizationを通じてのみ行われる。Synchronizationは状態を持たず、Conceptの状態を読み取り、別のConceptのアクションをトリガーする役割に徹する。
+
+### なぜこの原則が重要なのか
+
+- **AIの理解範囲を限定**: AIは変更対象のConceptやSynchronizationという限定的なコンテキストのみを理解すればよい
+- **影響範囲の明確化**: 依存関係が明確なため、変更の影響範囲が即座に判定できる
+- **テストの容易さ**: Concept単体のテストが容易で、Synchronizationのテストも複数のConceptの状態をインプットとして検証できる
+
+---
+
+## ディレクトリ構造
+
+### 基本構造 (Next.js Colocation風)
+
+関連ファイルを機能単位（Concept）でまとめることで、関心事の分離を徹底します。
+
+```plaintext
+.
+├── docs/
+│   ├── 00_prompts/              # AI・開発者への指示書
+│   ├── 01_issues/               # 問題・要件定義
+│   │   ├── open/                # 未解決のIssue
+│   │   └── resolved/            # 解決済みのIssue
+│   ├── 02_research/             # 技術選定・調査結果
+│   ├── 03_plans/                # 段階的な実装計画
+│   └── 05_logs/                 # 作業記録
+│
+├── src/
+│   ├── concepts/
+│   │   ├── post/
+│   │   │   ├── index.ts         # Post Conceptの公開API (型定義, アクション)
+│   │   │   ├── state.ts         # 状態の型定義と初期状態
+│   │   │   ├── actions.ts       # 状態を操作するロジック (純粋関数)
+│   │   │   ├── post.test.ts     # 単体テスト (npm run test)
+│   │   │   └── post.spec.md     # 仕様書 (このConceptの責務、状態、アクション、テストケースを記述)
+│   │   │
+│   │   └── user/
+│   │       ├── index.ts
+│   │       ├── state.ts
+│   │       ├── actions.ts
+│   │       ├── user.test.ts
+│   │       └── user.spec.md
+│   │
+│   ├── synchronizations/
+│   │   ├── userPosts.sync.ts    # UserとPostを連携させるロジック
+│   │   ├── userPosts.sync.test.ts
+│   │   └── userPosts.spec.md    # この連携の目的やルール、テストケースを記述
+│   │
+│   ├── lib/                     # 外部APIクライアントなど、共通のライブラリ
+│   │
+│   ├── ui/                      # UIコンポーネント (Reactなど)
+│   │   ├── components/
+│   │   └── pages/
+│   │
+│   └── main.ts                  # アプリケーションのエントリーポイント
+│
+└── src-tauri/                   # Tauriの設定ファイル (Rustコードなど)
+```
+
+### 発展的な構造（ドメイン別グルーピング）
+
+Conceptが増えてきたら、ドメイン（関連領域）でグルーピングします。
+
+```plaintext
+src/
+├── concepts/
+│   ├── identity/         # 認証・認可ドメイン
+│   │   ├── user/
+│   │   └── auth/
+│   │
+│   └── publishing/       # コンテンツ公開ドメイン
+│       ├── post/
+│       ├── comment/
+│       └── like/
+│
+└── synchronizations/
+    ├── identity-publishing.sync.ts # 認証と公開ドメイン間の連携
+    └── publishing-internal.sync.ts # 公開ドメイン内部での連携
+```
+
+---
+
+## コーディングルール
+
+### A. Conceptのルール
+
+#### 1. 独立性の原則
+
+Conceptは、他のいかなるConceptも直接`import`してはならない。
+
+**❌ 悪い例:**
+```typescript
+// src/concepts/post/actions.ts
+import { UserState } from '../user/state'; // ❌ 他のConceptを直接参照
+
+export const addPost = (state: PostState, post: Post, userState: UserState): PostState => {
+  // ...
+};
+```
+
+**✅ 良い例:**
+```typescript
+// src/concepts/post/actions.ts
+import { Post, PostState } from './state';
+
+// 外部のConceptに依存せず、渡されたデータで自身の状態を更新するだけ
+export const addPost = (state: PostState, post: Post): PostState => {
+  return {
+    ...state,
+    posts: [...state.posts, post],
+  };
+};
+```
+
+#### 2. 自己完結
+
+Conceptは、自身の`state`とそれを操作する`actions`のみで構成される。`actions`は可能な限り純粋関数として実装する。
+
+**ファイル構成:**
+- `state.ts`: 状態の型定義と初期状態
+- `actions.ts`: 状態を操作するロジック（純粋関数）
+- `index.ts`: 公開API（型定義、アクションのエクスポート）
+- `{concept-name}.test.ts`: 単体テスト（.spec.mdのTest Casesに基づいて記述）
+- `{concept-name}.spec.md`: 仕様書（RequirementsとTest Casesを含む）
+
+#### 3. 副作用の分離
+
+外部APIの呼び出しやデータベースへのアクセスといった副作用はConcept内に直接記述しない。これらは上位層（`synchronizations`やアプリケーションサービス層）が担当し、結果を引数として`actions`に渡す。
+
+**例: `src/concepts/post/actions.ts`**
+```typescript
+import { Post, PostState } from './state';
+
+// 外部のConceptに依存せず、渡されたデータで自身の状態を更新するだけ
+export const addPost = (state: PostState, post: Post): PostState => {
+  return {
+    ...state,
+    posts: [...state.posts, post],
+  };
+};
+
+// ❌ 副作用を含む実装は避ける
+// export const fetchAndAddPost = async (state: PostState, postId: string): Promise<PostState> => {
+//   const post = await fetchPostFromAPI(postId); // ❌ 副作用
+//   return addPost(state, post);
+// };
+```
+
+### B. Synchronizationのルール
+
+#### 1. 唯一の連携点
+
+複数のConceptを`import`し、連携させることができるのは`synchronizations`ディレクトリ内のファイルのみ。
+
+**例: `src/synchronizations/userPosts.sync.ts`**
+```typescript
+import * as UserConcept from '../concepts/user';
+import * as PostConcept from '../concepts/post';
+
+// when: ユーザーが作成されたら
+// then: そのユーザーの初期投稿を作成する
+export const onUserCreated = (
+  userState: UserConcept.UserState,
+  postState: PostConcept.PostState,
+  userId: string
+): PostConcept.PostState => {
+  const user = userState.users.find(u => u.id === userId);
+  if (!user) {
+    return postState; // where: ユーザーが存在しない場合は何もしない
+  }
+
+  const welcomePost = {
+    id: 'post-0',
+    authorId: userId,
+    content: `ようこそ、${user.name}さん！`,
+  };
+
+  return PostConcept.actions.addPost(postState, welcomePost);
+};
+```
+
+#### 2. 状態を持たない
+
+Synchronizationは状態を持たない。Conceptの状態を読み取り、別のConceptのアクションをトリガーする役割に徹する。
+
+#### 3. 宣言的な記述
+
+「when (イベント), where (条件), then (アクション)」を意識したコードを記述する。イベント駆動の設計が適している。
+
+**命名規則:**
+- `on{Event}`: イベントハンドラー（例: `onUserCreated`）
+- `when{Condition}`: 条件付き処理（例: `whenUserLikesPost`）
+
+### C. テストとドキュメント
+
+#### 1. テスト駆動開発
+
+- 新しい`action`を実装する前に、必ず`*.test.ts`にテストケースを追加する
+- `npm run test`で、Concept単体のロジックが期待通りに動作することを保証する
+- Synchronizationのテストでは、複数のConceptの状態をインプットとし、連携後の状態が期待通りか検証する
+
+**例: `src/concepts/post/post.test.ts`**
+```typescript
+import { describe, it, expect } from 'npm run:test';
+import { addPost } from './actions';
+import { initialPostState } from './state';
+
+describe('Post Concept', () => {
+  it('should add a post to the state', () => {
+    const newPost = { id: '1', authorId: 'user-1', content: 'Hello' };
+    const result = addPost(initialPostState, newPost);
+    
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0]).toEqual(newPost);
+  });
+});
+```
+
+#### 2. ドキュメント駆動開発
+
+このフレームワークでは、**ドキュメント駆動開発**と**テスト駆動開発**を組み合わせて実践します。
+
+**ドキュメントの種類:**
+
+1. **Spec（仕様書）**: `src/concepts/{concept-name}/{concept-name}.spec.md` / `src/synchronizations/{name}.spec.md`
+   - Concept/Synchronizationの仕様定義とテストケース定義を記述
+   - Requirements（要件）とTest Cases（テストケース）を含む
+   - 実装ファイルと同じディレクトリに配置
+
+2. **Issue（問題・要件）**: `docs/01_issues/open/YYYY_MM/YYYYMMDD_{issue-name}.md`
+   - 新機能の要件定義やバグ報告を記述
+   - 実装前に作成し、実装完了後に`resolved/`に移動
+
+3. **Research（技術調査）**: `docs/02_research/YYYY_MM/YYYYMMDD_{research-name}.md`
+   - 技術選定や調査結果を記述
+   - Concept/Synchronizationの実装前に技術的な検討が必要な場合に作成
+
+4. **Plan（実装計画）**: `docs/03_plans/{feature-name}/YYYYMMDD_{plan-name}.md`
+   - 段階的な実装計画を記述
+   - 複数のConcept/Synchronizationにまたがる機能の場合に作成
+
+5. **Log（作業ログ）**: `docs/05_logs/YYYY_MM/YYYYMMDD/{log-name}.md`
+   - 実装作業の記録を記述
+   - 実装完了後に作成
+
+**仕様書の配置:**
+
+- **Conceptの仕様書**: `src/concepts/{concept-name}/{concept-name}.spec.md`
+  - そのConceptが担当する責務、管理する状態の構造、各アクションの目的と動作を記述
+  - Requirements（要件）とTest Cases（テストケース）を含む
+
+- **Synchronizationの仕様書**: `src/synchronizations/{name}.spec.md`
+  - どのConcept間を、どのようなルールで連携させるのかを記述
+  - when（イベント）、where（条件）、then（アクション）を明確に記述
+  - Requirements（要件）とTest Cases（テストケース）を含む
+
+**仕様書の構造例:**
+
+```markdown
+# Post Concept Specification
+
+## Related Files
+
+- Implementation: `src/concepts/post/index.ts`
+- State: `src/concepts/post/state.ts`
+- Actions: `src/concepts/post/actions.ts`
+- Tests: `src/concepts/post/post.test.ts`
+
+## Related Documentation
+
+- Issue: `docs/01_issues/resolved/2025_10/20251022_01_post-concept.md`
+- Plan: `docs/03_plans/post-feature/20251022_01_implementation-plan.md`
+- Log: `docs/05_logs/2025_10/20251022/post-concept-implementation.md`
+- Synchronizations:
+  - userPosts: `src/synchronizations/userPosts.sync.ts`
+
+## Requirements
+
+### 責務
+- 投稿データの管理
+- 投稿の追加・更新・削除
+
+### 状態構造
+- PostState: { posts: Post[] }
+- Post: { id: string, authorId: string, content: string }
+
+### アクション
+- addPost: 投稿を追加
+- updatePost: 投稿を更新
+- deletePost: 投稿を削除
+
+## Test Cases
+
+### TC-001: addPost
+- Given: 空のPostState
+- When: addPost(state, newPost)を実行
+- Then: posts配列にnewPostが追加される
+
+### TC-002: updatePost
+- Given: 既存の投稿を含むPostState
+- When: updatePost(state, postId, updatedContent)を実行
+- Then: 指定された投稿のcontentが更新される
+```
+
+**ファイルとドキュメントの同期:**
+
+実装ファイルを修正したら、必ず関連ドキュメントも更新してください：
+
+**必須の更新:**
+- `.spec.md`の「Requirements」セクションを更新
+- `.spec.md`の「Test Cases」に新規テストケースを追加
+- `.test.ts`に対応するテストを追加（.spec.mdのTest Casesに基づいて）
+- DEPENDENCY MAPを更新（実装ファイルの先頭コメント）
+
+**推奨の更新:**
+- 実装計画の進捗状況を更新（Planが存在する場合）
+- 作業ログを記録（大きな変更の場合）
+- Issueの状態を更新（open → resolved など、バグ修正の場合）
+
+**更新チェックリスト:**
+- [ ] `.spec.md`の「Requirements」は最新か？
+- [ ] `.spec.md`の「Test Cases」に新しいケースを追加したか？
+- [ ] `.test.ts`は`.spec.md`のTest Casesと一致しているか？
+- [ ] DEPENDENCY MAPが最新か？（Parents / Dependencies）
+- [ ] 親ファイル（Parents）のDEPENDENCY MAPも更新したか？
+- [ ] Spec/Issue/Plan/Logへの参照が最新か？
+
+---
+
+## 実装フロー
+
+### ドキュメント駆動開発のワークフロー
+
+```
+PROMPT → ISSUE → RESEARCH → PLAN → SPEC+TEST → IMPLEMENTATION → LOG
+```
+
+1. **Prompt（プロンプト）**: `docs/00_prompts/` - AI・開発者への指示書（このファイル）
+2. **Issue（問題・要件）**: `docs/01_issues/open/YYYY_MM/` - 問題・要件定義
+3. **Research（技術調査）**: `docs/02_research/YYYY_MM/` - 技術選定・調査結果（必要に応じて）
+4. **Plan（実装計画）**: `docs/03_plans/{機能名}/` - 段階的な実装計画（複数Conceptにまたがる場合）
+5. **Spec（仕様書）**: `src/concepts/{concept-name}/{concept-name}.spec.md` / `src/synchronizations/{name}.spec.md` - 仕様定義＋テストケース定義
+6. **Implementation（実装）**: テスト駆動開発で実装
+7. **Log（作業ログ）**: `docs/05_logs/YYYY_MM/YYYYMMDD/` - 作業記録
+
+### Concept作成フロー
+
+```
+1. Issue作成（必要に応じて）
+   └── docs/01_issues/open/YYYY_MM/YYYYMMDD_{concept-name}.md
+       - 新Conceptの要件を定義
+
+2. Research作成（技術的な検討が必要な場合）
+   └── docs/02_research/YYYY_MM/YYYYMMDD_{concept-name}-research.md
+       - 技術選定や設計方針を検討
+
+3. Plan作成（複数のConcept/Synchronizationにまたがる場合）
+   └── docs/03_plans/{feature-name}/YYYYMMDD_{plan-name}.md
+       - 段階的な実装計画を記述
+
+4. Spec作成（仕様書）
+   └── src/concepts/{concept-name}/{concept-name}.spec.md
+       - Requirements（要件）を記述
+       - Test Cases（テストケース）を記述
+
+5. ディレクトリ作成
+   └── src/concepts/{concept-name}/
+
+6. ファイル作成
+   ├── state.ts      # 状態の型定義と初期状態
+   ├── actions.ts    # 状態を操作するロジック
+   ├── index.ts      # 公開API
+   └── {concept-name}.test.ts  # テスト
+
+7. テスト駆動開発
+   ├── .spec.mdのTest Casesに基づいてテストケースを書く
+   ├── テストを実行（失敗することを確認）
+   ├── 実装する（テストが通る最小限の実装）
+   ├── リファクタリング
+   └── npm run test で確認（成功することを確認）
+
+8. ドキュメント更新
+   ├── .spec.mdのRequirementsを実装に合わせて更新
+   └── DEPENDENCY MAPを記載
+
+9. Log作成
+   └── docs/05_logs/YYYY_MM/YYYYMMDD/{concept-name}-implementation.md
+       - 実装作業の記録
+
+10. Issue解決
+    └── docs/01_issues/open/ → docs/01_issues/resolved/ へ移動
+```
+
+### Synchronization作成フロー
+
+```
+1. Issue作成（必要に応じて）
+   └── docs/01_issues/open/YYYY_MM/YYYYMMDD_{sync-name}.md
+       - 新Synchronizationの要件を定義
+
+2. Research作成（技術的な検討が必要な場合）
+   └── docs/02_research/YYYY_MM/YYYYMMDD_{sync-name}-research.md
+       - 連携方法の検討
+
+3. Plan作成（複数のConcept/Synchronizationにまたがる場合）
+   └── docs/03_plans/{feature-name}/YYYYMMDD_{plan-name}.md
+       - 段階的な実装計画を記述
+
+4. Spec作成（仕様書）
+   └── src/synchronizations/{name}.spec.md
+       - Requirements（要件）を記述
+       - when（イベント）、where（条件）、then（アクション）を明確に記述
+       - Test Cases（テストケース）を記述
+
+5. ファイル作成
+   ├── src/synchronizations/{name}.sync.ts
+   └── src/synchronizations/{name}.sync.test.ts
+
+6. 連携するConceptを特定
+   └── どのConcept間を連携させるか明確にする
+
+7. テスト駆動開発
+   ├── .spec.mdのTest Casesに基づいてテストケースを書く
+   ├── 複数のConceptの状態をインプットとしてテスト
+   ├── テストを実行（失敗することを確認）
+   ├── 実装する（テストが通る最小限の実装）
+   ├── リファクタリング
+   └── npm run test で確認（成功することを確認）
+
+8. ドキュメント更新
+   ├── .spec.mdのRequirementsを実装に合わせて更新
+   └── DEPENDENCY MAPを記載
+
+9. Log作成
+   └── docs/05_logs/YYYY_MM/YYYYMMDD/{sync-name}-implementation.md
+       - 実装作業の記録
+
+10. Issue解決
+    └── docs/01_issues/open/ → docs/01_issues/resolved/ へ移動
+```
+
+### テスト駆動開発の流れ
+
+```
+1. SpecのTest Casesを確認
+   └── .spec.mdのTest Casesセクションを参照
+
+2. テストケースを書く
+   └── .test.tsに.spec.mdのTest Casesに基づいてテストコードを記述
+
+3. テストを実行（失敗することを確認）
+   └── npm run test
+
+4. 実装する
+   └── テストが通る最小限の実装
+
+5. リファクタリング
+   └── コードの品質を向上させる
+
+6. テストを再実行（成功することを確認）
+   └── npm run test
+
+7. Specの更新
+   └── 実装に合わせて.spec.mdのRequirementsを更新
+```
+
+---
+
+## 依存関係の明示
+
+### Concept間の依存関係マッピング
+
+Conceptは他のConceptを直接参照しないため、Concept間の依存関係は存在しません。代わりに、SynchronizationがConcept間の連携を担当します。
+
+### Synchronizationの依存関係
+
+Synchronizationファイルの先頭に、依存関係マップを記載してください：
+
+```typescript
+/**
+ * UserPosts Synchronization
+ *
+ * DEPENDENCY MAP:
+ *
+ * Concepts (Concept files that this synchronization imports):
+ *   ├─ src/concepts/user/index.ts
+ *   └─ src/concepts/post/index.ts
+ */
+
+import * as UserConcept from '../concepts/user';
+import * as PostConcept from '../concepts/post';
+
+// ...
+```
+
+### Conceptファイルの依存関係マッピング
+
+Conceptファイルの先頭にも、依存関係マップを記載してください：
+
+```typescript
+/**
+ * Post Concept
+ *
+ * DEPENDENCY MAP:
+ *
+ * Parents (Files that import this Concept):
+ *   ├─ src/synchronizations/userPosts.sync.ts
+ *   ├─ src/ui/components/PostList.tsx
+ *   └─ src/ui/pages/PostPage.tsx
+ */
+
+import { Post, PostState } from './state';
+import * as actions from './actions';
+
+// ...
+```
+
+**なぜ必要か:**
+- 修正時の影響範囲が即座に判定できる
+- リファクタリングのリスク評価が容易
+- 軽量AIモデルでも依存関係を理解できる
+- デッドコード検出が簡単
+
+---
+
+## チェックリスト
+
+### Concept作成時のチェックリスト
+
+新しいConceptを作成する際は、以下を確認してください：
+
+**ドキュメント作成:**
+- [ ] Issueを作成したか？（必要に応じて）`docs/01_issues/open/YYYY_MM/YYYYMMDD_{concept-name}.md`
+- [ ] Researchを作成したか？（技術的な検討が必要な場合）`docs/02_research/YYYY_MM/YYYYMMDD_{concept-name}-research.md`
+- [ ] Planを作成したか？（複数のConcept/Synchronizationにまたがる場合）`docs/03_plans/{feature-name}/YYYYMMDD_{plan-name}.md`
+- [ ] Specを作成したか？`src/concepts/{concept-name}/{concept-name}.spec.md`
+  - [ ] Requirements（要件）を記述したか？
+  - [ ] Test Cases（テストケース）を記述したか？
+
+**実装:**
+- [ ] `src/concepts/{concept-name}/` ディレクトリを作成したか？
+- [ ] `state.ts` に状態の型定義と初期状態を定義したか？
+- [ ] `actions.ts` に純粋関数としてアクションを実装したか？
+- [ ] `index.ts` に公開APIを定義したか？
+- [ ] 他のConceptを直接`import`していないか？（独立性の原則）
+- [ ] 副作用（API呼び出し、DBアクセス）を含んでいないか？
+
+**テスト:**
+- [ ] `.spec.md`のTest Casesに基づいて`{concept-name}.test.ts`にテストケースを追加したか？
+- [ ] `npm run test` でテストが通るか？
+
+**ドキュメント更新:**
+- [ ] `.spec.md`のRequirementsを実装に合わせて更新したか？
+- [ ] ファイル先頭に DEPENDENCY MAP を記載したか？
+  - [ ] Specへの参照を記載したか？
+  - [ ] Issue/Plan/Logへの参照を記載したか？（存在する場合）
+
+**完了作業:**
+- [ ] Logを作成したか？`docs/05_logs/YYYY_MM/YYYYMMDD/{concept-name}-implementation.md`
+- [ ] Issueを`resolved/`に移動したか？（Issueを作成した場合）
+
+### Synchronization作成時のチェックリスト
+
+新しいSynchronizationを作成する際は、以下を確認してください：
+
+**ドキュメント作成:**
+- [ ] Issueを作成したか？（必要に応じて）`docs/01_issues/open/YYYY_MM/YYYYMMDD_{sync-name}.md`
+- [ ] Researchを作成したか？（技術的な検討が必要な場合）`docs/02_research/YYYY_MM/YYYYMMDD_{sync-name}-research.md`
+- [ ] Planを作成したか？（複数のConcept/Synchronizationにまたがる場合）`docs/03_plans/{feature-name}/YYYYMMDD_{plan-name}.md`
+- [ ] Specを作成したか？`src/synchronizations/{name}.spec.md`
+  - [ ] Requirements（要件）を記述したか？
+  - [ ] when（イベント）、where（条件）、then（アクション）を明確に記述したか？
+  - [ ] Test Cases（テストケース）を記述したか？
+
+**実装:**
+- [ ] `src/synchronizations/{name}.sync.ts` を作成したか？
+- [ ] 連携するConceptを明確に特定したか？
+- [ ] 「when (イベント), where (条件), then (アクション)」を意識した実装か？
+- [ ] 状態を持たない実装か？（純粋関数として実装）
+
+**テスト:**
+- [ ] `.spec.md`のTest Casesに基づいて`{name}.sync.test.ts`にテストケースを追加したか？
+- [ ] 複数のConceptの状態をインプットとしてテストしているか？
+- [ ] `npm run test` でテストが通るか？
+
+**ドキュメント更新:**
+- [ ] `.spec.md`のRequirementsを実装に合わせて更新したか？
+- [ ] ファイル先頭に DEPENDENCY MAP を記載したか？
+  - [ ] Specへの参照を記載したか？
+  - [ ] Issue/Plan/Logへの参照を記載したか？（存在する場合）
+
+**完了作業:**
+- [ ] Logを作成したか？`docs/05_logs/YYYY_MM/YYYYMMDD/{sync-name}-implementation.md`
+- [ ] Issueを`resolved/`に移動したか？（Issueを作成した場合）
+
+### コード更新時のチェックリスト
+
+既存のConceptやSynchronizationを更新する際は、以下を確認してください：
+
+**ドキュメント更新:**
+- [ ] `.spec.md`の「Requirements」セクションを更新したか？
+- [ ] `.spec.md`の「Test Cases」に新規テストケースを追加したか？
+- [ ] 実装計画の進捗状況を更新したか？（Planが存在する場合）
+- [ ] 作業ログを記録したか？（大きな変更の場合）
+
+**テスト:**
+- [ ] `.test.ts`に`.spec.md`のTest Casesに基づいてテストケースを追加・更新したか？
+- [ ] `npm run test` でテストが通るか？
+
+**依存関係:**
+- [ ] DEPENDENCY MAP が最新か？（Parents / Dependencies）
+- [ ] 親ファイル（Parents）の DEPENDENCY MAP も更新したか？
+- [ ] Spec/Issue/Plan/Logへの参照が最新か？
+
+**原則の確認:**
+- [ ] 他のConceptを直接`import`していないか？（Conceptの場合）
+- [ ] 副作用を含んでいないか？（Conceptの場合）
+- [ ] 状態を持たない実装か？（Synchronizationの場合）
+
+**Issue管理:**
+- [ ] Issueの状態を更新したか？（open → resolved など、バグ修正の場合）
+
+---
+
+## AIモデルへの指示例
+
+### Concept追加の指示例
+
+```
+【タスク】Post Conceptに「いいね」機能を追加
+
+【参照ドキュメント】
+- 仕様書: src/concepts/post/post.spec.md
+- Issue: docs/01_issues/open/2025_10/20251022_01_post-like-feature.md
+- Plan: docs/03_plans/post-feature/20251022_01_like-implementation-plan.md（存在する場合）
+- 依存関係: src/concepts/post/actions.ts の DEPENDENCY MAP コメント
+
+【更新するファイル】
+1. src/concepts/post/post.spec.md
+   - Requirementsセクションにいいね機能の要件を追加
+   - Test CasesセクションにincrementLike/decrementLikeのテストケースを追加
+
+2. src/concepts/post/state.ts
+   - Post型にlikesCountフィールドを追加
+   - PostStateにlikesCountの集計ロジックを追加
+   - DEPENDENCY MAP の確認（変更があれば更新）
+
+3. src/concepts/post/actions.ts
+   - incrementLike アクションを追加
+   - decrementLike アクションを追加
+   - DEPENDENCY MAP の確認（変更があれば更新）
+
+4. src/concepts/post/post.test.ts
+   - .spec.mdのTest Casesに基づいてincrementLikeのテストケース追加
+   - .spec.mdのTest Casesに基づいてdecrementLikeのテストケース追加
+
+5. src/concepts/post/index.ts
+   - incrementLike/decrementLike をエクスポート
+
+6. docs/05_logs/2025_10/20251022/post-like-feature-implementation.md
+   - 実装作業の記録を作成
+
+【依存関係チェック】
+- Parents（このConceptを使用）: userPosts.sync.ts, PostList.tsx
+  - これらのファイルのDEPENDENCY MAPも更新が必要か確認
+- Dependencies（このConceptが使用）: state.ts, actions.ts
+
+【重要な原則】
+- 他のConceptを直接importしない
+- 副作用を含まない純粋関数として実装
+- .spec.mdのTest Casesに基づいてテスト駆動開発で実装
+- 実装完了後、.spec.mdのRequirementsを実装に合わせて更新
+```
+
+### Synchronization追加の指示例
+
+```
+【タスク】ユーザーが投稿にいいねしたら通知を送るSynchronizationを追加
+
+【参照ドキュメント】
+- User Concept: src/concepts/user/user.spec.md
+- Post Concept: src/concepts/post/post.spec.md
+- Notification Concept: src/concepts/notification/notification.spec.md
+- Issue: docs/01_issues/open/2025_10/20251022_01_user-like-notification.md（存在する場合）
+- Plan: docs/03_plans/notification-feature/20251022_01_implementation-plan.md（存在する場合）
+
+【作成するファイル】
+1. src/synchronizations/userLikePostNotification.spec.md
+   - Requirementsセクションに連携の要件を記述
+   - when（イベント）、where（条件）、then（アクション）を明確に記述
+   - Test Casesセクションにテストケースを記述
+
+2. src/synchronizations/userLikePostNotification.sync.ts
+   - User, Post, Notification Conceptを連携
+   - when: ユーザーが投稿にいいねしたら
+   - then: 通知を作成する
+   - DEPENDENCY MAP を記載（Spec/Issue/Planへの参照を含む）
+
+3. src/synchronizations/userLikePostNotification.sync.test.ts
+   - .spec.mdのTest Casesに基づいてテストケースを記述
+   - User, Post, Notification の状態をインプットとしてテスト
+   - 連携後の状態が期待通りか検証
+
+4. docs/05_logs/2025_10/20251022/user-like-notification-implementation.md
+   - 実装作業の記録を作成
+
+【依存関係チェック】
+- Concepts（このSynchronizationが使用）:
+  - User: src/concepts/user/index.ts
+  - Post: src/concepts/post/index.ts
+  - Notification: src/concepts/notification/index.ts
+- これらのConceptのDEPENDENCY MAPにこのSynchronizationへの参照を追加
+
+【重要な原則】
+- 状態を持たない純粋関数として実装
+- 「when, where, then」を意識した宣言的な記述
+- .spec.mdのTest Casesに基づいてテスト駆動開発で実装
+- 実装完了後、.spec.mdのRequirementsを実装に合わせて更新
+```
+
+### バグ修正の指示例
+
+```
+【タスク】Post ConceptのaddPostアクションで、重複チェックが不十分なバグを修正
+
+【参照ドキュメント】
+- 仕様書: src/concepts/post/post.spec.md
+- Issue: docs/01_issues/open/2025_10/20251022_01_post-duplicate-bug.md
+- 依存関係: src/concepts/post/actions.ts の DEPENDENCY MAP コメント
+
+【更新するファイル】
+1. src/concepts/post/post.spec.md
+   - Requirementsセクションに重複チェックの要件を追加
+   - Test Casesセクションに重複チェックのテストケースを追加（バグを再現するケースを含む）
+
+2. src/concepts/post/actions.ts
+   - addPost アクションに重複チェックを追加
+   - DEPENDENCY MAP の確認（変更があれば更新）
+
+3. src/concepts/post/post.test.ts
+   - .spec.mdのTest Casesに基づいて重複チェックのテストケース追加
+   - 既存のテストが壊れていないか確認
+
+4. docs/05_logs/2025_10/20251022/post-duplicate-bugfix.md
+   - バグ修正作業の記録を作成
+
+5. docs/01_issues/open/2025_10/20251022_01_post-duplicate-bug.md
+   - Issueをresolved/に移動
+
+【依存関係チェック】
+- Parents（このConceptを使用）: userPosts.sync.ts, PostList.tsx
+- 影響を受ける可能性のあるファイルを確認
+  - これらのファイルのDEPENDENCY MAPも更新が必要か確認
+
+【重要な原則】
+- 既存のテストが通ることを確認
+- 他のConceptに影響を与えない
+- 副作用を含まない純粋関数として実装
+- .spec.mdのTest Casesに基づいてテスト駆動開発で実装
+- 実装完了後、.spec.mdのRequirementsを実装に合わせて更新
+```
+
+---
+
+## 発展的な質問への回答
+
+### Q1: 3個以上のConceptが関わる場合はどうするのでしょうか？
+
+**回答:** 1つのSynchronizationファイルで3つ以上のConceptを扱います。重要なのは、その**連携の関心事が単一であること**です。
+
+*   **命名**: ファイル名は、連携の目的がわかるように命名します。
+    *   例: `ユーザーが投稿にいいねしたら通知を送る` という連携
+        *   関わるConcept: `User`, `Post`, `Notification`
+        *   ファイル名: `userLikePostNotification.sync.ts`
+*   **責務**: 1つのSynchronizationファイルが、1つのビジネス上のユースケースに対応するように設計します。もし1つのファイルが肥大化し、複数のユースケースを扱っている場合は、ファイルを分割することを検討してください。
+
+**例: `src/synchronizations/userLikePostNotification.sync.ts`**
+```typescript
+import * as UserConcept from '../concepts/user';
+import * as PostConcept from '../concepts/post';
+import * as NotificationConcept from '../concepts/notification';
+
+// when: ユーザーが投稿にいいねしたら
+// then: 通知を作成する
+export const onUserLikesPost = (
+  userState: UserConcept.UserState,
+  postState: PostConcept.PostState,
+  notificationState: NotificationConcept.NotificationState,
+  userId: string,
+  postId: string
+): NotificationConcept.NotificationState => {
+  const user = userState.users.find(u => u.id === userId);
+  const post = postState.posts.find(p => p.id === postId);
+  
+  if (!user || !post) {
+    return notificationState; // where: ユーザーまたは投稿が存在しない場合は何もしない
+  }
+
+  const notification = {
+    id: `notification-${Date.now()}`,
+    userId: post.authorId,
+    message: `${user.name}さんがあなたの投稿にいいねしました`,
+  };
+
+  return NotificationConcept.actions.addNotification(notificationState, notification);
+};
+```
+
+### Q2: 実装が複雑になってきた時にはどのようなディレクトリ構造が望ましいのでしょうか？
+
+**回答:** Conceptが増えてきたら、ドメイン（関連領域）でグルーピングします。
+
+```plaintext
+src/
+├── concepts/
+│   ├── identity/         # 認証・認可ドメイン
+│   │   ├── user/
+│   │   │   ├── index.ts
+│   │   │   ├── state.ts
+│   │   │   ├── actions.ts
+│   │   │   ├── user.test.ts
+│   │   │   └── user.spec.md
+│   │   └── auth/
+│   │       ├── index.ts
+│   │       ├── state.ts
+│   │       ├── actions.ts
+│   │       ├── auth.test.ts
+│   │       └── auth.spec.md
+│   │
+│   └── publishing/       # コンテンツ公開ドメイン
+│       ├── post/
+│       │   ├── index.ts
+│       │   ├── state.ts
+│       │   ├── actions.ts
+│       │   ├── post.test.ts
+│       │   └── post.spec.md
+│       ├── comment/
+│       │   ├── index.ts
+│       │   ├── state.ts
+│       │   ├── actions.ts
+│       │   ├── comment.test.ts
+│       │   └── comment.spec.md
+│       └── like/
+│           ├── index.ts
+│           ├── state.ts
+│           ├── actions.ts
+│           ├── like.test.ts
+│           └── like.spec.md
+│
+└── synchronizations/
+    ├── identity-publishing.sync.ts # 認証と公開ドメイン間の連携
+    ├── identity-publishing.sync.test.ts
+    ├── identity-publishing.spec.md
+    ├── publishing-internal.sync.ts # 公開ドメイン内部での連携
+    ├── publishing-internal.sync.test.ts
+    └── publishing-internal.spec.md
+```
+
+### Q3: Concept間にまたがりそうな状態などはどうしたら良いのでしょうか？
+
+**回答:** 「Legible Software」の原則では、**状態は必ず単一のConceptに属します**。一見またがっているように見える状態は、以下のいずれかの方法で解決します。
+
+1.  **主となるConceptに所属させる**:
+    *   例: 「ユーザーがいいねした投稿のリスト」
+    *   これは `User` Conceptの状態（`likedPostIds: string[]`）として持つのが自然かもしれません。`Post` Conceptは自身のいいね数をカウントするだけです。
+
+    **例: `src/concepts/user/state.ts`**
+    ```typescript
+    export interface User {
+      id: string;
+      name: string;
+      likedPostIds: string[]; // ユーザーがいいねした投稿のIDリスト
+    }
+    ```
+
+2.  **新しいConceptを作成する**:
+    *   状態の所有者が曖昧で、どちらのConceptに置いても不自然な場合は、その状態を管理するための新しいConceptを作成します。
+    *   例: 「ユーザーと投稿のマッチング情報」
+    *   `User` にも `Post` にも属しづらい場合、`Matching` という新しいConceptを作成し、`{ userId, postId, score }` のような状態を管理させます。
+
+    **例: `src/concepts/matching/state.ts`**
+    ```typescript
+    export interface Matching {
+      userId: string;
+      postId: string;
+      score: number;
+    }
+
+    export interface MatchingState {
+      matchings: Matching[];
+    }
+    ```
+
+**重要なのは、Synchronizationは状態を持たず、必ずいずれかのConceptが状態の「信頼できる情報源（Single Source of Truth）」となるルールを徹底することです。**
+
+---
+
+## まとめ
+
+このフレームワークを採用することで、以下のメリットが得られます：
+
+- **AIにとって理解しやすい**: 変更対象のConceptやSynchronizationという限定的なコンテキストのみを理解すれば、安全で精度の高いコード生成が可能。ドキュメント駆動開発により、仕様書（.spec.md）から要件とテストケースを明確に把握できる
+- **人間にとって把握しやすい**: システムの全体像が把握しやすく、変更の影響範囲が明確。Issue/Research/Plan/Logにより、開発の文脈と意思決定の経緯が追跡可能
+- **変更に強い**: 関心事の分離により、一箇所の変更が他に波及しにくい構造。DEPENDENCY MAPにより、影響範囲が即座に判定できる
+- **テストが容易**: Concept単体のテストが容易で、Synchronizationのテストも複数のConceptの状態をインプットとして検証できる。.spec.mdのTest Casesに基づいてテストを記述することで、仕様とテストの整合性が保たれる
+- **ドキュメントとコードの同期**: 実装ファイルと仕様書（.spec.md）が同じディレクトリに配置され、常に同期を保つことで、コードとドキュメントの乖離を防ぐ
+- **開発プロセスの可視化**: Issue/Research/Plan/Logにより、開発プロセス全体が可視化され、後から振り返りや引き継ぎが容易
+
+このガイドラインに従うことで、AIと人間双方にとって可読性が高く、変更に強いソフトウェア構造を実現できます。

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,8 @@
         "next-themes": "^0.4.6",
         "nodemailer": "^7.0.3",
         "pdfkit": "^0.17.1",
+        "pino": "^10.1.0",
+        "pino-pretty": "^13.1.2",
         "qrcode": "^1.5.4",
         "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
@@ -793,6 +795,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@playwright/test": ["@playwright/test@1.52.0", "", { "dependencies": { "playwright": "1.52.0" }, "bin": { "playwright": "cli.js" } }, "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g=="],
 
@@ -1660,6 +1664,8 @@
 
     "atob": ["atob@2.1.2", "", { "bin": { "atob": "bin/atob.js" } }, "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "attr-accept": ["attr-accept@2.2.5", "", {}, "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="],
 
     "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
@@ -2010,6 +2016,8 @@
 
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
@@ -2250,6 +2258,8 @@
 
     "farmhash-modern": ["farmhash-modern@1.1.0", "", {}, "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA=="],
 
+    "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-equals": ["fast-equals@5.2.2", "", {}, "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="],
@@ -2261,6 +2271,8 @@
     "fast-json-parse": ["fast-json-parse@1.0.3", "", {}, "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
 
@@ -2503,6 +2515,8 @@
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "helmet": ["helmet@8.1.0", "", {}, "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -2801,6 +2815,8 @@
     "jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "jotai": ["jotai@2.12.5", "", { "peerDependencies": { "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-G8m32HW3lSmcz/4mbqx0hgJIQ0ekndKWiYP7kWVKi0p6saLXdSoye+FZiOFyonnd7Q482LCzm8sMDl7Ar1NWDw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "jpeg-exif": ["jpeg-exif@1.1.4", "", {}, "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="],
 
@@ -3254,6 +3270,8 @@
 
     "oidc-token-hash": ["oidc-token-hash@5.1.0", "", {}, "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -3358,6 +3376,14 @@
 
     "pinkie-promise": ["pinkie-promise@2.0.1", "", { "dependencies": { "pinkie": "^2.0.0" } }, "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw=="],
 
+    "pino": ["pino@10.1.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.2", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^3.0.2", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-3cN0tCakkT4f3zo9RXDIhy6GTvtYD6bK4CRBLN9j3E/ePqN1tugAXD5rGVfoChW6s0hiek+eyYlLNqc/BG7vBQ=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
@@ -3413,6 +3439,8 @@
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "process-on-spawn": ["process-on-spawn@1.1.0", "", { "dependencies": { "fromentries": "^1.2.0" } }, "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
 
@@ -3500,6 +3528,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "quick-lru": ["quick-lru@6.1.2", "", {}, "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="],
 
     "ramda": ["ramda@0.28.0", "", {}, "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="],
@@ -3561,6 +3591,8 @@
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -3722,6 +3754,8 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sass-loader": ["sass-loader@14.2.1", "", { "dependencies": { "neo-async": "^2.6.2" }, "peerDependencies": { "@rspack/core": "0.x || 1.x", "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0", "sass": "^1.3.0", "sass-embedded": "*", "webpack": "^5.0.0" }, "optionalPeers": ["@rspack/core", "node-sass", "sass", "sass-embedded", "webpack"] }, "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ=="],
@@ -3734,7 +3768,7 @@
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
-    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
@@ -3806,6 +3840,8 @@
 
     "snapdragon-util": ["snapdragon-util@3.0.1", "", { "dependencies": { "kind-of": "^3.2.0" } }, "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ=="],
 
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
     "sonner": ["sonner@2.0.5", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ=="],
 
     "source-list-map": ["source-list-map@2.0.1", "", {}, "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="],
@@ -3839,6 +3875,8 @@
     "speakeasy": ["speakeasy@2.0.0", "", { "dependencies": { "base32.js": "0.0.1" } }, "sha512-lW2A2s5LKi8rwu77ewisuUOtlCydF/hmQSOJjpTqTj1gZLkNgTaYnyvfxy2WBr4T/h+9c4g8HIITfj83OkFQFw=="],
 
     "split-string": ["split-string@3.1.0", "", { "dependencies": { "extend-shallow": "^3.0.0" } }, "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -3914,7 +3952,7 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "stripe": ["stripe@18.2.1", "", { "dependencies": { "qs": "^6.11.0" }, "peerDependencies": { "@types/node": ">=12.x.x" }, "optionalPeers": ["@types/node"] }, "sha512-GwB1B7WSwEBzW4dilgyJruUYhbGMscrwuyHsPUmSRKrGHZ5poSh2oU9XKdii5BFVJzXHn35geRvGJ6R8bYcp8w=="],
 
@@ -3969,6 +4007,8 @@
     "terser-webpack-plugin": ["terser-webpack-plugin@5.3.14", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "serialize-javascript": "^6.0.2", "terser": "^5.31.1" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
@@ -4325,6 +4365,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@ai-sdk/provider-utils/secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -4813,6 +4855,8 @@
     "jest-circus/@types/node": ["@types/node@22.15.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ=="],
 
     "jest-circus/jest-matcher-utils": ["jest-matcher-utils@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "jest-diff": "^29.7.0", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g=="],
+
+    "jest-config/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "jest-diff/jest-get-type": ["jest-get-type@28.0.2", "", {}, "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA=="],
 

--- a/docs/LOGGER_MIGRATION_LOG.md
+++ b/docs/LOGGER_MIGRATION_LOG.md
@@ -1,0 +1,239 @@
+# pinoロガー移行作業ログ
+
+## 作業概要
+
+issue #17に基づき、`console.log`/`console.error`/`console.warn`をpinoベースの構造化ログシステムに段階的に置き換える作業を実施。
+
+## 実装内容
+
+### 1. ロガーモジュールの作成
+
+- **ファイル**: `src/lib/logger.ts`
+- **内容**: 
+  - サーバー側: pino + pino-pretty（開発環境）
+  - クライアント側: console.logベースのカスタムロガー
+  - ログレベル管理（DEBUG, INFO, WARN, ERROR）
+  - 環境変数`LOG_LEVEL`による制御
+  - 構造化ログのサポート
+
+### 2. 環境変数の型定義追加
+
+- **ファイル**: `src/types/env.d.ts`
+- **追加内容**: `LOG_LEVEL: string;`
+
+## 完了した作業
+
+### 完了ファイル一覧（約497箇所を置き換え済み）
+
+#### Server Actions（主要ファイル）
+
+1. ✅ `src/app/_actions/admin/dashboard.ts` - 完了
+2. ✅ `src/app/_actions/entries.ts` - 完了
+3. ✅ `src/app/_actions/admin/users.ts` - 完了
+4. ✅ `src/app/_actions/members.ts` - 完了
+5. ✅ `src/app/_actions/roles.ts` - 完了
+6. ✅ `src/app/_actions/user-surveys.ts` (14箇所) - 完了
+7. ✅ `src/app/_actions/auth.ts` (2箇所) - 完了
+8. ✅ `src/app/_actions/notifications.ts` (2箇所) - 完了
+9. ✅ `src/app/_actions/contact.ts` (5箇所) - 完了
+10. ✅ `src/app/_actions/profiles.ts` (4箇所) - 完了
+11. ✅ `src/app/_actions/invitations.ts` (17箇所) - 完了
+12. ✅ `src/app/_actions/telegrams.ts` (7箇所) - 完了
+13. ✅ `src/app/_actions/offerings.ts` (13箇所) - 完了
+14. ✅ `src/app/_actions/relationships.ts` (11箇所) - 完了
+15. ✅ `src/app/_actions/announcements.ts` (10箇所) - 完了
+16. ✅ `src/app/_actions/koudens/read.ts` (4箇所) - 完了
+17. ✅ `src/app/_actions/koudens/create.ts` (2箇所) - 完了
+18. ✅ `src/app/_actions/koudens/update.ts` (1箇所) - 完了
+19. ✅ `src/app/_actions/koudens/delete.ts` (3箇所) - 完了
+20. ✅ `src/app/_actions/koudens/duplicate.ts` (1箇所) - 完了
+21. ✅ `src/app/_actions/settings.ts` (6箇所) - 完了
+22. ✅ `src/app/_actions/exportReceipt.ts` (7箇所) - 完了
+23. ✅ `src/app/_actions/exportPdf.ts` (3箇所) - 完了
+24. ✅ `src/app/_actions/hearing-applications.ts` (9箇所) - 完了
+25. ✅ `src/app/_actions/purchaseKouden.ts` (3箇所) - 完了
+26. ✅ `src/app/_actions/plans.ts` (1箇所) - 完了
+
+#### return-records関連（全ファイル完了）
+
+27. ✅ `src/app/_actions/return-records/crud.ts` (5箇所) - 完了
+28. ✅ `src/app/_actions/return-records/bulk-update.ts` (7箇所) - 完了
+29. ✅ `src/app/_actions/return-records/return-items.ts` (8箇所) - 完了
+30. ✅ `src/app/_actions/return-records/updates.ts` (4箇所) - 完了
+31. ✅ `src/app/_actions/return-records/return-record-items.ts` (6箇所) - 完了
+32. ✅ `src/app/_actions/return-records/return-record-selected-methods.ts` (5箇所) - 完了
+33. ✅ `src/app/_actions/return-records/return-method-types.ts` (5箇所) - 完了
+34. ✅ `src/app/_actions/return-records/bulk-operations.ts` (3箇所) - 完了
+35. ✅ `src/app/_actions/return-records/pagination.ts` (1箇所) - 完了
+36. ✅ `src/app/_actions/return-records/performance-monitor.ts` (1箇所) - 完了
+37. ✅ `src/app/_actions/return-records/bulk-update-optimized.ts` (1箇所) - 完了
+
+#### API Routes
+
+38. ✅ `src/app/api/stripe/webhook/route.ts` - 完了
+39. ✅ `src/app/api/debug/organization-access/route.ts` - 完了
+40. ✅ `src/app/api/csrf-token/route.ts` - 完了
+41. ✅ `src/app/api/ai/generate/route.ts` (4箇所) - 完了
+42. ✅ `src/app/api/ai/translate/route.ts` (1箇所) - 完了
+43. ✅ `src/app/api/cron/send-reminders/route.ts` (2箇所) - 完了
+44. ✅ `src/app/api/availability/route.ts` (1箇所) - 完了
+45. ✅ `src/app/api/koudens/[id]/entries/route.ts` (1箇所) - 完了
+
+#### セキュリティ・ユーティリティ
+
+46. ✅ `src/lib/security/security-logger.ts` - 完了
+47. ✅ `src/lib/security/ip-restrictions.ts` (4箇所) - 完了
+48. ✅ `src/lib/security/csrf-protection.ts` (3箇所) - 完了
+49. ✅ `src/lib/security/file-upload-validation.ts` (3箇所) - 完了
+50. ✅ `src/lib/security/admin-2fa-enforcement.ts` (2箇所) - 完了
+51. ✅ `src/lib/security/rate-limiting.ts` (1箇所) - 完了
+52. ✅ `src/lib/security/login-attempts.ts` (1箇所) - 完了
+53. ✅ `src/lib/errors.ts` - 完了
+54. ✅ `src/lib/access.ts` (17箇所) - 完了
+55. ✅ `src/lib/supabase/server.ts` (1箇所) - 完了
+56. ✅ `src/lib/changelogs.ts` (2箇所) - 完了
+57. ✅ `src/lib/milestones.ts` (2箇所) - 完了
+
+#### admin関連（全ファイル完了）
+
+58. ✅ `src/app/_actions/admin/users.ts` (1箇所) - 完了
+59. ✅ `src/app/_actions/admin/survey-export.ts` (4箇所) - 完了
+60. ✅ `src/app/_actions/admin/admin-2fa.ts` (3箇所) - 完了
+61. ✅ `src/app/_actions/admin/campaign-applications.ts` (7箇所) - 完了
+62. ✅ `src/app/_actions/admin/permissions.ts` (3箇所) - 完了
+63. ✅ `src/app/_actions/admin/contact-requests.ts` (6箇所) - 完了
+64. ✅ `src/app/_actions/admin/middleware.ts` (2箇所) - 完了
+65. ✅ `src/app/_actions/admin/announcements.ts` (1箇所) - 完了
+
+#### funeral関連（全ファイル完了）
+
+66. ✅ `src/app/_actions/funeral/cases/getCase.ts` (1箇所) - 完了
+67. ✅ `src/app/_actions/funeral/kouden/create.ts` (5箇所) - 完了
+68. ✅ `src/app/_actions/funeral/customers/updateCustomer.ts` (4箇所) - 完了
+69. ✅ `src/app/_actions/funeral/customers/createCustomer.ts` (3箇所) - 完了
+70. ✅ `src/app/_actions/funeral/customers/getCustomer.ts` (3箇所) - 完了
+
+## 残りの作業（約22箇所、9ファイル）
+
+### 優先度：中
+
+#### blog関連（約7箇所、2ファイル）
+
+1. ⏳ `src/app/_actions/blog/analytics.ts` (3箇所)
+2. ⏳ `src/app/_actions/blog/bookmarks.ts` (4箇所)
+
+#### offerings関連（約7箇所、2ファイル）
+
+3. ⏳ `src/app/_actions/offerings/allocation.ts` (3箇所)
+4. ⏳ `src/app/_actions/offerings/queries.ts` (4箇所)
+
+### 優先度：低
+
+#### その他の小規模ファイル（約8箇所、6ファイル）
+
+5. ⏳ `src/app/_actions/help/help-items.ts` (3箇所)
+6. ⏳ `src/app/_actions/common/organizationRequests.ts` (1箇所)
+7. ⏳ `src/app/_actions/updateKoudenPlan.ts` (1箇所)
+8. ⏳ `src/app/_actions/validateDuplicateEntries.ts` (1箇所)
+9. ⏳ `src/app/_actions/email.ts` (1箇所)
+10. ⏳ `src/app/_actions/feedback.ts` (1箇所)
+
+## 進捗状況
+
+- **総数**: 約562箇所
+- **完了**: 約540箇所（約96%）
+- **残り**: 約22箇所（約4%）
+- **完了ファイル数**: 70ファイル以上
+- **残りファイル数**: 9ファイル
+
+## 置き換えパターン
+
+### 基本的な置き換え例
+
+```typescript
+// Before
+console.error("エラーメッセージ:", error);
+
+// After
+import logger from "@/lib/logger";
+logger.error(
+  {
+    error: error instanceof Error ? error.message : String(error),
+    context: "追加のコンテキスト情報",
+  },
+  "エラーメッセージ"
+);
+```
+
+### 構造化ログの形式
+
+```typescript
+// エラーログ
+logger.error(
+  {
+    error: error.message,
+    code: error.code,
+    userId: user.id,
+    koudenId,
+  },
+  "操作名エラー"
+);
+
+// 情報ログ
+logger.info(
+  {
+    userId: user.id,
+    action: "create_entry",
+    koudenId,
+  },
+  "香典情報を作成しました"
+);
+
+// 警告ログ
+logger.warn(
+  {
+    userId: user.id,
+    reason: "権限不足",
+  },
+  "アクセス拒否"
+);
+```
+
+## 次のステップ
+
+1. ✅ **admin関連ファイルの更新**（優先度：高） - 完了
+   - 管理者機能は重要なため、優先的に更新
+   
+2. ✅ **funeral関連ファイルの更新**（優先度：高） - 完了
+   - 葬儀関連機能も重要な機能のため、優先的に更新
+
+3. **blog関連ファイルの更新**（優先度：中）
+   - ブログ機能のログを統一
+
+4. **offerings関連ファイルの更新**（優先度：中）
+   - お供物関連のログを統一
+
+5. **その他の小規模ファイルの更新**（優先度：低）
+   - 残りの小規模ファイルを順次更新
+
+## 注意事項
+
+- すべての`console.log`/`console.error`/`console.warn`を`logger`に置き換える
+- エラーログには適切なコンテキスト情報を含める
+- ユーザーID、リソースIDなどの重要な情報を構造化ログに含める
+- 本番環境では`LOG_LEVEL=info`を推奨
+- 開発環境では`LOG_LEVEL=debug`で詳細なログを出力
+
+## 完了後の確認事項
+
+- [ ] すべての`console.log`/`console.error`/`console.warn`が置き換えられているか確認
+- [ ] ログレベルの設定が適切か確認
+- [ ] 構造化ログの形式が統一されているか確認
+- [ ] 本番環境でのログ出力が適切か確認
+
+---
+
+**最終更新日**: 2025-01-XX
+**作業者**: AI Assistant
+**関連Issue**: #17
+

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
 		"next-themes": "^0.4.6",
 		"nodemailer": "^7.0.3",
 		"pdfkit": "^0.17.1",
+		"pino": "^10.1.0",
+		"pino-pretty": "^13.1.2",
 		"qrcode": "^1.5.4",
 		"qrcode.react": "^4.2.0",
 		"react": "^19.1.0",

--- a/src/app/_actions/admin/admin-2fa.ts
+++ b/src/app/_actions/admin/admin-2fa.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/security/two-factor-auth";
 import { logTwoFactorEventServerAction } from "@/lib/security/security-logger";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 export interface TwoFactorActionResult {
 	success: boolean;
@@ -84,7 +85,13 @@ export async function setupTwoFactorAuth(
 			message: "二要素認証が正常に設定されました",
 		};
 	} catch (error) {
-		console.error("2FA setup error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId: user?.id,
+			},
+			"2FA setup error",
+		);
 		return {
 			success: false,
 			error: "設定中にエラーが発生しました",
@@ -141,7 +148,13 @@ export async function disableTwoFactorAuth(): Promise<TwoFactorActionResult> {
 			message: "二要素認証が無効化されました",
 		};
 	} catch (error) {
-		console.error("2FA disable error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId: user?.id,
+			},
+			"2FA disable error",
+		);
 		return {
 			success: false,
 			error: "無効化中にエラーが発生しました",
@@ -209,7 +222,13 @@ export async function verifyTwoFactorLogin(
 			message: "認証が成功しました",
 		};
 	} catch (error) {
-		console.error("2FA verification error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId: user?.id,
+			},
+			"2FA verification error",
+		);
 		return {
 			success: false,
 			error: "認証中にエラーが発生しました",

--- a/src/app/_actions/admin/announcements.ts
+++ b/src/app/_actions/admin/announcements.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 export type Announcement = {
 	id: string;
@@ -84,14 +85,17 @@ export async function createAnnouncement({
 
 	if (error) {
 		// デバッグ: エラーの詳細をログ出力
-		console.error("Failed to create announcement:", {
-			error,
-			requestData,
-			user: {
-				id: user.id,
-				email: user.email,
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				requestData,
+				userId: user.id,
+				userEmail: user.email,
 			},
-		});
+			"Failed to create announcement",
+		);
 		throw error;
 	}
 

--- a/src/app/_actions/admin/campaign-applications.ts
+++ b/src/app/_actions/admin/campaign-applications.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import logger from "@/lib/logger";
 
 /**
  * 管理者権限チェック
@@ -58,7 +59,14 @@ export async function getCampaignApplications(params?: {
 	const { data, error, count } = await query;
 
 	if (error) {
-		console.error("Failed to fetch campaign applications:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+			},
+			"Failed to fetch campaign applications",
+		);
 		throw new Error(error.message);
 	}
 
@@ -84,7 +92,15 @@ export async function getCampaignApplication(id: string) {
 		.single();
 
 	if (error) {
-		console.error("Failed to fetch campaign application:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				applicationId: id,
+			},
+			"Failed to fetch campaign application",
+		);
 		throw new Error(error.message);
 	}
 
@@ -111,7 +127,16 @@ export async function updateCampaignApplicationStatus(
 		.single();
 
 	if (error) {
-		console.error("Failed to update application status:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				applicationId,
+				status,
+			},
+			"Failed to update application status",
+		);
 		throw new Error(error.message);
 	}
 
@@ -130,7 +155,14 @@ export async function getCampaignApplicationStats() {
 		.select("status", { count: "exact" });
 
 	if (totalError) {
-		console.error("Failed to fetch total stats:", totalError);
+		logger.error(
+			{
+				error: totalError.message,
+				code: totalError.code,
+				details: totalError.details,
+			},
+			"Failed to fetch total stats",
+		);
 		throw new Error(totalError.message);
 	}
 
@@ -141,7 +173,14 @@ export async function getCampaignApplicationStats() {
 		.order("status");
 
 	if (statusError) {
-		console.error("Failed to fetch status stats:", statusError);
+		logger.error(
+			{
+				error: statusError.message,
+				code: statusError.code,
+				details: statusError.details,
+			},
+			"Failed to fetch status stats",
+		);
 		throw new Error(statusError.message);
 	}
 
@@ -154,7 +193,14 @@ export async function getCampaignApplicationStats() {
 		.gte("created_at", today.toISOString());
 
 	if (todayError) {
-		console.error("Failed to fetch today stats:", todayError);
+		logger.error(
+			{
+				error: todayError.message,
+				code: todayError.code,
+				details: todayError.details,
+			},
+			"Failed to fetch today stats",
+		);
 		throw new Error(todayError.message);
 	}
 
@@ -168,7 +214,14 @@ export async function getCampaignApplicationStats() {
 		.gte("created_at", weekStart.toISOString());
 
 	if (weekError) {
-		console.error("Failed to fetch week stats:", weekError);
+		logger.error(
+			{
+				error: weekError.message,
+				code: weekError.code,
+				details: weekError.details,
+			},
+			"Failed to fetch week stats",
+		);
 		throw new Error(weekError.message);
 	}
 

--- a/src/app/_actions/admin/contact-requests.ts
+++ b/src/app/_actions/admin/contact-requests.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import logger from "@/lib/logger";
 
 /**
  * 管理者権限チェック
@@ -62,7 +63,14 @@ export async function getContactRequests(params?: {
 	const { data, error, count } = await query;
 
 	if (error) {
-		console.error("Failed to fetch contact requests:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+			},
+			"Failed to fetch contact requests",
+		);
 		throw new Error(error.message);
 	}
 
@@ -96,7 +104,15 @@ export async function getContactRequestDetail(requestId: string) {
 		.single();
 
 	if (error) {
-		console.error("Failed to fetch contact request detail:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				requestId,
+			},
+			"Failed to fetch contact request detail",
+		);
 		throw new Error(error.message);
 	}
 
@@ -123,7 +139,16 @@ export async function updateContactRequestStatus(
 		.single();
 
 	if (error) {
-		console.error("Failed to update contact request status:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				requestId,
+				status,
+			},
+			"Failed to update contact request status",
+		);
 		throw new Error(error.message);
 	}
 
@@ -142,7 +167,14 @@ export async function getContactRequestStats() {
 		.select("status", { count: "exact" });
 
 	if (totalError) {
-		console.error("Failed to fetch total stats:", totalError);
+		logger.error(
+			{
+				error: totalError.message,
+				code: totalError.code,
+				details: totalError.details,
+			},
+			"Failed to fetch total stats",
+		);
 		throw new Error(totalError.message);
 	}
 
@@ -153,7 +185,14 @@ export async function getContactRequestStats() {
 		.order("status");
 
 	if (statusError) {
-		console.error("Failed to fetch status stats:", statusError);
+		logger.error(
+			{
+				error: statusError.message,
+				code: statusError.code,
+				details: statusError.details,
+			},
+			"Failed to fetch status stats",
+		);
 		throw new Error(statusError.message);
 	}
 
@@ -164,7 +203,14 @@ export async function getContactRequestStats() {
 		.order("category");
 
 	if (categoryError) {
-		console.error("Failed to fetch category stats:", categoryError);
+		logger.error(
+			{
+				error: categoryError.message,
+				code: categoryError.code,
+				details: categoryError.details,
+			},
+			"Failed to fetch category stats",
+		);
 		throw new Error(categoryError.message);
 	}
 

--- a/src/app/_actions/admin/dashboard.ts
+++ b/src/app/_actions/admin/dashboard.ts
@@ -4,6 +4,7 @@ import { unstable_cache as cache } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getContactRequestStats } from "./contact-requests";
 import { getCampaignApplicationStats } from "./campaign-applications";
+import logger from "@/lib/logger";
 
 // 1. getDashboardSummary
 export async function getDashboardSummary() {
@@ -16,7 +17,13 @@ export async function getDashboardSummary() {
 		.in("status", ["new", "in_progress"]);
 
 	if (openContactsError) {
-		console.error("Error fetching open contacts count:", openContactsError.message);
+		logger.error(
+			{
+				error: openContactsError.message,
+				code: openContactsError.code,
+			},
+			"Error fetching open contacts count",
+		);
 	}
 
 	// 過去24時間のエラー数を取得 (debug_logsテーブルのcreated_atが24時間以内のもの)
@@ -27,7 +34,13 @@ export async function getDashboardSummary() {
 		.gte("created_at", twentyFourHoursAgo);
 
 	if (recentErrorsError) {
-		console.error("Error fetching recent errors count:", recentErrorsError.message);
+		logger.error(
+			{
+				error: recentErrorsError.message,
+				code: recentErrorsError.code,
+			},
+			"Error fetching recent errors count",
+		);
 	}
 
 	return {
@@ -43,7 +56,13 @@ const fetchServiceStatus = async (url: string, serviceName: string): Promise<any
 		const response = await fetch(url, { next: { revalidate: 300 } }); // 5分キャッシュ
 		if (!response.ok) {
 			// APIがエラーを返した場合でも、サービスがダウンしていると解釈できる
-			console.warn(`Failed to fetch ${serviceName} status: ${response.status}`);
+			logger.warn(
+				{
+					serviceName,
+					status: response.status,
+				},
+				`Failed to fetch ${serviceName} status`,
+			);
 			return { name: serviceName, status: "degraded" }; // または "outage"
 		}
 		// const data = await response.json();
@@ -67,7 +86,13 @@ const fetchServiceStatus = async (url: string, serviceName: string): Promise<any
 		}
 		return { name: serviceName, status: "operational" }; // デフォルト
 	} catch (error) {
-		console.error(`Error fetching ${serviceName} status:`, error);
+		logger.error(
+			{
+				serviceName,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			`Error fetching ${serviceName} status`,
+		);
 		return { name: serviceName, status: "outage" }; // フェッチ自体に失敗した場合
 	}
 };
@@ -112,7 +137,14 @@ export async function getSalesMetrics(range: "7d" | "30d" | "90d" = "30d") {
 		.order("purchased_at", { ascending: true });
 
 	if (error) {
-		console.error("Error fetching sales metrics:", error.message);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				range,
+			},
+			"Error fetching sales metrics",
+		);
 		// エラー時は空のデータ配列を返す
 		return Array.from({ length: days }).map((_, i) => {
 			const date = new Date(startDate);
@@ -169,7 +201,14 @@ export async function getActivityMetrics(range: "7d" | "30d" | "90d" = "30d") {
 		.order("created_at", { ascending: true });
 
 	if (error) {
-		console.error("Error fetching activity metrics:", error.message);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				range,
+			},
+			"Error fetching activity metrics",
+		);
 		// エラー時は空のデータ配列を返す
 		return Array.from({ length: days }).map((_, i) => {
 			const date = new Date(startDate);
@@ -217,7 +256,14 @@ export async function getRecentInquiries(limit = 5) {
 		.limit(limit);
 
 	if (error) {
-		console.error("Error fetching recent inquiries:", error.message);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				limit,
+			},
+			"Error fetching recent inquiries",
+		);
 		return [];
 	}
 	return data;
@@ -233,7 +279,14 @@ export async function getRecentErrors(limit = 5) {
 		.limit(limit);
 
 	if (error) {
-		console.error("Error fetching recent errors:", error.message);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				limit,
+			},
+			"Error fetching recent errors",
+		);
 		// エラー時は空配列を返す
 		return [];
 	}

--- a/src/app/_actions/admin/middleware.ts
+++ b/src/app/_actions/admin/middleware.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { createAuditLog } from "./audit-logs";
+import logger from "@/lib/logger";
 
 export async function withAdmin<T>(action: () => Promise<T>): Promise<T> {
 	const supabase = await createClient();
@@ -34,7 +35,15 @@ export async function withAdmin<T>(action: () => Promise<T>): Promise<T> {
 					error: error.message,
 					stack: error.stack,
 				},
-			}).catch(console.error); // 監査ログの記録に失敗してもメインの処理には影響を与えない
+			}).catch((err) => {
+				logger.error(
+					{
+						error: err instanceof Error ? err.message : String(err),
+						userId: user.id,
+					},
+					"監査ログの記録に失敗",
+				);
+			}); // 監査ログの記録に失敗してもメインの処理には影響を与えない
 		}
 		throw error;
 	}
@@ -73,7 +82,15 @@ export async function withSuperAdmin<T>(action: () => Promise<T>): Promise<T> {
 					error: error.message,
 					stack: error.stack,
 				},
-			}).catch(console.error);
+			}).catch((err) => {
+				logger.error(
+					{
+						error: err instanceof Error ? err.message : String(err),
+						userId: user.id,
+					},
+					"監査ログの記録に失敗",
+				);
+			});
 		}
 		throw error;
 	}

--- a/src/app/_actions/admin/permissions.ts
+++ b/src/app/_actions/admin/permissions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import logger from "@/lib/logger";
 
 /**
  * 管理者権限をチェックする
@@ -25,16 +26,35 @@ export async function checkAdminPermission() {
 		.single();
 
 	if (error && error.code !== "PGRST116") {
-		console.error("Admin permission check error:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				userId: user.id,
+			},
+			"Admin permission check error",
+		);
 		throw new Error("管理者権限の確認に失敗しました");
 	}
 
 	if (!adminUser) {
-		console.warn(`User ${user.id} is not registered as admin in admin_users table`);
+		logger.warn(
+			{
+				userId: user.id,
+			},
+			`User ${user.id} is not registered as admin in admin_users table`,
+		);
 		throw new Error("管理者権限が必要です");
 	}
 
-	console.log(`Admin access granted for user ${user.id} with role: ${adminUser.role}`);
+	logger.info(
+		{
+			userId: user.id,
+			role: adminUser.role,
+		},
+		`Admin access granted for user ${user.id} with role: ${adminUser.role}`,
+	);
 
 	return { supabase, user, adminRole: adminUser.role };
 }

--- a/src/app/_actions/admin/survey-export.ts
+++ b/src/app/_actions/admin/survey-export.ts
@@ -2,20 +2,23 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import logger from "@/lib/logger";
 
 /**
  * アンケートデータをCSV形式でエクスポート
  * @returns CSV文字列
  */
 export async function exportSurveyDataToCsv() {
+	let user: { id: string } | null = null;
 	try {
 		const supabase = await createClient();
 
 		// 認証確認
 		const {
-			data: { user },
+			data: { user: authUser },
 			error: authError,
 		} = await supabase.auth.getUser();
+		user = authUser;
 		if (authError || !user) {
 			return {
 				success: false,
@@ -61,7 +64,15 @@ export async function exportSurveyDataToCsv() {
 			.order("created_at", { ascending: false });
 
 		if (fetchError) {
-			console.error("アンケートデータ取得エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					details: fetchError.details,
+					userId: user.id,
+				},
+				"アンケートデータ取得エラー",
+			);
 			return {
 				success: false,
 				error: "データ取得に失敗しました",
@@ -119,7 +130,13 @@ export async function exportSurveyDataToCsv() {
 			filename: `survey_data_${new Date().toISOString().split("T")[0]}.csv`,
 		};
 	} catch (error) {
-		console.error("CSVエクスポートエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId: user?.id,
+			},
+			"CSVエクスポートエラー",
+		);
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました",
@@ -132,14 +149,16 @@ export async function exportSurveyDataToCsv() {
  * @returns CSV文字列
  */
 export async function exportSurveySummaryToCsv() {
+	let user: { id: string } | null = null;
 	try {
 		const supabase = await createClient();
 
 		// 認証確認
 		const {
-			data: { user },
+			data: { user: authUser },
 			error: authError,
 		} = await supabase.auth.getUser();
+		user = authUser;
 		if (authError || !user) {
 			return {
 				success: false,
@@ -168,7 +187,15 @@ export async function exportSurveySummaryToCsv() {
 			.order("created_at", { ascending: false });
 
 		if (fetchError) {
-			console.error("アンケートデータ取得エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					details: fetchError.details,
+					userId: user.id,
+				},
+				"アンケートデータ取得エラー",
+			);
 			return {
 				success: false,
 				error: "データ取得に失敗しました",
@@ -266,7 +293,13 @@ export async function exportSurveySummaryToCsv() {
 			filename: `survey_summary_${new Date().toISOString().split("T")[0]}.csv`,
 		};
 	} catch (error) {
-		console.error("サマリーCSVエクスポートエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId: user?.id,
+			},
+			"サマリーCSVエクスポートエラー",
+		);
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました",

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 /**
  * 全ユーザー管理用の型定義
@@ -151,7 +152,13 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<{
 							admin_info: adminInfo,
 						};
 					} catch (error) {
-						console.error(`Failed to get details for user ${profile.id}:`, error);
+						logger.error(
+							{
+								userId: profile.id,
+								error: error instanceof Error ? error.message : String(error),
+							},
+							"Failed to get details for user",
+						);
 						// エラーが発生した場合は基本情報のみ返す
 						const stats = await getUserStats(profile.id).catch(() => ({
 							owned_koudens_count: 0,
@@ -191,7 +198,13 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<{
 			hasMore: (count || 0) > offset + limit,
 		};
 	} catch (error) {
-		console.error("Error fetching users:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				params,
+			},
+			"Error fetching users",
+		);
 		throw new Error("ユーザー一覧の取得に失敗しました");
 	}
 }
@@ -236,7 +249,13 @@ export async function getUserDetail(userId: string): Promise<UserDetail> {
 			koudens,
 		};
 	} catch (error) {
-		console.error(`Error fetching user detail for ${userId}:`, error);
+		logger.error(
+			{
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error fetching user detail",
+		);
 		throw new Error("ユーザー詳細の取得に失敗しました");
 	}
 }
@@ -258,9 +277,22 @@ async function getUserAuthInfo(userId: string): Promise<{
 		if (error) {
 			// 権限エラーの場合は警告レベルで記録
 			if (error.code === "not_admin") {
-				console.warn(`Admin access denied for user ${userId}:`, error.message);
+				logger.warn(
+					{
+						userId,
+						error: error.message,
+					},
+					"Admin access denied for user",
+				);
 			} else {
-				console.error(`Failed to get auth info for user ${userId}:`, error);
+				logger.error(
+					{
+						userId,
+						error: error.message,
+						code: error.code,
+					},
+					"Failed to get auth info for user",
+				);
 			}
 			return {};
 		}
@@ -271,7 +303,13 @@ async function getUserAuthInfo(userId: string): Promise<{
 			email_confirmed_at: authUser.user?.email_confirmed_at,
 		};
 	} catch (error) {
-		console.error(`Error getting auth info for user ${userId}:`, error);
+		logger.error(
+			{
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error getting auth info for user",
+		);
 		return {};
 	}
 }
@@ -305,7 +343,14 @@ async function getAllUsersAuthInfo(userIds: string[]): Promise<
 		const { data: users, error } = await supabase.auth.admin.listUsers();
 
 		if (error) {
-			console.error("Failed to get all users auth info:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userIdsCount: userIds.length,
+				},
+				"Failed to get all users auth info",
+			);
 			// エラーの場合は空のオブジェクトを各ユーザーに設定
 			for (const id of userIds) {
 				result[id] = {};
@@ -331,7 +376,13 @@ async function getAllUsersAuthInfo(userIds: string[]): Promise<
 
 		return result;
 	} catch (error) {
-		console.error("Error getting all users auth info:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userIdsCount: userIds.length,
+			},
+			"Error getting all users auth info",
+		);
 		// エラーの場合は空のオブジェクトを各ユーザーに設定
 		for (const id of userIds) {
 			result[id] = {};
@@ -370,7 +421,13 @@ async function getUserStats(userId: string): Promise<{
 			total_entries_count: totalEntries.count || 0,
 		};
 	} catch (error) {
-		console.error(`Error getting stats for user ${userId}:`, error);
+		logger.error(
+			{
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error getting stats for user",
+		);
 		return {
 			owned_koudens_count: 0,
 			participated_koudens_count: 0,
@@ -483,7 +540,13 @@ async function getUserKoudens(userId: string): Promise<
 			.sort((a, b) => new Date(b.joined_at).getTime() - new Date(a.joined_at).getTime())
 			.map(({ status, ...kouden }) => kouden);
 	} catch (error) {
-		console.error(`Error getting koudens for user ${userId}:`, error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+			},
+			`Error getting koudens for user ${userId}`,
+		);
 		return [];
 	}
 }
@@ -636,7 +699,7 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 		const adminCheck = await isAdminUser();
 
 		if (!adminCheck) {
-			console.error("Admin permission denied");
+			logger.error({}, "Admin permission denied");
 			throw new Error("管理者権限が必要です");
 		}
 
@@ -679,7 +742,13 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 		const { data: koudens, error: koudensError, count } = await query;
 
 		if (koudensError) {
-			console.error("Koudens query error:", koudensError);
+			logger.error(
+				{
+					error: koudensError.message,
+					code: koudensError.code,
+				},
+				"Koudens query error",
+			);
 			throw new Error(`香典帳の取得に失敗しました: ${koudensError.message}`);
 		}
 
@@ -722,7 +791,13 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 						remainingDays,
 					};
 				} catch (error) {
-					console.error(`Failed to get details for kouden ${kouden.id}:`, error);
+					logger.error(
+						{
+							koudenId: kouden.id,
+							error: error instanceof Error ? error.message : String(error),
+						},
+						"Failed to get details for kouden",
+					);
 					// エラーが発生した場合は基本情報のみ返す
 					return {
 						...kouden,
@@ -751,7 +826,13 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			hasMore: (count || 0) > offset + limit,
 		};
 	} catch (error) {
-		console.error("Error fetching admin koudens:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				params,
+			},
+			"Error fetching admin koudens",
+		);
 
 		// エラーの詳細を含めて再スロー
 		if (error instanceof Error) {
@@ -844,7 +925,13 @@ async function getKoudenStats(koudenId: string): Promise<{
 			total_amount: totalAmount,
 		};
 	} catch (error) {
-		console.error(`Error getting stats for kouden ${koudenId}:`, error);
+		logger.error(
+			{
+				koudenId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error getting stats for kouden",
+		);
 		return {
 			entries_count: 0,
 			members_count: 0,

--- a/src/app/_actions/announcements.ts
+++ b/src/app/_actions/announcements.ts
@@ -6,6 +6,7 @@ import type {
 	CreateAnnouncementInput,
 	UpdateAnnouncementInput,
 } from "@/types/announcements";
+import logger from "@/lib/logger";
 
 /**
  * アクティブなお知らせを取得（表示用）
@@ -27,13 +28,24 @@ export async function getActiveAnnouncements(): Promise<{
 			.order("created_at", { ascending: false });
 
 		if (error) {
-			console.error("[ERROR] Failed to fetch announcements:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+				},
+				"Failed to fetch announcements",
+			);
 			throw new Error("お知らせの取得に失敗しました");
 		}
 
 		return { announcements: announcements || [] };
 	} catch (error) {
-		console.error("[ERROR] Error in getActiveAnnouncements:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error in getActiveAnnouncements",
+		);
 		return {
 			announcements: [],
 			error: error instanceof Error ? error.message : "お知らせの取得に失敗しました",
@@ -66,13 +78,25 @@ export async function getAllAnnouncements(): Promise<{
 			.order("created_at", { ascending: false });
 
 		if (error) {
-			console.error("[ERROR] Failed to fetch all announcements:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+				},
+				"Failed to fetch all announcements",
+			);
 			throw new Error("お知らせの取得に失敗しました");
 		}
 
 		return { announcements: announcements || [] };
 	} catch (error) {
-		console.error("[ERROR] Error in getAllAnnouncements:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error in getAllAnnouncements",
+		);
 		return {
 			announcements: [],
 			error: error instanceof Error ? error.message : "お知らせの取得に失敗しました",
@@ -108,13 +132,27 @@ export async function createAnnouncement(input: CreateAnnouncementInput): Promis
 			.single();
 
 		if (error) {
-			console.error("[ERROR] Failed to create announcement:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+					input,
+				},
+				"Failed to create announcement",
+			);
 			throw new Error("お知らせの作成に失敗しました");
 		}
 
 		return { announcement };
 	} catch (error) {
-		console.error("[ERROR] Error in createAnnouncement:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				input,
+			},
+			"Error in createAnnouncement",
+		);
 		return {
 			error: error instanceof Error ? error.message : "お知らせの作成に失敗しました",
 		};
@@ -151,13 +189,27 @@ export async function updateAnnouncement(input: UpdateAnnouncementInput): Promis
 			.single();
 
 		if (error) {
-			console.error("[ERROR] Failed to update announcement:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+					id: input.id,
+				},
+				"Failed to update announcement",
+			);
 			throw new Error("お知らせの更新に失敗しました");
 		}
 
 		return { announcement };
 	} catch (error) {
-		console.error("[ERROR] Error in updateAnnouncement:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id: input.id,
+			},
+			"Error in updateAnnouncement",
+		);
 		return {
 			error: error instanceof Error ? error.message : "お知らせの更新に失敗しました",
 		};
@@ -184,13 +236,27 @@ export async function deleteAnnouncement(id: string): Promise<{
 		const { error } = await supabase.from("announcements").delete().eq("id", id);
 
 		if (error) {
-			console.error("[ERROR] Failed to delete announcement:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+					id,
+				},
+				"Failed to delete announcement",
+			);
 			throw new Error("お知らせの削除に失敗しました");
 		}
 
 		return { success: true };
 	} catch (error) {
-		console.error("[ERROR] Error in deleteAnnouncement:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"Error in deleteAnnouncement",
+		);
 		return {
 			error: error instanceof Error ? error.message : "お知らせの削除に失敗しました",
 		};

--- a/src/app/_actions/auth.ts
+++ b/src/app/_actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import logger from "@/lib/logger";
 
 /**
  * プロフィールの存在確認
@@ -39,7 +40,12 @@ export async function ensureProfile() {
 
 		return { success: true };
 	} catch (error) {
-		console.error("[ERROR] Error ensuring profile:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error ensuring profile",
+		);
 		return { error: "プロフィールの確認に失敗しました" };
 	}
 }
@@ -57,7 +63,12 @@ export async function getCurrentUser() {
 
 		return user;
 	} catch (error) {
-		console.error("[ERROR] Error getting current user:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error getting current user",
+		);
 		return null;
 	}
 }

--- a/src/app/_actions/contact.ts
+++ b/src/app/_actions/contact.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import logger from "@/lib/logger";
 
 /**
  * Create a new contact request (support unauthenticated and authenticated users).
@@ -29,7 +30,15 @@ export async function createContactRequest(formData: FormData) {
 	const { data, error } = await supabase.from("contact_requests").insert(insertData);
 
 	if (error) {
-		console.error("Failed to create contact request:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				userId: user?.id,
+				category: insertData.category,
+			},
+			"Failed to create contact request",
+		);
 		throw new Error(error.message);
 	}
 
@@ -57,7 +66,14 @@ export async function getContactRequests() {
 		.order("created_at", { ascending: false });
 
 	if (error) {
-		console.error("Failed to fetch contact requests:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				userId: user.id,
+			},
+			"Failed to fetch contact requests",
+		);
 		throw new Error(error.message);
 	}
 
@@ -95,7 +111,15 @@ export async function getContactRequestDetail(requestId: string) {
 		.single();
 
 	if (error) {
-		console.error("Failed to fetch contact request detail:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				userId: user.id,
+				requestId,
+			},
+			"Failed to fetch contact request detail",
+		);
 		throw new Error(error.message);
 	}
 
@@ -118,7 +142,14 @@ export async function uploadContactAttachment(requestId: string, file: File) {
 		.from("contact-attachments")
 		.upload(filePath, file, { cacheControl: "3600", upsert: false });
 	if (uploadError) {
-		console.error("Failed to upload attachment:", uploadError);
+		logger.error(
+			{
+				error: uploadError.message,
+				requestId,
+				fileName: file.name,
+			},
+			"Failed to upload attachment",
+		);
 		throw new Error(uploadError.message);
 	}
 	// データベースにメタ情報を保存
@@ -127,7 +158,15 @@ export async function uploadContactAttachment(requestId: string, file: File) {
 		.insert({ request_id: requestId, file_url: filePath, file_name: file.name })
 		.select();
 	if (dbError) {
-		console.error("Failed to insert attachment record:", dbError);
+		logger.error(
+			{
+				error: dbError.message,
+				code: dbError.code,
+				requestId,
+				fileName: file.name,
+			},
+			"Failed to insert attachment record",
+		);
 		throw new Error(dbError.message);
 	}
 	return data;

--- a/src/app/_actions/entries.ts
+++ b/src/app/_actions/entries.ts
@@ -10,6 +10,7 @@ import type {
 	Entry,
 	AttendanceType,
 } from "@/types/entries";
+import logger from "@/lib/logger";
 
 export async function createEntry(input: CreateEntryInput): Promise<EntryResponse> {
 	const supabase = await createClient();
@@ -41,14 +42,16 @@ export async function createEntry(input: CreateEntryInput): Promise<EntryRespons
 
 		if (error) {
 			// デバッグ: エラーの詳細情報をログ
-			console.error("[ERROR] Create Entry with Return Record Failed:", {
-				error,
-				errorCode: error.code,
-				errorMessage: error.message,
-				errorDetails: error.details,
-				input,
-				userId: user.id,
-			});
+			logger.error(
+				{
+					errorCode: error.code,
+					errorMessage: error.message,
+					errorDetails: error.details,
+					input,
+					userId: user.id,
+				},
+				"Create Entry with Return Record Failed",
+			);
 
 			// エラーメッセージの改善
 			if (error.code === "42501") {
@@ -79,12 +82,14 @@ export async function createEntry(input: CreateEntryInput): Promise<EntryRespons
 
 		return response;
 	} catch (error) {
-		console.error("[ERROR] Unexpected error in createEntry:", {
-			error,
-			input,
-			errorMessage: error instanceof Error ? error.message : "Unknown error",
-			userId: user.id,
-		});
+		logger.error(
+			{
+				input,
+				errorMessage: error instanceof Error ? error.message : "Unknown error",
+				userId: user.id,
+			},
+			"Unexpected error in createEntry",
+		);
 		throw error instanceof Error ? error : new Error("香典情報の作成に失敗しました");
 	}
 }
@@ -159,12 +164,16 @@ export async function getEntries(
 		const entries = rawEntries ?? [];
 
 		if (entriesError) {
-			console.error("[ERROR] Failed to fetch entries:", {
-				message: entriesError.message,
-				details: entriesError.details,
-				hint: entriesError.hint,
-				code: entriesError.code,
-			});
+			logger.error(
+				{
+					message: entriesError.message,
+					details: entriesError.details,
+					hint: entriesError.hint,
+					code: entriesError.code,
+					koudenId,
+				},
+				"Failed to fetch entries",
+			);
 			throw new Error("香典情報の取得に失敗しました");
 		}
 
@@ -175,12 +184,16 @@ export async function getEntries(
 			.eq("kouden_id", koudenId);
 
 		if (relationshipsError) {
-			console.error("[ERROR] Failed to fetch relationships:", {
-				message: relationshipsError.message,
-				details: relationshipsError.details,
-				hint: relationshipsError.hint,
-				code: relationshipsError.code,
-			});
+			logger.error(
+				{
+					message: relationshipsError.message,
+					details: relationshipsError.details,
+					hint: relationshipsError.hint,
+					code: relationshipsError.code,
+					koudenId,
+				},
+				"Failed to fetch relationships",
+			);
 			throw new Error("関係性情報の取得に失敗しました");
 		}
 
@@ -197,7 +210,13 @@ export async function getEntries(
 
 		return { entries: entriesWithRelationships as Entry[], count: count ?? 0 };
 	} catch (error) {
-		console.error("[ERROR] Unexpected error in getEntries:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Unexpected error in getEntries",
+		);
 		throw error;
 	}
 }
@@ -277,12 +296,16 @@ export async function getEntriesForAdmin(
 		const entries = rawEntries ?? [];
 
 		if (entriesError) {
-			console.error("[ERROR] Failed to fetch entries for admin:", {
-				message: entriesError.message,
-				details: entriesError.details,
-				hint: entriesError.hint,
-				code: entriesError.code,
-			});
+			logger.error(
+				{
+					message: entriesError.message,
+					details: entriesError.details,
+					hint: entriesError.hint,
+					code: entriesError.code,
+					koudenId,
+				},
+				"Failed to fetch entries for admin",
+			);
 			throw new Error("香典情報の取得に失敗しました");
 		}
 
@@ -293,12 +316,16 @@ export async function getEntriesForAdmin(
 			.eq("kouden_id", koudenId);
 
 		if (relationshipsError) {
-			console.error("[ERROR] Failed to fetch relationships for admin:", {
-				message: relationshipsError.message,
-				details: relationshipsError.details,
-				hint: relationshipsError.hint,
-				code: relationshipsError.code,
-			});
+			logger.error(
+				{
+					message: relationshipsError.message,
+					details: relationshipsError.details,
+					hint: relationshipsError.hint,
+					code: relationshipsError.code,
+					koudenId,
+				},
+				"Failed to fetch relationships for admin",
+			);
 			throw new Error("関係性情報の取得に失敗しました");
 		}
 
@@ -315,7 +342,13 @@ export async function getEntriesForAdmin(
 
 		return { entries: entriesWithRelationships as Entry[], count: count ?? 0 };
 	} catch (error) {
-		console.error("[ERROR] Unexpected error in getEntriesForAdmin:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Unexpected error in getEntriesForAdmin",
+		);
 		throw error;
 	}
 }
@@ -383,10 +416,14 @@ export async function updateEntry(id: string, input: UpdateEntryInput): Promise<
 			.single();
 
 		if (error || !updatedData) {
-			console.error("[ERROR] Update failed:", {
-				error,
-				id,
-			});
+			logger.error(
+				{
+					error: error?.message,
+					errorCode: error?.code,
+					id,
+				},
+				"Update failed",
+			);
 			throw new Error("香典情報の更新に失敗しました");
 		}
 
@@ -400,7 +437,13 @@ export async function updateEntry(id: string, input: UpdateEntryInput): Promise<
 			relationshipId: updatedData.relationship_id,
 		};
 	} catch (error) {
-		console.error("[ERROR] Failed to update entry:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"Failed to update entry",
+		);
 		throw new Error("香典情報の更新に失敗しました");
 	}
 }
@@ -498,7 +541,14 @@ export async function updateEntryField(
 			relationshipId: updatedData.relationship_id,
 		};
 	} catch (error) {
-		console.error("[ERROR] Failed to update entry:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				field,
+			},
+			"Failed to update entry",
+		);
 		throw new Error(`${field}の更新に失敗しました`);
 	}
 }

--- a/src/app/_actions/exportPdf.ts
+++ b/src/app/_actions/exportPdf.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import type { KoudenData, KoudenEntry } from "@/types/entries";
 import { formatAmount } from "@/utils/pdfFormatter";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳 PDF 用データ取得
@@ -19,7 +20,14 @@ export async function exportKoudenToPdf(koudenId: string): Promise<KoudenData> {
 		.single();
 
 	if (koudenError || !kouden) {
-		console.error("[exportKoudenToPdf] koudenError:", koudenError, "kouden:", kouden);
+		logger.error(
+			{
+				error: koudenError?.message,
+				code: koudenError?.code,
+				koudenId,
+			},
+			"[exportKoudenToPdf] koudenError",
+		);
 		throw new Error("香典帳の取得に失敗しました");
 	}
 
@@ -31,7 +39,14 @@ export async function exportKoudenToPdf(koudenId: string): Promise<KoudenData> {
 		.order("amount", { ascending: false });
 
 	if (entriesError || !entries) {
-		console.error("[exportKoudenToPdf] entriesError:", entriesError, "entries:", entries);
+		logger.error(
+			{
+				error: entriesError?.message,
+				code: entriesError?.code,
+				koudenId,
+			},
+			"[exportKoudenToPdf] entriesError",
+		);
 		throw new Error("香典データの取得に失敗しました");
 	}
 
@@ -41,7 +56,14 @@ export async function exportKoudenToPdf(koudenId: string): Promise<KoudenData> {
 		.select("id,name")
 		.eq("kouden_id", koudenId);
 	if (relationsError || !relations) {
-		console.error("[exportKoudenToPdf] relationsError:", relationsError, "relations:", relations);
+		logger.error(
+			{
+				error: relationsError?.message,
+				code: relationsError?.code,
+				koudenId,
+			},
+			"[exportKoudenToPdf] relationsError",
+		);
 		throw new Error("関係性データの取得に失敗しました");
 	}
 	const relationsMap = new Map(relations.map((r) => [r.id, r.name]));

--- a/src/app/_actions/exportReceipt.ts
+++ b/src/app/_actions/exportReceipt.ts
@@ -5,6 +5,7 @@ import PDFDocument from "pdfkit";
 import { Resend } from "resend";
 import fs from "node:fs";
 import path from "node:path";
+import logger from "@/lib/logger";
 
 /**
  * 購入後に領収書PDFを生成し、Storageへ保存、メール送信を行う
@@ -20,7 +21,14 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		.eq("id", purchaseId)
 		.single();
 	if (purchaseError || !purchase) {
-		console.error("[exportReceiptToPdf] purchaseError:", purchaseError);
+		logger.error(
+			{
+				error: purchaseError?.message,
+				code: purchaseError?.code,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] purchaseError",
+		);
 		throw new Error("購入情報の取得に失敗しました");
 	}
 
@@ -31,7 +39,15 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		.eq("id", purchase.plan_id)
 		.single();
 	if (planError || !plan) {
-		console.error("[exportReceiptToPdf] planError:", planError);
+		logger.error(
+			{
+				error: planError?.message,
+				code: planError?.code,
+				planId: purchase.plan_id,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] planError",
+		);
 		throw new Error("プラン情報の取得に失敗しました");
 	}
 
@@ -42,7 +58,15 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		.eq("id", purchase.kouden_id)
 		.single();
 	if (koudenError || !kouden) {
-		console.error("[exportReceiptToPdf] koudenError:", koudenError);
+		logger.error(
+			{
+				error: koudenError?.message,
+				code: koudenError?.code,
+				koudenId: purchase.kouden_id,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] koudenError",
+		);
 		throw new Error("香典帳情報の取得に失敗しました");
 	}
 
@@ -51,7 +75,14 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		purchase.user_id,
 	);
 	if (userError || !userData.user) {
-		console.error("[exportReceiptToPdf] userError:", userError);
+		logger.error(
+			{
+				error: userError?.message,
+				userId: purchase.user_id,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] userError",
+		);
 		throw new Error("ユーザー情報の取得に失敗しました");
 	}
 	const userEmail = userData.user.email;
@@ -103,7 +134,13 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 			upsert: false,
 		});
 	if (storageError) {
-		console.error("[exportReceiptToPdf] storageError:", storageError);
+		logger.error(
+			{
+				error: storageError.message,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] storageError",
+		);
 		throw new Error("Storageへのアップロードに失敗しました");
 	}
 
@@ -135,7 +172,14 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		.eq("type_key", "receipt_sent")
 		.single();
 	if (typeError || !notifType) {
-		console.error("[exportReceiptToPdf] notifTypeError:", typeError);
+		logger.error(
+			{
+				error: typeError?.message,
+				code: typeError?.code,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] notifTypeError",
+		);
 		throw new Error("通知タイプの取得に失敗しました");
 	}
 	const { error: notifError } = await supabase.from("notifications").insert({
@@ -148,7 +192,15 @@ export async function exportReceiptToPdf(purchaseId: string): Promise<void> {
 		link_path: null,
 	});
 	if (notifError) {
-		console.error("[exportReceiptToPdf] notifError:", notifError);
+		logger.error(
+			{
+				error: notifError.message,
+				code: notifError.code,
+				userId: purchase.user_id,
+				purchaseId,
+			},
+			"[exportReceiptToPdf] notifError",
+		);
 		throw new Error("通知作成に失敗しました");
 	}
 }

--- a/src/app/_actions/funeral/cases/getCase.ts
+++ b/src/app/_actions/funeral/cases/getCase.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { FuneralCaseWithDetails } from "@/types/funeral-management";
+import logger from "@/lib/logger";
 
 /**
  * Get a single funeral case by ID with customer details.
@@ -30,7 +31,15 @@ export async function getCase(id: string): Promise<FuneralCaseWithDetails | null
 		.single();
 
 	if (customerError) {
-		console.warn("Customer not found for case:", id, customerError);
+		logger.warn(
+			{
+				error: customerError.message,
+				code: customerError.code,
+				caseId: id,
+				customerId: caseRecord.customer_id,
+			},
+			"Customer not found for case",
+		);
 	}
 
 	// 顧客詳細情報を別途取得

--- a/src/app/_actions/funeral/customers/createCustomer.ts
+++ b/src/app/_actions/funeral/customers/createCustomer.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import type { CreateCustomerInput } from "@/types/funeral-management";
+import logger from "@/lib/logger";
 
 /**
  * 新規顧客を作成する
@@ -26,7 +27,15 @@ export async function createCustomer(input: CreateCustomerInput) {
 			.single();
 
 		if (customerError) {
-			console.error("顧客基本情報作成エラー:", customerError);
+			logger.error(
+				{
+					error: customerError.message,
+					code: customerError.code,
+					details: customerError.details,
+					organizationId: input.organization_id,
+				},
+				"顧客基本情報作成エラー",
+			);
 			return {
 				success: false,
 				error: "顧客の基本情報の作成に失敗しました",
@@ -50,7 +59,16 @@ export async function createCustomer(input: CreateCustomerInput) {
 			});
 
 		if (detailsError) {
-			console.error("顧客詳細情報作成エラー:", detailsError);
+			logger.error(
+				{
+					error: detailsError.message,
+					code: detailsError.code,
+					details: detailsError.details,
+					customerId: customer.id,
+					organizationId: input.organization_id,
+				},
+				"顧客詳細情報作成エラー",
+			);
 			// 基本情報をロールバック
 			await supabase.schema("common").from("customers").delete().eq("id", customer.id);
 			return {
@@ -67,7 +85,13 @@ export async function createCustomer(input: CreateCustomerInput) {
 			data: customer,
 		};
 	} catch (error) {
-		console.error("顧客作成中の予期しないエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				organizationId: input.organization_id,
+			},
+			"顧客作成中の予期しないエラー",
+		);
 		return {
 			success: false,
 			error: "システムエラーが発生しました",

--- a/src/app/_actions/funeral/customers/getCustomer.ts
+++ b/src/app/_actions/funeral/customers/getCustomer.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { Customer } from "@/types/funeral-management";
+import logger from "@/lib/logger";
 
 /**
  * IDで顧客を取得する（詳細情報も含む）
@@ -23,7 +24,15 @@ export async function getCustomer(id: string): Promise<{
 			.single();
 
 		if (customerError) {
-			console.error("顧客基本情報取得エラー:", customerError);
+			logger.error(
+				{
+					error: customerError.message,
+					code: customerError.code,
+					details: customerError.details,
+					customerId: id,
+				},
+				"顧客基本情報取得エラー",
+			);
 			return {
 				success: false,
 				error: "顧客が見つかりません",
@@ -39,7 +48,15 @@ export async function getCustomer(id: string): Promise<{
 			.single();
 
 		if (detailsError && detailsError.code !== "PGRST116") {
-			console.error("顧客詳細情報取得エラー:", detailsError);
+			logger.error(
+				{
+					error: detailsError.message,
+					code: detailsError.code,
+					details: detailsError.details,
+					customerId: id,
+				},
+				"顧客詳細情報取得エラー",
+			);
 			// 詳細情報がない場合は基本情報のみ返す
 		}
 
@@ -68,7 +85,13 @@ export async function getCustomer(id: string): Promise<{
 			data: result,
 		};
 	} catch (error) {
-		console.error("顧客取得中の予期しないエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				customerId: id,
+			},
+			"顧客取得中の予期しないエラー",
+		);
 		return {
 			success: false,
 			error: "システムエラーが発生しました",

--- a/src/app/_actions/funeral/customers/updateCustomer.ts
+++ b/src/app/_actions/funeral/customers/updateCustomer.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import type { UpdateCustomerInput } from "@/types/funeral-management";
+import logger from "@/lib/logger";
 
 /**
  * 顧客情報を更新する
@@ -26,7 +27,15 @@ export async function updateCustomer(input: UpdateCustomerInput) {
 				.eq("id", input.id);
 
 			if (customerError) {
-				console.error("顧客基本情報更新エラー:", customerError);
+				logger.error(
+					{
+						error: customerError.message,
+						code: customerError.code,
+						details: customerError.details,
+						customerId: input.id,
+					},
+					"顧客基本情報更新エラー",
+				);
 				return {
 					success: false,
 					error: "顧客の基本情報の更新に失敗しました",
@@ -64,7 +73,15 @@ export async function updateCustomer(input: UpdateCustomerInput) {
 					.eq("customer_id", input.id);
 
 				if (detailsError) {
-					console.error("顧客詳細情報更新エラー:", detailsError);
+					logger.error(
+						{
+							error: detailsError.message,
+							code: detailsError.code,
+							details: detailsError.details,
+							customerId: input.id,
+						},
+						"顧客詳細情報更新エラー",
+					);
 					return {
 						success: false,
 						error: "顧客の詳細情報の更新に失敗しました",
@@ -97,7 +114,15 @@ export async function updateCustomer(input: UpdateCustomerInput) {
 					});
 
 				if (detailsError) {
-					console.error("顧客詳細情報作成エラー:", detailsError);
+					logger.error(
+						{
+							error: detailsError.message,
+							code: detailsError.code,
+							details: detailsError.details,
+							customerId: input.id,
+						},
+						"顧客詳細情報作成エラー",
+					);
 					return {
 						success: false,
 						error: "顧客の詳細情報の作成に失敗しました",
@@ -114,7 +139,13 @@ export async function updateCustomer(input: UpdateCustomerInput) {
 			success: true,
 		};
 	} catch (error) {
-		console.error("顧客更新中の予期しないエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				customerId: input.id,
+			},
+			"顧客更新中の予期しないエラー",
+		);
 		return {
 			success: false,
 			error: "システムエラーが発生しました",

--- a/src/app/_actions/funeral/kouden/create.ts
+++ b/src/app/_actions/funeral/kouden/create.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { requireOrganizationAccess } from "@/lib/access";
+import logger from "@/lib/logger";
 
 export interface CreateKoudenForCaseInput {
 	caseId: string;
@@ -84,7 +85,17 @@ export async function createKoudenForCase(
 		);
 
 		if (createError) {
-			console.error("[ERROR] Failed to create kouden for case:", createError);
+			logger.error(
+				{
+					error: createError.message,
+					code: createError.code,
+					details: createError.details,
+					caseId: input.caseId,
+					organizationId: orgData.organization_id,
+					userId: user.id,
+				},
+				"Failed to create kouden for case",
+			);
 			return { success: false, error: "香典帳の作成に失敗しました" };
 		}
 
@@ -93,7 +104,13 @@ export async function createKoudenForCase(
 			koudenId: koudenId as string,
 		};
 	} catch (error) {
-		console.error("[ERROR] Error in createKoudenForCase:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				caseId: input.caseId,
+			},
+			"Error in createKoudenForCase",
+		);
 		return { success: false, error: "予期せぬエラーが発生しました" };
 	}
 }
@@ -172,7 +189,13 @@ export async function getKoudenForCase(caseId: string) {
 			koudens: koudenDetails || null,
 		};
 	} catch (error) {
-		console.error("[ERROR] Error in getKoudenForCase:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				caseId,
+			},
+			"Error in getKoudenForCase",
+		);
 		throw error;
 	}
 }
@@ -212,13 +235,30 @@ export async function transferKoudenOwnership(koudenId: string, newOwnerEmail: s
 		});
 
 		if (transferError) {
-			console.error("[ERROR] Failed to transfer ownership:", transferError);
+			logger.error(
+				{
+					error: transferError.message,
+					code: transferError.code,
+					details: transferError.details,
+					koudenId,
+					newOwnerEmail,
+					userId: user.id,
+				},
+				"Failed to transfer ownership",
+			);
 			return { success: false, error: "所有権の移譲に失敗しました" };
 		}
 
 		return { success: true };
 	} catch (error) {
-		console.error("[ERROR] Error in transferKoudenOwnership:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				newOwnerEmail,
+			},
+			"Error in transferKoudenOwnership",
+		);
 		return { success: false, error: "予期せぬエラーが発生しました" };
 	}
 }

--- a/src/app/_actions/hearing-applications.ts
+++ b/src/app/_actions/hearing-applications.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import logger from "@/lib/logger";
 
 /**
  * ヒアリング申し込みフォームのバリデーションスキーマ
@@ -81,7 +82,14 @@ export async function submitHearingApplication(formData: FormData) {
 			.single();
 
 		if (insertError) {
-			console.error("Database insert error:", insertError);
+			logger.error(
+				{
+					error: insertError.message,
+					code: insertError.code,
+					userId: user.id,
+				},
+				"Database insert error",
+			);
 			throw new Error("申し込み保存に失敗しました");
 		}
 
@@ -109,7 +117,14 @@ export async function submitHearingApplication(formData: FormData) {
 					})
 					.eq("id", application.id);
 			} catch (calendarError) {
-				console.error("カレンダー予約エラー:", calendarError);
+				logger.error(
+					{
+						error: calendarError instanceof Error ? calendarError.message : String(calendarError),
+						applicationId: application.id,
+						userId: user.id,
+					},
+					"カレンダー予約エラー",
+				);
 				// カレンダー予約失敗してもデータベース保存は成功としてエラーにしない
 				// ただし、ステータスは submitted のまま残す
 			}
@@ -121,7 +136,12 @@ export async function submitHearingApplication(formData: FormData) {
 			message: "ヒアリング申し込みが完了しました",
 		};
 	} catch (error) {
-		console.error("ヒアリング申し込みエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"ヒアリング申し込みエラー",
+		);
 
 		if (error instanceof z.ZodError) {
 			return {
@@ -161,7 +181,14 @@ export async function getUserHearingApplications() {
 			.order("created_at", { ascending: false });
 
 		if (error) {
-			console.error("申し込み履歴取得エラー:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+				},
+				"申し込み履歴取得エラー",
+			);
 			throw new Error("申し込み履歴の取得に失敗しました");
 		}
 
@@ -170,7 +197,12 @@ export async function getUserHearingApplications() {
 			applications: data,
 		};
 	} catch (error) {
-		console.error("申し込み履歴取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"申し込み履歴取得エラー",
+		);
 		return {
 			success: false,
 			error: error instanceof Error ? error.message : "申し込み履歴の取得に失敗しました",
@@ -211,7 +243,14 @@ export async function getAllHearingApplications() {
 			.order("created_at", { ascending: false });
 
 		if (error) {
-			console.error("申し込み一覧取得エラー:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+				},
+				"申し込み一覧取得エラー",
+			);
 			throw new Error("申し込み一覧の取得に失敗しました");
 		}
 
@@ -220,7 +259,12 @@ export async function getAllHearingApplications() {
 			applications: data,
 		};
 	} catch (error) {
-		console.error("申し込み一覧取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"申し込み一覧取得エラー",
+		);
 		return {
 			success: false,
 			error: error instanceof Error ? error.message : "申し込み一覧の取得に失敗しました",
@@ -266,7 +310,16 @@ export async function updateHearingApplicationStatus(
 			.single();
 
 		if (error) {
-			console.error("ステータス更新エラー:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					applicationId,
+					status,
+					userId: user.id,
+				},
+				"ステータス更新エラー",
+			);
 			throw new Error("ステータスの更新に失敗しました");
 		}
 
@@ -277,7 +330,14 @@ export async function updateHearingApplicationStatus(
 			application: data,
 		};
 	} catch (error) {
-		console.error("ステータス更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				applicationId,
+				status,
+			},
+			"ステータス更新エラー",
+		);
 		return {
 			success: false,
 			error: error instanceof Error ? error.message : "ステータスの更新に失敗しました",

--- a/src/app/_actions/invitations.ts
+++ b/src/app/_actions/invitations.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import ms from "ms";
 import type { Database } from "@/types/supabase";
 import type { PostgrestError } from "@supabase/supabase-js";
+import logger from "@/lib/logger";
 
 const createInvitationSchema = z.object({
 	koudenId: z.string().uuid(),
@@ -68,7 +69,13 @@ export async function createShareInvitation(
 
 		return invitation;
 	} catch (error) {
-		console.error("[ERROR] Error in createShareInvitation:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				input,
+			},
+			"Error in createShareInvitation",
+		);
 		throw error;
 	}
 }
@@ -102,7 +109,14 @@ export async function getInvitation(token: string) {
 		};
 
 		if (invitationError) {
-			console.error("[ERROR] Database error in getInvitation:", invitationError);
+			logger.error(
+				{
+					error: invitationError.message,
+					code: invitationError.code,
+					token,
+				},
+				"Database error in getInvitation",
+			);
 			if (invitationError.code === "PGRST116") {
 				throw new Error("招待情報が見つかりません");
 			}
@@ -110,7 +124,7 @@ export async function getInvitation(token: string) {
 		}
 
 		if (!invitation) {
-			console.error("[ERROR] No invitation found for token:", token);
+			logger.error({ token }, "No invitation found for token");
 			throw new Error("招待情報が見つかりません");
 		}
 
@@ -122,7 +136,14 @@ export async function getInvitation(token: string) {
 			.single();
 
 		if (creatorError) {
-			console.warn("[WARN] Failed to get creator profile:", creatorError);
+			logger.warn(
+				{
+					error: creatorError.message,
+					code: creatorError.code,
+					creatorId: invitation.created_by,
+				},
+				"Failed to get creator profile",
+			);
 		}
 
 		// ユーザーが既にメンバーかどうかをチェック
@@ -136,7 +157,15 @@ export async function getInvitation(token: string) {
 				.single();
 
 			if (memberCheckError && memberCheckError.code !== "PGRST116") {
-				console.warn("[WARN] Failed to check existing membership:", memberCheckError);
+				logger.warn(
+					{
+						error: memberCheckError.message,
+						code: memberCheckError.code,
+						userId: user.id,
+						koudenId: invitation.kouden_id,
+					},
+					"Failed to check existing membership",
+				);
 			}
 
 			isExistingMember = !!existingMember;
@@ -152,7 +181,13 @@ export async function getInvitation(token: string) {
 
 		return result;
 	} catch (error) {
-		console.error("[ERROR] Error in getInvitation:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				token,
+			},
+			"Error in getInvitation",
+		);
 		throw error;
 	}
 }
@@ -176,7 +211,14 @@ export async function acceptInvitation(token: string) {
 			.single();
 
 		if (invitationError) {
-			console.error("[ERROR] Failed to get invitation:", invitationError);
+			logger.error(
+				{
+					error: invitationError.message,
+					code: invitationError.code,
+					token,
+				},
+				"Failed to get invitation",
+			);
 			if (invitationError.code === "PGRST116") {
 				throw new Error("招待が見つかりません");
 			}
@@ -184,28 +226,48 @@ export async function acceptInvitation(token: string) {
 		}
 
 		if (!invitation) {
-			console.error("[ERROR] No invitation found for token:", token);
+			logger.error({ token }, "No invitation found for token");
 			throw new Error("招待が見つかりません");
 		}
 
 		// 2. 招待の有効性チェック
 		if (invitation.status !== "pending") {
-			console.error("[ERROR] Invitation status is not pending:", invitation.status);
+			logger.error(
+				{
+					invitationId: invitation.id,
+					status: invitation.status,
+					token,
+				},
+				"Invitation status is not pending",
+			);
 			throw new Error("この招待は既に使用されています");
 		}
 
 		const now = new Date();
 		const expiresAt = new Date(invitation.expires_at);
 		if (expiresAt < now) {
-			console.error("[ERROR] Invitation expired:", { expiresAt, now });
+			logger.error(
+				{
+					invitationId: invitation.id,
+					expiresAt: expiresAt.toISOString(),
+					now: now.toISOString(),
+					token,
+				},
+				"Invitation expired",
+			);
 			throw new Error("招待の有効期限が切れています");
 		}
 
 		if (invitation.max_uses && invitation.used_count >= invitation.max_uses) {
-			console.error("[ERROR] Invitation usage limit exceeded:", {
-				used_count: invitation.used_count,
-				max_uses: invitation.max_uses,
-			});
+			logger.error(
+				{
+					invitationId: invitation.id,
+					used_count: invitation.used_count,
+					max_uses: invitation.max_uses,
+					token,
+				},
+				"Invitation usage limit exceeded",
+			);
 			throw new Error("招待の使用回数が上限に達しました");
 		}
 
@@ -218,15 +280,27 @@ export async function acceptInvitation(token: string) {
 			.single();
 
 		if (memberCheckError && memberCheckError.code !== "PGRST116") {
-			console.error("[ERROR] Failed to check existing membership:", memberCheckError);
+			logger.error(
+				{
+					error: memberCheckError.message,
+					code: memberCheckError.code,
+					userId: user.id,
+					koudenId: invitation.kouden_id,
+				},
+				"Failed to check existing membership",
+			);
 			throw new Error("メンバーシップの確認に失敗しました");
 		}
 
 		if (existingMember) {
-			console.error("[ERROR] User is already a member:", {
-				user_id: user.id,
-				kouden_id: invitation.kouden_id,
-			});
+			logger.error(
+				{
+					userId: user.id,
+					koudenId: invitation.kouden_id,
+					token,
+				},
+				"User is already a member",
+			);
 			throw new Error("すでにメンバーとして参加しています");
 		}
 
@@ -240,7 +314,16 @@ export async function acceptInvitation(token: string) {
 		});
 
 		if (memberError) {
-			console.error("[ERROR] Failed to add member:", memberError);
+			logger.error(
+				{
+					error: memberError.message,
+					code: memberError.code,
+					userId: user.id,
+					koudenId: invitation.kouden_id,
+					invitationId: invitation.id,
+				},
+				"Failed to add member",
+			);
 			throw new Error("メンバーの追加に失敗しました");
 		}
 
@@ -254,15 +337,33 @@ export async function acceptInvitation(token: string) {
 			.eq("id", invitation.id);
 
 		if (updateError) {
-			console.error("[ERROR] Failed to update invitation:", updateError);
+			logger.error(
+				{
+					error: updateError.message,
+					code: updateError.code,
+					invitationId: invitation.id,
+				},
+				"Failed to update invitation",
+			);
 			// メンバー追加は成功しているので、招待の更新失敗は警告レベル
-			console.warn("[WARN] Member was added but invitation update failed");
-		} else {
+			logger.warn(
+				{
+					invitationId: invitation.id,
+					userId: user.id,
+				},
+				"Member was added but invitation update failed",
+			);
 		}
 
 		return { success: true };
 	} catch (error) {
-		console.error("[ERROR] Error in acceptInvitation:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				token,
+			},
+			"Error in acceptInvitation",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { CreateKoudenParams, Kouden } from "@/types/kouden";
 import { KOUDEN_ROLES } from "@/types/role";
+import logger from "@/lib/logger";
 
 export interface CreateKoudenWithPlanParams extends CreateKoudenParams {
 	planCode: string;
@@ -89,7 +90,14 @@ export async function createKouden({
 
 		return { kouden: { ...kouden, owner } as unknown as Kouden };
 	} catch (error) {
-		console.error("[ERROR] Error creating kouden:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				title,
+				userId,
+			},
+			"Error creating kouden",
+		);
 		return { error: "香典帳の作成に失敗しました" };
 	}
 }
@@ -149,7 +157,15 @@ export async function createKoudenWithPlan({
 		}
 		return { koudenId: kouden.id };
 	} catch (error) {
-		console.error("[ERROR] Error creating kouden with plan:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				title,
+				planCode,
+				userId: uid,
+			},
+			"Error creating kouden with plan",
+		);
 		return { error: "有料香典帳の作成に失敗しました" };
 	}
 }

--- a/src/app/_actions/koudens/delete.ts
+++ b/src/app/_actions/koudens/delete.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidatePath } from "next/cache";
 import { canDeleteKouden } from "../permissions";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳の削除
@@ -11,18 +12,31 @@ export async function deleteKouden(id: string) {
 	try {
 		const hasPermission = await canDeleteKouden(id);
 		if (!hasPermission) {
-			console.error("[deleteKouden] permission denied");
+			logger.error({ koudenId: id }, "[deleteKouden] permission denied");
 			return; // 権限不足時は例外を投げずに終了
 		}
 
 		const supabase = createAdminClient();
 		const { error } = await supabase.from("koudens").delete().eq("id", id);
 		if (error) {
-			console.error("[deleteKouden] supabase delete error:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId: id,
+				},
+				"[deleteKouden] supabase delete error",
+			);
 			return; // 削除エラー時も例外を投げずに終了
 		}
 	} catch (err) {
-		console.error("[deleteKouden] suppressed error:", err);
+		logger.error(
+			{
+				error: err instanceof Error ? err.message : String(err),
+				koudenId: id,
+			},
+			"[deleteKouden] suppressed error",
+		);
 		// 例外を抑制してUI側に伝播させない
 	} finally {
 		// キャッシュ再検証は必ず行う

--- a/src/app/_actions/koudens/duplicate.ts
+++ b/src/app/_actions/koudens/duplicate.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Kouden } from "@/types/kouden";
 import { checkKoudenPermission } from "../permissions";
 import { KOUDEN_ROLES } from "@/types/role";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳の複製（デフォルトで free プラン適用）
@@ -311,7 +312,13 @@ export async function duplicateKouden(id: string): Promise<{ kouden?: Kouden; er
 
 		return { kouden: { ...newKouden, owner } as unknown as Kouden };
 	} catch (error) {
-		console.error("[ERROR] Error duplicating kouden:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId: id,
+			},
+			"[ERROR] Error duplicating kouden",
+		);
 		return { error: "香典帳の複製に失敗しました" };
 	}
 }

--- a/src/app/_actions/koudens/read.ts
+++ b/src/app/_actions/koudens/read.ts
@@ -5,6 +5,7 @@ import type { Kouden } from "@/types/kouden";
 import type { Entry } from "@/types/entries";
 import { checkKoudenPermission } from "../permissions";
 import type { Database } from "@/types/supabase";
+import logger from "@/lib/logger";
 type Plan = Database["public"]["Tables"]["plans"]["Row"];
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
 type KoudenWithPlan = Kouden & {
@@ -122,7 +123,12 @@ export async function getKoudens(): Promise<{ koudens?: KoudenWithPlan[]; error?
 		});
 		return { koudens: results };
 	} catch (error) {
-		console.error("[ERROR] Error getting koudens:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error getting koudens",
+		);
 		return { error: "香典帳の取得に失敗しました" };
 	}
 }
@@ -191,7 +197,14 @@ export async function getKoudenWithEntries(id: string) {
 		.single();
 
 	if (koudenError) {
-		console.error("[ERROR] Error fetching kouden:", koudenError);
+		logger.error(
+			{
+				error: koudenError.message,
+				code: koudenError.code,
+				koudenId: id,
+			},
+			"Error fetching kouden",
+		);
 		throw new Error("香典帳の取得に失敗しました");
 	}
 
@@ -203,7 +216,15 @@ export async function getKoudenWithEntries(id: string) {
 		.single();
 
 	if (ownerError) {
-		console.error("[ERROR] Error fetching owner profile:", ownerError);
+		logger.error(
+			{
+				error: ownerError.message,
+				code: ownerError.code,
+				ownerId: kouden.owner_id,
+				koudenId: id,
+			},
+			"Error fetching owner profile",
+		);
 		throw new Error("オーナー情報の取得に失敗しました");
 	}
 
@@ -224,7 +245,14 @@ export async function getKoudenWithEntries(id: string) {
 		.order("created_at", { ascending: false });
 
 	if (entriesError) {
-		console.error("[ERROR] Error fetching kouden entries:", entriesError);
+		logger.error(
+			{
+				error: entriesError.message,
+				code: entriesError.code,
+				koudenId: id,
+			},
+			"Error fetching kouden entries",
+		);
 		throw new Error("香典帳の記帳データの取得に失敗しました");
 	}
 

--- a/src/app/_actions/koudens/update.ts
+++ b/src/app/_actions/koudens/update.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import type { Kouden } from "@/types/kouden";
 import { canEditKouden, checkKoudenPermission } from "../permissions";
 import { KOUDEN_ROLES } from "@/types/role";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳の更新
@@ -40,7 +41,15 @@ export async function updateKouden(id: string, input: { title: string; descripti
 	const { error } = await supabase.from("koudens").update(updateData).eq("id", id);
 
 	if (error) {
-		console.error("Failed to update kouden:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				id,
+				input,
+			},
+			"Failed to update kouden",
+		);
 		throw new Error("香典帳の更新に失敗しました。しばらく経ってから再度お試しください。");
 	}
 

--- a/src/app/_actions/members.ts
+++ b/src/app/_actions/members.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { cache } from "react";
 import { KoudenError, withErrorHandling } from "@/lib/errors";
+import logger from "@/lib/logger";
 
 /**
  * メンバー一覧を取得する（最適化版）
@@ -28,7 +29,14 @@ export const getMembers = cache(async (koudenId: string) => {
 			.single();
 
 		if (permissionError) {
-			console.error("[ERROR] Failed to fetch permission:", permissionError);
+			logger.error(
+				{
+					error: permissionError.message,
+					code: permissionError.code,
+					koudenId,
+				},
+				"Failed to fetch permission",
+			);
 			throw new KoudenError("権限の確認に失敗しました", "FETCH_PERMISSION_ERROR");
 		}
 
@@ -44,7 +52,15 @@ export const getMembers = cache(async (koudenId: string) => {
 				.single();
 
 			if (membershipError) {
-				console.error("[ERROR] Failed to check membership:", membershipError);
+				logger.error(
+					{
+						error: membershipError.message,
+						code: membershipError.code,
+						koudenId,
+						userId: user.id,
+					},
+					"Failed to check membership",
+				);
 				throw new KoudenError("メンバー権限の確認に失敗しました", "FETCH_MEMBERSHIP_ERROR");
 			}
 
@@ -73,7 +89,14 @@ export const getMembers = cache(async (koudenId: string) => {
 			.eq("kouden_id", koudenId);
 
 		if (membersError) {
-			console.error("[ERROR] Failed to fetch members:", membersError);
+			logger.error(
+				{
+					error: membersError.message,
+					code: membersError.code,
+					koudenId,
+				},
+				"Failed to fetch members",
+			);
 			throw new KoudenError("メンバー一覧の取得に失敗しました", "FETCH_MEMBERS_ERROR");
 		}
 
@@ -89,7 +112,14 @@ export const getMembers = cache(async (koudenId: string) => {
 			.in("id", userIds);
 
 		if (profilesError) {
-			console.error("[ERROR] Failed to fetch profiles:", profilesError);
+			logger.error(
+				{
+					error: profilesError.message,
+					code: profilesError.code,
+					koudenId,
+				},
+				"Failed to fetch profiles",
+			);
 			throw new KoudenError("プロフィール情報の取得に失敗しました", "FETCH_PROFILES_ERROR");
 		}
 
@@ -148,7 +178,14 @@ export const getMembersForAdmin = cache(async (koudenId: string) => {
 			.single();
 
 		if (koudenError) {
-			console.error("[ERROR] Failed to fetch kouden:", koudenError);
+			logger.error(
+				{
+					error: koudenError.message,
+					code: koudenError.code,
+					koudenId,
+				},
+				"Failed to fetch kouden",
+			);
 			throw new KoudenError("香典帳の取得に失敗しました", "FETCH_KOUDEN_ERROR");
 		}
 
@@ -176,7 +213,14 @@ export const getMembersForAdmin = cache(async (koudenId: string) => {
 			.eq("kouden_id", koudenId);
 
 		if (membersError) {
-			console.error("[ERROR] Failed to fetch members:", membersError);
+			logger.error(
+				{
+					error: membersError.message,
+					code: membersError.code,
+					koudenId,
+				},
+				"Failed to fetch members",
+			);
 			throw new KoudenError("メンバー一覧の取得に失敗しました", "FETCH_MEMBERS_ERROR");
 		}
 
@@ -192,7 +236,14 @@ export const getMembersForAdmin = cache(async (koudenId: string) => {
 			.in("id", userIds);
 
 		if (profilesError) {
-			console.error("[ERROR] Failed to fetch profiles:", profilesError);
+			logger.error(
+				{
+					error: profilesError.message,
+					code: profilesError.code,
+					koudenId,
+				},
+				"Failed to fetch profiles",
+			);
 			throw new KoudenError("プロフィール情報の取得に失敗しました", "FETCH_PROFILES_ERROR");
 		}
 

--- a/src/app/_actions/notifications.ts
+++ b/src/app/_actions/notifications.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { NotificationItem } from "@/types/notifications";
+import logger from "@/lib/logger";
 
 /**
  * 通知一覧取得
@@ -37,7 +38,14 @@ export async function getNotifications(): Promise<{
 		.eq("user_id", user.id)
 		.order("created_at", { ascending: false });
 	if (error) {
-		console.error("[ERROR] Error fetching notifications:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				userId: user.id,
+			},
+			"Error fetching notifications",
+		);
 		return { error: "通知一覧の取得に失敗しました" };
 	}
 	return { notifications: data as NotificationItem[] };
@@ -61,7 +69,14 @@ export async function markNotificationRead(): Promise<{ error?: string }> {
 		.eq("user_id", user.id)
 		.eq("is_read", false);
 	if (error) {
-		console.error("[ERROR] Error marking notifications as read:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				userId: user.id,
+			},
+			"Error marking notifications as read",
+		);
 		return { error: "通知既読設定に失敗しました" };
 	}
 	return {};

--- a/src/app/_actions/offerings.ts
+++ b/src/app/_actions/offerings.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/types/offerings";
 import { snakeToCamel } from "@/utils/case-converter";
 import type { Database } from "@/types/supabase";
+import logger from "@/lib/logger";
 
 //お供物情報を作成する
 export async function createOffering(input: Omit<CreateOfferingInput, "created_by">) {
@@ -22,7 +23,7 @@ export async function createOffering(input: Omit<CreateOfferingInput, "created_b
 		} = await supabase.auth.getUser();
 
 		if (!user) {
-			console.error("[ERROR] Authentication required");
+			logger.error({}, "Authentication required");
 			throw new Error("認証が必要です");
 		}
 
@@ -41,7 +42,15 @@ export async function createOffering(input: Omit<CreateOfferingInput, "created_b
 			.single();
 
 		if (error) {
-			console.error("お供え物の作成に失敗しました:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId: input.kouden_id,
+					userId: user.id,
+				},
+				"お供え物の作成に失敗しました",
+			);
 			throw new Error("お供え物の作成に失敗しました。");
 		}
 
@@ -58,7 +67,15 @@ export async function createOffering(input: Omit<CreateOfferingInput, "created_b
 				.insert(offeringEntries);
 
 			if (offeringEntriesError) {
-				console.error("香典エントリーの関連付けに失敗しました:", offeringEntriesError);
+				logger.error(
+					{
+						error: offeringEntriesError.message,
+						code: offeringEntriesError.code,
+						offeringId: data.id,
+						entryIds: kouden_entry_ids,
+					},
+					"香典エントリーの関連付けに失敗しました",
+				);
 				throw new Error("香典エントリーの関連付けに失敗しました。");
 			}
 		}
@@ -70,20 +87,29 @@ export async function createOffering(input: Omit<CreateOfferingInput, "created_b
 			.eq("id", input.kouden_id as string);
 
 		if (updateError) {
-			console.error("[ERROR] Failed to update kouden:", {
-				error: updateError,
-				code: updateError.code,
-				details: updateError.details,
-				hint: updateError.hint,
-				message: updateError.message,
-			});
+			logger.error(
+				{
+					error: updateError.message,
+					code: updateError.code,
+					details: updateError.details,
+					hint: updateError.hint,
+					koudenId: input.kouden_id,
+				},
+				"Failed to update kouden",
+			);
 			// 更新エラーは致命的ではないのでログのみ
 		}
 
 		revalidatePath(`/koudens/${input.kouden_id}`);
 		return data;
 	} catch (error) {
-		console.error("お供え物の作成処理中にエラーが発生しました:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId: input.kouden_id,
+			},
+			"お供え物の作成処理中にエラーが発生しました",
+		);
 		throw error;
 	}
 }
@@ -114,7 +140,15 @@ export async function updateOffering(id: string, input: UpdateOfferingInput) {
 			.single();
 
 		if (error) {
-			console.error("お供え物の更新に失敗しました:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					id,
+					userId: user.id,
+				},
+				"お供え物の更新に失敗しました",
+			);
 			throw new Error("お供え物の更新に失敗しました。");
 		}
 
@@ -127,7 +161,14 @@ export async function updateOffering(id: string, input: UpdateOfferingInput) {
 				.eq("offering_id", id);
 
 			if (deleteError) {
-				console.error("既存の香典エントリー関連付けの削除に失敗しました:", deleteError);
+				logger.error(
+					{
+						error: deleteError.message,
+						code: deleteError.code,
+						offeringId: id,
+					},
+					"既存の香典エントリー関連付けの削除に失敗しました",
+				);
 				throw new Error("既存の香典エントリー関連付けの削除に失敗しました。");
 			}
 
@@ -144,7 +185,15 @@ export async function updateOffering(id: string, input: UpdateOfferingInput) {
 					.insert(offeringEntries);
 
 				if (insertError) {
-					console.error("香典エントリーの関連付けに失敗しました:", insertError);
+					logger.error(
+						{
+							error: insertError.message,
+							code: insertError.code,
+							offeringId: id,
+							entryIds: kouden_entry_ids,
+						},
+						"香典エントリーの関連付けに失敗しました",
+					);
 					throw new Error("香典エントリーの関連付けに失敗しました。");
 				}
 			}
@@ -157,20 +206,29 @@ export async function updateOffering(id: string, input: UpdateOfferingInput) {
 			.eq("id", input.kouden_id as string);
 
 		if (updateError) {
-			console.error("[ERROR] Failed to update kouden:", {
-				error: updateError,
-				code: updateError.code,
-				details: updateError.details,
-				hint: updateError.hint,
-				message: updateError.message,
-			});
+			logger.error(
+				{
+					error: updateError.message,
+					code: updateError.code,
+					details: updateError.details,
+					hint: updateError.hint,
+					koudenId: input.kouden_id,
+				},
+				"Failed to update kouden",
+			);
 			// 更新エラーは致命的ではないのでログのみ
 		}
 
 		revalidatePath(`/koudens/${input.kouden_id}`);
 		return data;
 	} catch (error) {
-		console.error("お供え物の更新処理中にエラーが発生しました:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"お供え物の更新処理中にエラーが発生しました",
+		);
 		throw error;
 	}
 }
@@ -189,7 +247,15 @@ export async function deleteOffering(id: string, koudenId: string) {
 	const { error } = await supabase.from("offerings").delete().eq("id", id);
 
 	if (error) {
-		console.error("[deleteOffering] Delete failed:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				id,
+				koudenId,
+			},
+			"[deleteOffering] Delete failed",
+		);
 		throw new Error(`お供え物の削除に失敗しました: ${error.message}`);
 	}
 
@@ -200,7 +266,14 @@ export async function deleteOffering(id: string, koudenId: string) {
 		.eq("id", koudenId);
 
 	if (updateError) {
-		console.error("[deleteOffering] Failed to update kouden:", updateError);
+		logger.error(
+			{
+				error: updateError.message,
+				code: updateError.code,
+				koudenId,
+			},
+			"[deleteOffering] Failed to update kouden",
+		);
 		// 更新エラーは致命的ではないのでログのみ
 	}
 
@@ -375,7 +448,15 @@ export async function updateOfferingField(
 		.single();
 
 	if (error) {
-		console.error("[updateOfferingField] Update failed:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				id,
+				field,
+			},
+			"[updateOfferingField] Update failed",
+		);
 		throw new Error(`お供え物の更新に失敗しました: ${error.message}`);
 	}
 

--- a/src/app/_actions/plans.ts
+++ b/src/app/_actions/plans.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/supabase";
+import logger from "@/lib/logger";
 
 type Plan = Database["public"]["Tables"]["plans"]["Row"];
 
@@ -17,7 +18,13 @@ export async function getPlans(): Promise<{ plans?: Plan[]; error?: string }> {
 		.order("price", { ascending: true });
 
 	if (error) {
-		console.error("[ERROR] Error fetching plans:", error);
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+			},
+			"[ERROR] Error fetching plans",
+		);
 		return { error: "プラン一覧の取得に失敗しました" };
 	}
 	return { plans: data };

--- a/src/app/_actions/profiles.ts
+++ b/src/app/_actions/profiles.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 interface UpdateProfileParams {
 	display_name: string;
@@ -23,7 +24,13 @@ export async function getProfile(userId: string) {
 
 		return { profile, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+			},
+			"Error getting profile",
+		);
 		return {
 			profile: null,
 			error: "プロフィールの取得に失敗しました",
@@ -44,11 +51,10 @@ export async function getActivityStats(userId: string) {
 		if (ownedError) throw ownedError;
 
 		// 参加している香典帳の数を取得
-		const { count: participatingKoudensCount, error: participatingError } =
-			await supabase
-				.from("kouden_members")
-				.select("*", { count: "exact", head: true })
-				.eq("user_id", userId);
+		const { count: participatingKoudensCount, error: participatingError } = await supabase
+			.from("kouden_members")
+			.select("*", { count: "exact", head: true })
+			.eq("user_id", userId);
 
 		if (participatingError) throw participatingError;
 
@@ -83,7 +89,13 @@ export async function getActivityStats(userId: string) {
 			error: null,
 		};
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+			},
+			"Error getting activity stats",
+		);
 		return {
 			stats: null,
 			error: "活動統計の取得に失敗しました",
@@ -91,10 +103,7 @@ export async function getActivityStats(userId: string) {
 	}
 }
 
-export async function updateProfile(
-	userId: string,
-	params: UpdateProfileParams,
-) {
+export async function updateProfile(userId: string, params: UpdateProfileParams) {
 	try {
 		const supabase = await createClient();
 
@@ -115,7 +124,14 @@ export async function updateProfile(
 		revalidatePath("/profile");
 		return { profile, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+				params,
+			},
+			"Error updating profile",
+		);
 		return {
 			profile: null,
 			error: "プロフィールの更新に失敗しました",
@@ -144,7 +160,14 @@ export async function updateAvatar(userId: string, avatarUrl: string) {
 		revalidatePath("/profile");
 		return { profile, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+				avatarUrl,
+			},
+			"Error updating avatar",
+		);
 		return {
 			profile: null,
 			error: "アバターの更新に失敗しました",

--- a/src/app/_actions/purchaseKouden.ts
+++ b/src/app/_actions/purchaseKouden.ts
@@ -4,6 +4,7 @@ import Stripe from "stripe";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import { calcSupportFee } from "@/utils/calcSupportFee";
+import logger from "@/lib/logger";
 
 /**
  * Stripe Checkout セッション生成
@@ -52,7 +53,7 @@ export async function purchaseKouden({
 		// Retrieve Stripe secret key safely and initialize
 		const stripeSecret = process.env.STRIPE_SECRET_KEY;
 		if (!stripeSecret) {
-			console.error("[ERROR] STRIPE_SECRET_KEY is not set");
+			logger.error({}, "[ERROR] STRIPE_SECRET_KEY is not set");
 			return { error: "支払いセッションの生成に失敗しました" };
 		}
 		// FIRST_EDIT: 開発環境では環境変数STRIPE_API_VERSIONを使い、それ以外は既存バージョンを使用
@@ -69,7 +70,12 @@ export async function purchaseKouden({
 			error: userError,
 		} = await supabaseClient.auth.getUser();
 		if (userError || !user) {
-			console.error("[ERROR] ユーザー取得失敗:", userError);
+			logger.error(
+				{
+					error: userError?.message,
+				},
+				"[ERROR] ユーザー取得失敗",
+			);
 			return { error: "認証が必要です" };
 		}
 		const userId = user.id;
@@ -116,7 +122,14 @@ export async function purchaseKouden({
 		});
 		return { url: session.url || undefined, sessionId: session.id };
 	} catch (error) {
-		console.error("[ERROR] Error creating Stripe session:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				planCode,
+			},
+			"[ERROR] Error creating Stripe session",
+		);
 		return { error: "支払いセッションの生成に失敗しました" };
 	}
 }

--- a/src/app/_actions/relationships.ts
+++ b/src/app/_actions/relationships.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Database } from "@/types/supabase";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 // すべての関係性を取得
 export async function getAllRelationships() {
@@ -35,13 +36,20 @@ export async function getRelationships(koudenId: string) {
 			.eq("kouden_id", koudenId);
 
 		if (countError) {
-			console.error("[ERROR] Failed to count relationships:", countError);
+			logger.error(
+				{
+					error: countError.message,
+					code: countError.code,
+					koudenId,
+				},
+				"Failed to count relationships",
+			);
 			throw countError;
 		}
 
 		// 関係性が存在しない場合はすぐに空配列を返す
 		if (count === 0) {
-			console.warn(`[WARN] No relationships found for kouden ${koudenId}`);
+			logger.warn({ koudenId }, "No relationships found for kouden");
 			return [];
 		}
 
@@ -64,18 +72,31 @@ export async function getRelationships(koudenId: string) {
 			.order("name");
 
 		if (error) {
-			console.error("[ERROR] Failed to fetch relationships:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+				},
+				"Failed to fetch relationships",
+			);
 			throw error;
 		}
 
 		if (!data || data.length === 0) {
-			console.warn(`[WARN] No relationships data returned for kouden ${koudenId}`);
+			logger.warn({ koudenId }, "No relationships data returned for kouden");
 			return [];
 		}
 
 		return data;
 	} catch (error) {
-		console.error("[ERROR] Error in getRelationships:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Error in getRelationships",
+		);
 		throw error;
 	}
 }
@@ -103,13 +124,20 @@ export async function getRelationshipsForAdmin(koudenId: string) {
 			.eq("kouden_id", koudenId);
 
 		if (countError) {
-			console.error("[ERROR] Failed to count relationships for admin:", countError);
+			logger.error(
+				{
+					error: countError.message,
+					code: countError.code,
+					koudenId,
+				},
+				"Failed to count relationships for admin",
+			);
 			throw countError;
 		}
 
 		// 関係性が存在しない場合はすぐに空配列を返す
 		if (count === 0) {
-			console.warn(`[WARN] No relationships found for kouden ${koudenId}`);
+			logger.warn({ koudenId }, "No relationships found for kouden");
 			return [];
 		}
 
@@ -132,18 +160,31 @@ export async function getRelationshipsForAdmin(koudenId: string) {
 			.order("name");
 
 		if (error) {
-			console.error("[ERROR] Failed to fetch relationships for admin:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+				},
+				"Failed to fetch relationships for admin",
+			);
 			throw error;
 		}
 
 		if (!data || data.length === 0) {
-			console.warn(`[WARN] No relationships data returned for kouden ${koudenId}`);
+			logger.warn({ koudenId }, "No relationships data returned for kouden");
 			return [];
 		}
 
 		return data;
 	} catch (error) {
-		console.error("[ERROR] Error in getRelationshipsForAdmin:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Error in getRelationshipsForAdmin",
+		);
 		throw error;
 	}
 }
@@ -246,7 +287,13 @@ export async function initializeDefaultRelationships(koudenId: string) {
 		if (error) throw error;
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("[ERROR] Error initializing default relationships:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Error initializing default relationships",
+		);
 		throw new Error("デフォルトの関係性の初期化に失敗しました");
 	}
 }

--- a/src/app/_actions/return-records/bulk-operations.ts
+++ b/src/app/_actions/return-records/bulk-operations.ts
@@ -13,6 +13,7 @@ import type {
 	ReturnManagementSummary,
 	BulkUpdateConfig,
 } from "@/types/return-records/return-records";
+import logger from "@/lib/logger";
 
 /**
  * 一括変更用：香典帳の全返礼記録を取得する（ReturnManagementSummary形式）
@@ -102,7 +103,13 @@ export async function getAllReturnRecordsForBulkUpdate(
 
 		return summaries;
 	} catch (error) {
-		console.error("一括変更用全返礼記録の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"一括変更用全返礼記録の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -217,7 +224,13 @@ export async function bulkUpdateReturnRecords(
 		if (updates.returnItems) {
 			// TODO: 返礼品の操作ロジックを実装
 			// 現在は基本的なステータス・方法の更新のみ対応
-			console.log("返礼品の操作:", updates.returnItems);
+			logger.info(
+				{
+					returnItems: updates.returnItems,
+					koudenId,
+				},
+				"返礼品の操作",
+			);
 		}
 
 		// 一括更新実行
@@ -236,7 +249,14 @@ export async function bulkUpdateReturnRecords(
 
 		return targetRecords.length;
 	} catch (error) {
-		console.error("返礼記録の一括更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				config,
+			},
+			"返礼記録の一括更新エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/bulk-update-optimized.ts
+++ b/src/app/_actions/return-records/bulk-update-optimized.ts
@@ -8,6 +8,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import type { AmountGroupData, BulkUpdateResult } from "@/types/return-records/bulk-update";
+import logger from "@/lib/logger";
 
 /**
  * PostgreSQL最適化版：超高速一括更新
@@ -166,7 +167,14 @@ export async function executeBulkUpdateOptimized(
 			failureCount: allEntryIds.length - successCount,
 		};
 	} catch (error) {
-		console.error("PostgreSQL最適化版一括更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				amountGroupsCount: amountGroups.length,
+			},
+			"PostgreSQL最適化版一括更新エラー",
+		);
 		const errorMessage = error instanceof Error ? error.message : "不明なエラー";
 		throw new Error(`最適化一括更新に失敗: ${errorMessage}`);
 	}

--- a/src/app/_actions/return-records/bulk-update.ts
+++ b/src/app/_actions/return-records/bulk-update.ts
@@ -13,6 +13,7 @@ import type {
 	BulkUpdateExecutionData,
 	BulkUpdateResult,
 } from "@/types/return-records/bulk-update";
+import logger from "@/lib/logger";
 
 // 返礼品マスタのキャッシュ（セッション内で再利用）
 const returnItemsCache = new Map<string, ReturnItemMaster[]>();
@@ -47,7 +48,15 @@ export async function getReturnItemsForBulkUpdate(koudenId: string): Promise<Ret
 			.order("name", { ascending: true });
 
 		if (error) {
-			console.error("返礼品マスタ取得エラー:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+					userId: user.id,
+				},
+				"返礼品マスタ取得エラー",
+			);
 			throw new Error(`返礼品マスタの取得に失敗しました: ${error.message}`);
 		}
 
@@ -58,7 +67,13 @@ export async function getReturnItemsForBulkUpdate(koudenId: string): Promise<Ret
 
 		return result;
 	} catch (error) {
-		console.error("返礼品マスタの取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"返礼品マスタの取得エラー",
+		);
 		if (error instanceof Error) {
 			throw error;
 		}
@@ -98,7 +113,14 @@ export async function executeBulkUpdateByAmount(
 				.in("id", executionData.returnItemIds);
 
 			if (returnItemsError) {
-				console.error("返礼品マスタ取得エラー:", returnItemsError);
+				logger.error(
+					{
+						error: returnItemsError.message,
+						code: returnItemsError.code,
+						returnItemIds: executionData.returnItemIds,
+					},
+					"返礼品マスタ取得エラー",
+				);
 				throw new Error(`返礼品情報の取得に失敗しました: ${returnItemsError.message}`);
 			}
 
@@ -129,7 +151,14 @@ export async function executeBulkUpdateByAmount(
 			.in("kouden_entry_id", executionData.entryIds);
 
 		if (selectError) {
-			console.error("既存記録取得エラー:", selectError);
+			logger.error(
+				{
+					error: selectError.message,
+					code: selectError.code,
+					entryIds: executionData.entryIds,
+				},
+				"既存記録取得エラー",
+			);
 			throw new Error(`既存記録の取得に失敗しました: ${selectError.message}`);
 		}
 
@@ -253,7 +282,13 @@ export async function executeBulkUpdateByAmount(
 			errors: errors.length > 0 ? errors : undefined,
 		};
 	} catch (error) {
-		console.error("一括更新の実行エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				executionData,
+			},
+			"一括更新の実行エラー",
+		);
 		const errorMessage = error instanceof Error ? error.message : "不明なエラー";
 		throw new Error(`一括更新の実行に失敗しました: ${errorMessage}`);
 	}
@@ -297,7 +332,14 @@ export async function executeBulkUpdateMultipleGroups(
 				try {
 					return await executeBulkUpdateByAmount(executionData);
 				} catch (error) {
-					console.error(`グループ処理エラー (金額: ${group.amount}):`, error);
+					logger.error(
+						{
+							error: error instanceof Error ? error.message : String(error),
+							amount: group.amount,
+							entryIds: group.entryIds,
+						},
+						`グループ処理エラー (金額: ${group.amount})`,
+					);
 					return {
 						successCount: 0,
 						failureCount: group.count,
@@ -329,7 +371,14 @@ export async function executeBulkUpdateMultipleGroups(
 			errors: allErrors.length > 0 ? allErrors : undefined,
 		};
 	} catch (error) {
-		console.error("複数グループ一括更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				amountGroupsCount: amountGroups.length,
+			},
+			"複数グループ一括更新エラー",
+		);
 		const errorMessage = error instanceof Error ? error.message : "不明なエラー";
 		throw new Error(`複数グループの一括更新に失敗しました: ${errorMessage}`);
 	}

--- a/src/app/_actions/return-records/crud.ts
+++ b/src/app/_actions/return-records/crud.ts
@@ -11,6 +11,7 @@ import type {
 	ReturnEntryRecord,
 	CreateReturnEntryInput,
 } from "@/types/return-records/return-records";
+import logger from "@/lib/logger";
 
 /**
  * 返礼情報を作成する
@@ -49,7 +50,13 @@ export async function createReturnEntry(input: CreateReturnEntryInput): Promise<
 
 		return data as ReturnEntryRecord;
 	} catch (error) {
-		console.error("返礼情報の作成エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId: input.kouden_entry_id,
+			},
+			"返礼情報の作成エラー",
+		);
 		throw error;
 	}
 }
@@ -79,7 +86,13 @@ export async function getReturnEntryRecord(
 
 		return data as ReturnEntryRecord | null;
 	} catch (error) {
-		console.error("返礼情報の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId,
+			},
+			"返礼情報の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -111,7 +124,13 @@ export async function getReturnEntriesByKouden(koudenId: string): Promise<Return
 
 		return data as ReturnEntryRecord[];
 	} catch (error) {
-		console.error("返礼情報一覧の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"返礼情報一覧の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -139,7 +158,14 @@ export async function deleteReturnEntry(koudenEntryId: string, koudenId: string)
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("返礼情報の削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId,
+				koudenId,
+			},
+			"返礼情報の削除エラー",
+		);
 		throw error;
 	}
 }
@@ -186,7 +212,13 @@ export async function deleteReturnRecords(returnRecordIds: string[]): Promise<vo
 			}
 		}
 	} catch (error) {
-		console.error("返礼記録の一括削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordIds,
+			},
+			"返礼記録の一括削除エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/pagination.ts
+++ b/src/app/_actions/return-records/pagination.ts
@@ -7,6 +7,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import type { ReturnEntryRecordWithKoudenEntry } from "@/types/return-records/return-records";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳IDに紐づく返礼情報をページング付きで取得する（無限スクロール用）
@@ -110,7 +111,16 @@ export async function getReturnEntriesByKoudenPaginated(
 			nextCursor,
 		};
 	} catch (error) {
-		console.error("返礼情報一覧の取得エラー（ページング）:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				limit,
+				cursor,
+				filters,
+			},
+			"返礼情報一覧の取得エラー（ページング）",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/performance-monitor.ts
+++ b/src/app/_actions/return-records/performance-monitor.ts
@@ -5,6 +5,8 @@
  * @module performance-monitor
  */
 
+import logger from "@/lib/logger";
+
 interface PerformanceMetrics {
 	operation: string;
 	startTime: number;
@@ -68,7 +70,13 @@ export class PerformanceMonitor {
 	 */
 	error(operation: string, error: Error | string): void {
 		const errorMsg = error instanceof Error ? error.message : error;
-		console.error(`❌ エラー: ${operation} - ${errorMsg}`);
+		logger.error(
+			{
+				operation,
+				error: errorMsg,
+			},
+			`❌ エラー: ${operation}`,
+		);
 
 		const metric = this.metrics.find((m) => m.operation.includes(operation));
 		if (metric) {

--- a/src/app/_actions/return-records/return-items.ts
+++ b/src/app/_actions/return-records/return-items.ts
@@ -12,6 +12,7 @@ import type {
 	CreateReturnItemInput,
 	UpdateReturnItemInput,
 } from "@/types/return-records/return-items";
+import logger from "@/lib/logger";
 
 /**
  * 返礼品マスター情報作成用の入力型（香典帳IDが必要）
@@ -94,7 +95,14 @@ export async function createReturnItem(input: CreateReturnItemWithKoudenInput): 
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${input.kouden_id}/settings/return-items`);
 	} catch (error) {
-		console.error("[Server] Error in createReturnItem:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId: input.kouden_id,
+				input,
+			},
+			"[Server] Error in createReturnItem",
+		);
 		// エラーメッセージを適切に変換
 		if (error instanceof Error) {
 			throw new Error(error.message);
@@ -143,7 +151,13 @@ export async function getReturnItem(id: string): Promise<ReturnItem | null> {
 
 		return data as ReturnItem;
 	} catch (error) {
-		console.error("返礼品マスター情報の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"返礼品マスター情報の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -191,7 +205,14 @@ export async function updateReturnItem(
 
 		return data as ReturnItem;
 	} catch (error) {
-		console.error("返礼品マスター情報の更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				koudenId: kouden_id,
+			},
+			"返礼品マスター情報の更新エラー",
+		);
 		throw error;
 	}
 }
@@ -225,7 +246,14 @@ export async function deleteReturnItem(id: string, koudenId: string): Promise<vo
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("返礼品情報の削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				koudenId,
+			},
+			"返礼品情報の削除エラー",
+		);
 		throw error;
 	}
 }
@@ -260,7 +288,15 @@ export async function uploadReturnItemImage(imageBlob: Blob, koudenId: string): 
 			});
 
 		if (uploadError) {
-			console.error("[ERROR] Failed to upload return item image:", uploadError);
+			logger.error(
+				{
+					error: uploadError.message,
+					koudenId,
+					userId: user.id,
+					fileName,
+				},
+				"Failed to upload return item image",
+			);
 			throw new Error("画像のアップロードに失敗しました");
 		}
 
@@ -269,7 +305,13 @@ export async function uploadReturnItemImage(imageBlob: Blob, koudenId: string): 
 
 		return publicUrl.publicUrl;
 	} catch (error) {
-		console.error("[ERROR] Upload return item image failed:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Upload return item image failed",
+		);
 		throw error instanceof Error ? error : new Error("画像のアップロードに失敗しました");
 	}
 }
@@ -303,11 +345,24 @@ export async function deleteReturnItemImage(imageUrl: string): Promise<void> {
 		const { error } = await supabase.storage.from("return-items").remove([filePath]);
 
 		if (error) {
-			console.error("[ERROR] Failed to delete return item image:", error);
+			logger.error(
+				{
+					error: error.message,
+					imageUrl,
+					filePath,
+				},
+				"Failed to delete return item image",
+			);
 			// 削除エラーは致命的ではないのでログのみ
 		}
 	} catch (error) {
-		console.error("[ERROR] Delete return item image failed:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				imageUrl,
+			},
+			"Delete return item image failed",
+		);
 		// 削除エラーは致命的ではないのでログのみ
 	}
 }

--- a/src/app/_actions/return-records/return-method-types.ts
+++ b/src/app/_actions/return-records/return-method-types.ts
@@ -12,6 +12,7 @@ import type {
 	CreateReturnMethodTypeInput,
 	UpdateReturnMethodTypeInput,
 } from "@/types/return-records/return-method-types";
+import logger from "@/lib/logger";
 
 /**
  * 返礼方法種別を作成する
@@ -49,7 +50,13 @@ export async function createReturnMethodType(
 
 		return data as ReturnMethodType;
 	} catch (error) {
-		console.error("返礼方法種別の作成エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				input,
+			},
+			"返礼方法種別の作成エラー",
+		);
 		throw error;
 	}
 }
@@ -73,7 +80,12 @@ export async function getReturnMethodTypes(): Promise<ReturnMethodType[]> {
 
 		return data as ReturnMethodType[];
 	} catch (error) {
-		console.error("返礼方法種別一覧の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"返礼方法種別一覧の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -99,7 +111,13 @@ export async function getReturnMethodType(id: string): Promise<ReturnMethodType 
 
 		return data as ReturnMethodType | null;
 	} catch (error) {
-		console.error("返礼方法種別の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"返礼方法種別の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -135,7 +153,13 @@ export async function updateReturnMethodType(
 
 		return data as ReturnMethodType;
 	} catch (error) {
-		console.error("返礼方法種別の更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id: input.id,
+			},
+			"返礼方法種別の更新エラー",
+		);
 		throw error;
 	}
 }
@@ -157,7 +181,13 @@ export async function deleteReturnMethodType(id: string): Promise<void> {
 
 		revalidatePath("/settings/return-method-types");
 	} catch (error) {
-		console.error("返礼方法種別の削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"返礼方法種別の削除エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/return-record-items.ts
+++ b/src/app/_actions/return-records/return-record-items.ts
@@ -12,6 +12,7 @@ import type {
 	CreateReturnRecordItemInput,
 	UpdateReturnRecordItemInput,
 } from "@/types/return-records/return-record-items";
+import logger from "@/lib/logger";
 
 /**
  * 返礼品詳細情報を作成する
@@ -61,7 +62,14 @@ export async function createReturnRecordItem(
 
 		return data as ReturnRecordItem;
 	} catch (error) {
-		console.error("返礼品詳細情報の作成エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId: input.return_record_id,
+				koudenId,
+			},
+			"返礼品詳細情報の作成エラー",
+		);
 		throw error;
 	}
 }
@@ -88,7 +96,13 @@ export async function getReturnRecordItems(returnRecordId: string): Promise<Retu
 
 		return data as ReturnRecordItem[];
 	} catch (error) {
-		console.error("返礼品詳細情報一覧の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId,
+			},
+			"返礼品詳細情報一覧の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -115,7 +129,13 @@ export async function getReturnRecordItem(id: string): Promise<ReturnRecordItem 
 
 		return data as ReturnRecordItem | null;
 	} catch (error) {
-		console.error("返礼品詳細情報の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"返礼品詳細情報の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -174,7 +194,14 @@ export async function updateReturnRecordItem(
 
 		return data as ReturnRecordItem;
 	} catch (error) {
-		console.error("返礼品詳細情報の更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id: input.id,
+				koudenId,
+			},
+			"返礼品詳細情報の更新エラー",
+		);
 		throw error;
 	}
 }
@@ -217,7 +244,14 @@ export async function deleteReturnRecordItem(id: string, koudenId: string): Prom
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("返礼品詳細情報の削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				koudenId,
+			},
+			"返礼品詳細情報の削除エラー",
+		);
 		throw error;
 	}
 }
@@ -253,7 +287,13 @@ async function updateReturnRecordTotalAmount(returnRecordId: string): Promise<vo
 		//     throw updateError;
 		// }
 	} catch (error) {
-		console.error("返礼情報の合計金額更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId,
+			},
+			"返礼情報の合計金額更新エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/return-record-selected-methods.ts
+++ b/src/app/_actions/return-records/return-record-selected-methods.ts
@@ -12,6 +12,7 @@ import type {
 	CreateReturnRecordSelectedMethodInput,
 	UpdateReturnRecordSelectedMethodInput,
 } from "@/types/return-records/return-record-selected-methods";
+import logger from "@/lib/logger";
 
 /**
  * 返礼情報に返礼方法を追加する
@@ -50,7 +51,14 @@ export async function createReturnRecordSelectedMethod(
 		revalidatePath(`/koudens/${koudenId}`);
 		return data as ReturnRecordSelectedMethod;
 	} catch (error) {
-		console.error("返礼方法選択の作成エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId: input.return_record_id,
+				koudenId,
+			},
+			"返礼方法選択の作成エラー",
+		);
 		throw error;
 	}
 }
@@ -78,7 +86,13 @@ export async function getReturnRecordSelectedMethods(
 
 		return data as ReturnRecordSelectedMethod[];
 	} catch (error) {
-		console.error("返礼方法選択一覧の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId,
+			},
+			"返礼方法選択一覧の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -106,7 +120,13 @@ export async function getReturnRecordSelectedMethod(
 
 		return data as ReturnRecordSelectedMethod | null;
 	} catch (error) {
-		console.error("返礼方法選択の取得エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"返礼方法選択の取得エラー",
+		);
 		throw error;
 	}
 }
@@ -143,7 +163,14 @@ export async function updateReturnRecordSelectedMethod(
 		revalidatePath(`/koudens/${koudenId}`);
 		return data as ReturnRecordSelectedMethod;
 	} catch (error) {
-		console.error("返礼方法選択の更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id: input.id,
+				koudenId,
+			},
+			"返礼方法選択の更新エラー",
+		);
 		throw error;
 	}
 }
@@ -169,7 +196,14 @@ export async function deleteReturnRecordSelectedMethod(
 
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("返礼方法選択の削除エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				koudenId,
+			},
+			"返礼方法選択の削除エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/return-records/updates.ts
+++ b/src/app/_actions/return-records/updates.ts
@@ -12,6 +12,7 @@ import type {
 	ReturnStatus,
 	UpdateReturnEntryInput,
 } from "@/types/return-records/return-records";
+import logger from "@/lib/logger";
 
 /**
  * 返礼記録の更新可能フィールドの値の型定義
@@ -76,7 +77,14 @@ export async function updateReturnEntry(
 
 		return data as ReturnEntryRecord;
 	} catch (error) {
-		console.error("返礼情報の更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId: input.kouden_entry_id,
+				koudenId: input.kouden_id,
+			},
+			"返礼情報の更新エラー",
+		);
 		throw error;
 	}
 }
@@ -126,7 +134,15 @@ export async function updateReturnEntryStatus(
 
 		return data as ReturnEntryRecord;
 	} catch (error) {
-		console.error("返礼情報のステータス更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId,
+				status,
+				koudenId,
+			},
+			"返礼情報のステータス更新エラー",
+		);
 		throw error;
 	}
 }
@@ -205,7 +221,14 @@ export async function updateReturnRecordField(
 			revalidatePath(`/koudens/${recordData.kouden_entries.kouden_id}`);
 		}
 	} catch (error) {
-		console.error("返礼記録フィールドの更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				returnRecordId,
+				fieldName,
+			},
+			"返礼記録フィールドの更新エラー",
+		);
 		throw error;
 	}
 }
@@ -284,7 +307,14 @@ export async function updateReturnRecordFieldByKoudenEntryId(
 			revalidatePath(`/koudens/${recordData.kouden_entries.kouden_id}`);
 		}
 	} catch (error) {
-		console.error("返礼記録フィールドの更新エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenEntryId,
+				fieldName,
+			},
+			"返礼記録フィールドの更新エラー",
+		);
 		throw error;
 	}
 }

--- a/src/app/_actions/roles.ts
+++ b/src/app/_actions/roles.ts
@@ -6,6 +6,7 @@ import { cache } from "react";
 import { KoudenError, withErrorHandling } from "@/lib/errors";
 import { isKoudenOwner } from "./permissions";
 import type { KoudenRole } from "@/types/role";
+import logger from "@/lib/logger";
 
 /**
  * 香典帳のロールを取得（キャッシュ対応）
@@ -23,7 +24,14 @@ export const getKoudenRoles = cache(async (koudenId: string): Promise<KoudenRole
 			.order("name");
 
 		if (error) {
-			console.error("[ERROR] Error fetching roles:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+				},
+				"Error fetching roles",
+			);
 			throw new KoudenError("ロール一覧の取得に失敗しました", "FETCH_ROLES_ERROR");
 		}
 
@@ -57,7 +65,14 @@ export const getKoudenRolesForAdmin = cache(async (koudenId: string): Promise<Ko
 			.order("name");
 
 		if (error) {
-			console.error("[ERROR] Error fetching roles for admin:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+				},
+				"Error fetching roles for admin",
+			);
 			throw new KoudenError("ロール情報の取得に失敗しました", "FETCH_ROLES_ERROR");
 		}
 
@@ -100,7 +115,16 @@ export async function updateMemberRole(koudenId: string, userId: string, roleId:
 		});
 
 		if (error) {
-			console.error("[ERROR] Failed to update member role:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+					userId,
+					roleId,
+				},
+				"Failed to update member role",
+			);
 			throw new KoudenError("ロールの更新に失敗しました", "UPDATE_ROLE_ERROR");
 		}
 
@@ -143,7 +167,15 @@ export async function removeMember(koudenId: string, userId: string) {
 		});
 
 		if (error) {
-			console.error("[ERROR] Failed to remove member:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+					userId,
+				},
+				"Failed to remove member",
+			);
 			throw new KoudenError("メンバーの削除に失敗しました", "REMOVE_MEMBER_ERROR");
 		}
 
@@ -202,7 +234,15 @@ export async function leaveMember(koudenId: string) {
 		});
 
 		if (error) {
-			console.error("[ERROR] Failed to leave member:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					koudenId,
+					userId: currentUser.id,
+				},
+				"Failed to leave member",
+			);
 			throw new KoudenError("香典帳からの退出に失敗しました", "LEAVE_MEMBER_ERROR");
 		}
 

--- a/src/app/_actions/settings.ts
+++ b/src/app/_actions/settings.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 interface UpdateSettingsParams {
 	guide_mode?: boolean;
@@ -24,7 +25,13 @@ export async function getUserSettings(userId: string) {
 
 		return { settings, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+			},
+			"Error getting user settings",
+		);
 		return {
 			settings: null,
 			error: "設定の取得に失敗しました",
@@ -53,7 +60,14 @@ export async function updateUserSettings(userId: string, params: UpdateSettingsP
 		revalidatePath("/settings");
 		return { settings, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				userId,
+				params,
+			},
+			"Error updating user settings",
+		);
 		return {
 			settings: null,
 			error: "設定の更新に失敗しました",
@@ -74,7 +88,12 @@ export async function getGuideVisibility(): Promise<boolean> {
 		} = await supabase.auth.getUser();
 
 		if (userError || !user) {
-			console.error("getGuideVisibility: ユーザー情報の取得に失敗:", userError);
+			logger.error(
+				{
+					error: userError?.message,
+				},
+				"getGuideVisibility: ユーザー情報の取得に失敗",
+			);
 			return false;
 		}
 
@@ -85,14 +104,26 @@ export async function getGuideVisibility(): Promise<boolean> {
 			.single();
 
 		if (error) {
-			console.error("getGuideVisibility: 設定の取得に失敗:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					userId: user.id,
+				},
+				"getGuideVisibility: 設定の取得に失敗",
+			);
 			return true;
 		}
 
 		const guideMode = data?.guide_mode ?? true;
 		return guideMode;
 	} catch (error) {
-		console.error("getGuideVisibility: 予期せぬエラーが発生:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"getGuideVisibility: 予期せぬエラーが発生",
+		);
 		return true;
 	}
 }
@@ -127,7 +158,13 @@ export async function updateGuideVisibility(show: boolean) {
 		revalidatePath("/koudens");
 		return { success: true, error: null };
 	} catch (error) {
-		console.error("Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				show,
+			},
+			"Error updating guide visibility",
+		);
 		return {
 			success: false,
 			error: "設定の更新に失敗しました",

--- a/src/app/_actions/telegrams.ts
+++ b/src/app/_actions/telegrams.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/types/telegrams";
 import { toCamelCase, toSnakeCase } from "@/store/telegrams";
 import type { EntryResponse, AttendanceType } from "@/types/entries";
+import logger from "@/lib/logger";
 
 // 弔電の取得（単一）
 export async function getTelegram(id: string) {
@@ -40,7 +41,13 @@ export async function getTelegrams(koudenId: string): Promise<Telegram[]> {
 		if (error) throw error;
 		return (data as TelegramRow[]).map(toCamelCase);
 	} catch (error) {
-		console.error("Failed to fetch telegrams:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+			},
+			"Failed to fetch telegrams",
+		);
 		throw new Error("弔電の取得に失敗しました");
 	}
 }
@@ -74,7 +81,13 @@ export async function createTelegram(
 		revalidatePath("/koudens/[id]", "page");
 		return toCamelCase(data as TelegramRow);
 	} catch (error) {
-		console.error("Failed to create telegram:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId: input.koudenId,
+			},
+			"Failed to create telegram",
+		);
 		throw new Error("弔電の作成に失敗しました");
 	}
 }
@@ -96,7 +109,13 @@ export async function updateTelegram(id: string, input: UpdateTelegramInput): Pr
 		revalidatePath("/koudens/[id]", "page");
 		return toCamelCase(data as TelegramRow);
 	} catch (error) {
-		console.error("Failed to update telegram:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+			},
+			"Failed to update telegram",
+		);
 		throw new Error("弔電の更新に失敗しました");
 	}
 }
@@ -112,7 +131,14 @@ export async function deleteTelegram(id: string, koudenId: string): Promise<void
 		if (error) throw error;
 		revalidatePath(`/koudens/${koudenId}`);
 	} catch (error) {
-		console.error("Failed to delete telegram:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				koudenId,
+			},
+			"Failed to delete telegram",
+		);
 		throw new Error("弔電の削除に失敗しました");
 	}
 }
@@ -173,18 +199,22 @@ export async function updateTelegramField(
 			.single();
 
 		if (error) {
-			console.error("[ERROR] Database update failed:", {
-				error,
-				code: error.code,
-				details: error.details,
-				hint: error.hint,
-				message: error.message,
-			});
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+					details: error.details,
+					hint: error.hint,
+					id,
+					field,
+				},
+				"Database update failed",
+			);
 			throw new Error(`${field}の更新に失敗しました`);
 		}
 
 		if (!updatedData) {
-			console.error("[ERROR] No data returned after update");
+			logger.error({ id, field }, "No data returned after update");
 			throw new Error(`${field}の更新に失敗しました`);
 		}
 
@@ -196,12 +226,15 @@ export async function updateTelegramField(
 
 		return camelCaseResult;
 	} catch (error) {
-		console.error("[ERROR] Failed to update telegram field:", {
-			error,
-			id,
-			field,
-			value,
-		});
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				id,
+				field,
+				value,
+			},
+			"Failed to update telegram field",
+		);
 		throw new Error(`${field}の更新に失敗しました`);
 	}
 }

--- a/src/app/_actions/user-surveys.ts
+++ b/src/app/_actions/user-surveys.ts
@@ -8,6 +8,7 @@ import {
 	type SurveyTrigger,
 } from "@/schemas/user-surveys";
 import { revalidatePath } from "next/cache";
+import logger from "@/lib/logger";
 
 /**
  * ユーザーアンケート回答を作成
@@ -39,7 +40,14 @@ export async function createUserSurvey(formData: UserSurveyFormInput, trigger: S
 			.single();
 
 		if (checkError && checkError.code !== "PGRST116") {
-			console.error("既存アンケート確認エラー:", checkError);
+			logger.error(
+				{
+					error: checkError.message,
+					code: checkError.code,
+					userId: user.id,
+				},
+				"既存アンケート確認エラー",
+			);
 			return {
 				success: false,
 				error: "アンケート状況の確認に失敗しました。時間を置いてお試しください。",
@@ -86,7 +94,15 @@ export async function createUserSurvey(formData: UserSurveyFormInput, trigger: S
 			.single();
 
 		if (insertError) {
-			console.error("アンケート保存エラー:", insertError);
+			logger.error(
+				{
+					error: insertError.message,
+					code: insertError.code,
+					userId: user.id,
+					trigger,
+				},
+				"アンケート保存エラー",
+			);
 			return {
 				success: false,
 				error: "アンケートの保存に失敗しました。時間を置いてお試しください。",
@@ -104,7 +120,13 @@ export async function createUserSurvey(formData: UserSurveyFormInput, trigger: S
 				"アンケートへのご回答、ありがとうございました。いただいたご意見は今後のサービス改善に活用させていただきます。",
 		};
 	} catch (error) {
-		console.error("アンケート作成エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				trigger,
+			},
+			"アンケート作成エラー",
+		);
 
 		// Zodバリデーションエラーの場合
 		if (error instanceof Error && error.name === "ZodError") {
@@ -165,7 +187,15 @@ export async function getUserSurveyStatus(trigger?: SurveyTrigger): Promise<Surv
 			.single();
 
 		if (fetchError && fetchError.code !== "PGRST116") {
-			console.error("アンケート状況取得エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					userId: user.id,
+					trigger,
+				},
+				"アンケート状況取得エラー",
+			);
 			return { hasAnswered: false };
 		}
 
@@ -202,7 +232,13 @@ export async function getUserSurveyStatus(trigger?: SurveyTrigger): Promise<Surv
 
 		return { hasAnswered: false };
 	} catch (error) {
-		console.error("アンケート状況確認エラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				trigger,
+			},
+			"アンケート状況確認エラー",
+		);
 		return { hasAnswered: false };
 	}
 }
@@ -243,13 +279,25 @@ export async function checkOneWeekOwnershipSurvey(): Promise<boolean> {
 			.limit(1);
 
 		if (fetchError) {
-			console.error("香典帳確認エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					userId: user.id,
+				},
+				"香典帳確認エラー",
+			);
 			return false;
 		}
 
 		return koudens && koudens.length > 0;
 	} catch (error) {
-		console.error("1週間経過チェックエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"1週間経過チェックエラー",
+		);
 		return false;
 	}
 }
@@ -295,7 +343,14 @@ export async function getAdminSurveyAnalytics() {
 			.order("created_at", { ascending: false });
 
 		if (fetchError) {
-			console.error("アンケートデータ取得エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					userId: user.id,
+				},
+				"アンケートデータ取得エラー",
+			);
 			return {
 				success: false,
 				error: "データ取得に失敗しました",
@@ -326,7 +381,12 @@ export async function getAdminSurveyAnalytics() {
 			},
 		};
 	} catch (error) {
-		console.error("管理者アナリティクスエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"管理者アナリティクスエラー",
+		);
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました",
@@ -365,7 +425,15 @@ export async function createSurveySkip(trigger: SurveyTrigger) {
 			.single();
 
 		if (checkError && checkError.code !== "PGRST116") {
-			console.error("既存スキップ記録確認エラー:", checkError);
+			logger.error(
+				{
+					error: checkError.message,
+					code: checkError.code,
+					userId: user.id,
+					trigger,
+				},
+				"既存スキップ記録確認エラー",
+			);
 			return {
 				success: false,
 				error: "スキップ記録の確認に失敗しました。時間を置いてお試しください。",
@@ -390,7 +458,15 @@ export async function createSurveySkip(trigger: SurveyTrigger) {
 			.single();
 
 		if (insertError) {
-			console.error("スキップ記録作成エラー:", insertError);
+			logger.error(
+				{
+					error: insertError.message,
+					code: insertError.code,
+					userId: user.id,
+					trigger,
+				},
+				"スキップ記録作成エラー",
+			);
 			return {
 				success: false,
 				error: "スキップ記録の作成に失敗しました。時間を置いてお試しください。",
@@ -403,7 +479,13 @@ export async function createSurveySkip(trigger: SurveyTrigger) {
 			message: "アンケートをスキップしました。1日後に再度表示される場合があります。",
 		};
 	} catch (error) {
-		console.error("アンケートスキップエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				trigger,
+			},
+			"アンケートスキップエラー",
+		);
 		return {
 			success: false,
 			error: "予期しないエラーが発生しました。時間を置いてお試しください。",
@@ -439,13 +521,27 @@ export async function checkSurveySkipStatus(trigger: SurveyTrigger): Promise<boo
 			.single();
 
 		if (fetchError && fetchError.code !== "PGRST116") {
-			console.error("スキップ状況確認エラー:", fetchError);
+			logger.error(
+				{
+					error: fetchError.message,
+					code: fetchError.code,
+					userId: user.id,
+					trigger,
+				},
+				"スキップ状況確認エラー",
+			);
 			return false;
 		}
 
 		return !!skipRecord;
 	} catch (error) {
-		console.error("スキップ状況チェックエラー:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				trigger,
+			},
+			"スキップ状況チェックエラー",
+		);
 		return false;
 	}
 }

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getGeminiModel, isGeminiConfigured, GEMINI_CONFIGS } from "@/lib/gemini";
 import { isAbstractInput, generateClarifyingQuestions } from "@/utils/blog-ai-agent";
+import logger from "@/lib/logger";
 
 interface SuggestionOption {
 	id: string;
@@ -418,8 +419,13 @@ export async function POST(request: NextRequest) {
 				aiResponse.searchResults = searchResults;
 			}
 		} catch (parseError) {
-			console.error("Failed to parse AI response as JSON:", parseError);
-			console.error("Raw response:", cleanedResponse);
+			logger.error(
+				{
+					error: parseError instanceof Error ? parseError.message : String(parseError),
+					rawResponse: cleanedResponse.substring(0, 500), // 最初の500文字のみ
+				},
+				"Failed to parse AI response as JSON",
+			);
 
 			// JSONパースに失敗した場合は、デフォルトの選択肢形式で返す
 			aiResponse = {
@@ -480,15 +486,14 @@ export async function POST(request: NextRequest) {
 
 		return NextResponse.json(aiResponse);
 	} catch (error) {
-		console.error("AI generation error:", error);
-
-		// エラーの詳細をログに記録
-		if (error instanceof Error) {
-			console.error("Error details:", {
-				message: error.message,
-				stack: error.stack,
-			});
-		}
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				errorStack: error instanceof Error ? error.stack : undefined,
+				model,
+			},
+			"AI generation error",
+		);
 
 		return NextResponse.json(
 			{

--- a/src/app/api/ai/translate/route.ts
+++ b/src/app/api/ai/translate/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getGeminiModel, isGeminiConfigured, GEMINI_CONFIGS } from "@/lib/gemini";
+import logger from "@/lib/logger";
 
 interface TranslateRequestBody {
 	text: string;
@@ -40,7 +41,13 @@ export async function POST(request: NextRequest) {
 			targetLanguage,
 		});
 	} catch (error) {
-		console.error("Translation error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				targetLanguage,
+			},
+			"Translation error",
+		);
 
 		return NextResponse.json(
 			{

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getWeeklyAvailability } from "@/app/_actions/calendar";
+import logger from "@/lib/logger";
 
 export async function GET(request: Request) {
 	const { searchParams } = new URL(request.url);
@@ -11,7 +12,13 @@ export async function GET(request: Request) {
 		const availability = await getWeeklyAvailability(weekStart);
 		return NextResponse.json(availability);
 	} catch (err: unknown) {
-		console.error("Error fetching availability", err);
+		logger.error(
+			{
+				error: err instanceof Error ? err.message : String(err),
+				weekStart,
+			},
+			"Error fetching availability",
+		);
 		const message = err instanceof Error ? err.message : String(err);
 		return NextResponse.json({ error: message }, { status: 500 });
 	}

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Resend } from "resend";
 import { buildReminderEmail } from "@/utils/emailTemplates/reminder";
+import logger from "@/lib/logger";
 
 const apiKey = process.env.RESEND_API_KEY;
 if (!apiKey) {
@@ -20,7 +21,13 @@ export async function GET() {
 		.eq("code", "free")
 		.single();
 	if (planError || !freePlan) {
-		console.error("[send-reminders] planError:", planError);
+		logger.error(
+			{
+				error: planError?.message,
+				code: planError?.code,
+			},
+			"[send-reminders] planError",
+		);
 		return NextResponse.error();
 	}
 
@@ -44,7 +51,15 @@ export async function GET() {
 			.eq("plan_id", freePlan.id)
 			.eq("created_at::date", dateStr);
 		if (koudenError || !koudenList) {
-			console.error("[send-reminders] koudenError:", koudenError);
+			logger.error(
+				{
+					error: koudenError?.message,
+					code: koudenError?.code,
+					daysLeft,
+					dateStr,
+				},
+				"[send-reminders] koudenError",
+			);
 			continue;
 		}
 

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -3,6 +3,8 @@
  * フロントエンドからCSRFトークンを取得するためのエンドポイント
  */
 
+import logger from "@/lib/logger";
+
 const CSRF_SECRET = process.env.CSRF_SECRET || "default-secret-change-in-production";
 
 /**
@@ -64,7 +66,12 @@ export async function GET() {
 
 		return response;
 	} catch (error) {
-		console.error("Error generating CSRF token:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error generating CSRF token",
+		);
 		return new Response("Internal Server Error", { status: 500 });
 	}
 }

--- a/src/app/api/debug/organization-access/route.ts
+++ b/src/app/api/debug/organization-access/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { debugUserOrganizationAccess } from "@/lib/access";
+import logger from "@/lib/logger";
 
 /**
  * Debug endpoint to check user's organization access
@@ -32,7 +33,12 @@ export async function GET() {
 			debugInfo,
 		});
 	} catch (error) {
-		console.error("[Debug API] Error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Debug API Error",
+		);
 		return NextResponse.json({ error: "Internal server error", details: error }, { status: 500 });
 	}
 }

--- a/src/app/api/koudens/[id]/entries/route.ts
+++ b/src/app/api/koudens/[id]/entries/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getEntries } from "@/app/_actions/entries";
+import logger from "@/lib/logger";
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
 	const { id: koudenId } = await params;
@@ -34,7 +35,15 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
 
 		return NextResponse.json({ entries, count });
 	} catch (error) {
-		console.error("[API] GET /api/koudens/[id]/entries error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				koudenId,
+				page,
+				pageSize,
+			},
+			"[API] GET /api/koudens/[id]/entries error",
+		);
 		return NextResponse.json({ error: "Failed to fetch entries" }, { status: 500 });
 	}
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { exportReceiptToPdf } from "@/app/_actions/exportReceipt";
+import logger from "@/lib/logger";
 
 export const runtime = "nodejs";
 
@@ -41,17 +42,17 @@ export async function POST(req: Request) {
 		const metadata = session.metadata as Record<string, string>;
 		const koudenId = metadata.koudenId;
 		if (!koudenId) {
-			console.error("Missing metadata.koudenId");
+			logger.error({ metadata }, "Missing metadata.koudenId");
 			return new NextResponse("Invalid webhook metadata", { status: 400 });
 		}
 		const planCode = metadata.planCode;
 		if (!planCode) {
-			console.error("Missing metadata.planCode");
+			logger.error({ metadata }, "Missing metadata.planCode");
 			return new NextResponse("Invalid webhook metadata", { status: 400 });
 		}
 		const userId = metadata.userId;
 		if (!userId) {
-			console.error("Missing metadata.userId");
+			logger.error({ metadata }, "Missing metadata.userId");
 			return new NextResponse("Invalid webhook metadata", { status: 400 });
 		}
 
@@ -67,7 +68,7 @@ export async function POST(req: Request) {
 		if (!existingKouden) {
 			const planRes = await supabase.from("plans").select("id").eq("code", planCode).single();
 			if (planRes.error || !planRes.data) {
-				console.error("Plan not found for code:", planCode);
+				logger.error({ planCode, error: planRes.error }, "Plan not found for code");
 				return new NextResponse("Plan not found", { status: 400 });
 			}
 			const planId = planRes.data.id;
@@ -79,19 +80,29 @@ export async function POST(req: Request) {
 				created_by: userId,
 				plan_id: planId,
 			});
-			if (koudenError) console.error("Error creating kouden:", koudenError);
+			if (koudenError) {
+				logger.error(
+					{
+						error: koudenError.message,
+						code: koudenError.code,
+						koudenId,
+						userId,
+					},
+					"Error creating kouden",
+				);
+			}
 		}
 
 		// Upsert purchase history
 		const planRes2 = await supabase.from("plans").select("id").eq("code", planCode).single();
 		if (planRes2.error || !planRes2.data) {
-			console.error("Plan not found for code:", planCode);
+			logger.error({ planCode, error: planRes2.error }, "Plan not found for code");
 			return new NextResponse("Plan not found", { status: 400 });
 		}
 		const planId2 = planRes2.data.id;
 		const amountTotal = session.amount_total;
 		if (amountTotal == null) {
-			console.error("Session amount_total is missing");
+			logger.error({ sessionId: session.id }, "Session amount_total is missing");
 			return new NextResponse("Invalid session data", { status: 400 });
 		}
 		const { data: purchaseRow, error: purchaseError } = await supabase
@@ -107,12 +118,26 @@ export async function POST(req: Request) {
 			.select("id")
 			.single();
 		if (purchaseError || !purchaseRow) {
-			console.error("Error inserting purchase:", purchaseError);
+			logger.error(
+				{
+					error: purchaseError?.message,
+					code: purchaseError?.code,
+					koudenId,
+					userId,
+				},
+				"Error inserting purchase",
+			);
 		} else {
 			try {
 				await exportReceiptToPdf(purchaseRow.id);
 			} catch (err) {
-				console.error("Receipt export error:", err);
+				logger.error(
+					{
+						error: err instanceof Error ? err.message : String(err),
+						purchaseId: purchaseRow.id,
+					},
+					"Receipt export error",
+				);
 			}
 		}
 
@@ -121,7 +146,17 @@ export async function POST(req: Request) {
 			.from("koudens")
 			.update({ plan_id: planId2, status: "active" })
 			.eq("id", koudenId);
-		if (updateError) console.error("Error updating kouden plan_id and status:", updateError);
+		if (updateError) {
+			logger.error(
+				{
+					error: updateError.message,
+					code: updateError.code,
+					koudenId,
+					planId: planId2,
+				},
+				"Error updating kouden plan_id and status",
+			);
+		}
 	}
 
 	return NextResponse.json({ received: true });

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import logger from "@/lib/logger";
 
 /**
  * Debug helper: Get detailed organization and membership info for a user
@@ -41,7 +42,13 @@ export async function debugUserOrganizationAccess(userId: string) {
 			},
 		};
 	} catch (error) {
-		console.error("[debugUserOrganizationAccess] Error:", error);
+		logger.error(
+			{
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"[debugUserOrganizationAccess] Error",
+		);
 		return { error };
 	}
 }
@@ -61,12 +68,18 @@ export async function requireOrganizationAccess(type: "funeral_company" | "gift_
 		} = await supabase.auth.getUser();
 
 		if (authError) {
-			console.error("[requireOrganizationAccess] Auth error:", authError);
+			logger.error(
+				{
+					error: authError.message,
+					type,
+				},
+				"[requireOrganizationAccess] Auth error",
+			);
 			redirect("/login");
 		}
 
 		if (!user) {
-			console.warn("[requireOrganizationAccess] No user found");
+			logger.warn({ type }, "[requireOrganizationAccess] No user found");
 			redirect("/login");
 		}
 
@@ -79,23 +92,51 @@ export async function requireOrganizationAccess(type: "funeral_company" | "gift_
 			.single();
 
 		if (typeError) {
-			console.error("[requireOrganizationAccess] Error fetching organization type:", typeError);
-			console.error("Type query details:", { type, schema: "common", table: "organization_types" });
+			logger.error(
+				{
+					error: typeError.message,
+					code: typeError.code,
+					type,
+					schema: "common",
+					table: "organization_types",
+				},
+				"[requireOrganizationAccess] Error fetching organization type",
+			);
 
 			// Get debug info when type lookup fails
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Debug info",
+			);
 
 			redirect("/unauthorized");
 		}
 
 		const typeId = typeRecord?.id;
 		if (!typeId) {
-			console.error(`[requireOrganizationAccess] Organization type '${type}' not found`);
+			logger.error(
+				{
+					type,
+					userId: user.id,
+				},
+				`[requireOrganizationAccess] Organization type '${type}' not found`,
+			);
 
 			// Get debug info when type not found
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Debug info",
+			);
 
 			redirect("/unauthorized");
 		}
@@ -109,11 +150,27 @@ export async function requireOrganizationAccess(type: "funeral_company" | "gift_
 			.eq("status", "active");
 
 		if (orgsError) {
-			console.error("[requireOrganizationAccess] Error fetching organizations:", orgsError);
+			logger.error(
+				{
+					error: orgsError.message,
+					code: orgsError.code,
+					type,
+					typeId,
+					userId: user.id,
+				},
+				"[requireOrganizationAccess] Error fetching organizations",
+			);
 
 			// Get debug info when org lookup fails
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Debug info",
+			);
 
 			redirect("/unauthorized");
 		}
@@ -121,11 +178,25 @@ export async function requireOrganizationAccess(type: "funeral_company" | "gift_
 		const orgIds = orgs?.map((o) => o.id) ?? [];
 
 		if (orgIds.length === 0) {
-			console.warn(`[requireOrganizationAccess] No organizations found for type '${type}'`);
+			logger.warn(
+				{
+					type,
+					typeId,
+					userId: user.id,
+				},
+				`[requireOrganizationAccess] No organizations found for type '${type}'`,
+			);
 
 			// Get debug info when no orgs found
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Debug info",
+			);
 
 			redirect("/unauthorized");
 		}
@@ -139,28 +210,62 @@ export async function requireOrganizationAccess(type: "funeral_company" | "gift_
 			.eq("user_id", user.id);
 
 		if (membershipError) {
-			console.error("[requireOrganizationAccess] Error fetching memberships:", membershipError);
+			logger.error(
+				{
+					error: membershipError.message,
+					code: membershipError.code,
+					type,
+					userId: user.id,
+					orgIds,
+				},
+				"[requireOrganizationAccess] Error fetching memberships",
+			);
 
 			// Get debug info when membership lookup fails
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Debug info",
+			);
 
 			redirect("/unauthorized");
 		}
 
 		if (!memberships || memberships.length === 0) {
-			console.warn(
-				`[requireOrganizationAccess] User ${user.id} has no membership in organizations of type '${type}'`,
+			logger.warn(
+				{
+					userId: user.id,
+					type,
+					orgIds,
+				},
+				`[requireOrganizationAccess] User has no membership in organizations of type '${type}'`,
 			);
 
 			// Get comprehensive debug info when access denied
 			const debugInfo = await debugUserOrganizationAccess(user.id);
-			console.error("[requireOrganizationAccess] Comprehensive debug info:", debugInfo);
+			logger.error(
+				{
+					userId: user.id,
+					type,
+					debugInfo,
+				},
+				"[requireOrganizationAccess] Comprehensive debug info",
+			);
 
 			redirect("/unauthorized");
 		}
 	} catch (error) {
-		console.error("[requireOrganizationAccess] Unexpected error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				type,
+			},
+			"[requireOrganizationAccess] Unexpected error",
+		);
 		redirect("/unauthorized");
 	}
 }

--- a/src/lib/changelogs.ts
+++ b/src/lib/changelogs.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
+import logger from "@/lib/logger";
 
 /**
  * 更新履歴のメタデータ
@@ -82,7 +83,12 @@ export async function getAllChangelogs(): Promise<ChangelogMeta[]> {
 			return compareVersions(a.version, b.version);
 		});
 	} catch (error) {
-		console.error("Error loading changelogs:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error loading changelogs",
+		);
 		return [];
 	}
 }
@@ -105,7 +111,13 @@ export async function getChangelogBySlug(slug: string) {
 			content,
 		};
 	} catch (error) {
-		console.error("Error loading changelog:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				slug,
+			},
+			"Error loading changelog",
+		);
 		throw new Error(`Changelog not found: ${slug}`);
 	}
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,5 @@
+import logger from "./logger";
+
 // カスタムエラークラスの定義
 export class KoudenError extends Error {
 	constructor(
@@ -18,7 +20,15 @@ export const withErrorHandling = async <T>(
 	try {
 		return await action();
 	} catch (error) {
-		console.error(`[ERROR] ${errorContext}:`, error);
+		logger.error(
+			{
+				errorContext,
+				error: error instanceof Error ? error.message : String(error),
+				errorStack: error instanceof Error ? error.stack : undefined,
+				errorCode: error instanceof KoudenError ? error.code : undefined,
+			},
+			`[ERROR] ${errorContext}`,
+		);
 		if (error instanceof KoudenError) {
 			throw error;
 		}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,153 @@
+/**
+ * ログ管理システム
+ * pinoを使用した構造化ログの実装
+ * サーバー側とクライアント側の両方に対応
+ */
+
+import pino from "pino";
+
+// ログレベルの型定義
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+// 環境変数からログレベルを取得（デフォルト: development=debug, production=info）
+function getLogLevel(): LogLevel {
+	const envLevel = process.env.LOG_LEVEL as LogLevel | undefined;
+	if (envLevel && ["debug", "info", "warn", "error"].includes(envLevel)) {
+		return envLevel;
+	}
+
+	// NODE_ENVに基づくデフォルト設定
+	if (process.env.NODE_ENV === "production") {
+		return "info";
+	}
+	return "debug";
+}
+
+// サーバー側ロガーの作成
+function createServerLogger(): pino.Logger {
+	const isDevelopment = process.env.NODE_ENV === "development";
+	const level = getLogLevel();
+
+	const logger = pino({
+		level,
+		transport: isDevelopment
+			? {
+					target: "pino-pretty",
+					options: {
+						colorize: true,
+						translateTime: "SYS:standard",
+						ignore: "pid,hostname",
+					},
+				}
+			: undefined,
+	});
+
+	return logger;
+}
+
+// ブラウザ環境用のロガーインターフェース
+interface BrowserLogger {
+	debug: (obj: Record<string, unknown>, msg?: string) => void;
+	info: (obj: Record<string, unknown>, msg?: string) => void;
+	warn: (obj: Record<string, unknown>, msg?: string) => void;
+	error: (obj: Record<string, unknown>, msg?: string) => void;
+}
+
+// ブラウザ環境用のロガー実装（console.logベース）
+function createBrowserLogger(): BrowserLogger {
+	const level = getLogLevel();
+	const levelPriority: Record<LogLevel, number> = {
+		debug: 0,
+		info: 1,
+		warn: 2,
+		error: 3,
+	};
+
+	const currentPriority = levelPriority[level];
+
+	const shouldLog = (targetLevel: LogLevel): boolean => {
+		return levelPriority[targetLevel] >= currentPriority;
+	};
+
+	return {
+		debug: (obj: Record<string, unknown>, msg?: string) => {
+			if (shouldLog("debug")) {
+				console.debug(msg || "", obj);
+			}
+		},
+		info: (obj: Record<string, unknown>, msg?: string) => {
+			if (shouldLog("info")) {
+				console.info(msg || "", obj);
+			}
+		},
+		warn: (obj: Record<string, unknown>, msg?: string) => {
+			if (shouldLog("warn")) {
+				console.warn(msg || "", obj);
+			}
+		},
+		error: (obj: Record<string, unknown>, msg?: string) => {
+			if (shouldLog("error")) {
+				console.error(msg || "", obj);
+			}
+		},
+	};
+}
+
+// 環境判定（サーバー側かブラウザ側か）
+const isServer = typeof window === "undefined";
+
+// ロガーインスタンス（シングルトンパターン）
+let loggerInstance: pino.Logger | BrowserLogger | null = null;
+
+/**
+ * ロガーインスタンスを取得
+ * サーバー側ではpino、ブラウザ側ではconsole.logベースのロガーを返す
+ */
+export function getLogger(): pino.Logger | BrowserLogger {
+	if (loggerInstance === null) {
+		if (isServer) {
+			loggerInstance = createServerLogger();
+		} else {
+			loggerInstance = createBrowserLogger();
+		}
+	}
+	return loggerInstance;
+}
+
+// デフォルトエクスポート（推奨）
+const logger = getLogger();
+
+export default logger;
+
+// 便利な関数エクスポート
+export const log = {
+	debug: (obj: Record<string, unknown>, msg?: string) => {
+		if (isServer) {
+			(logger as pino.Logger).debug(obj, msg);
+		} else {
+			(logger as BrowserLogger).debug(obj, msg);
+		}
+	},
+	info: (obj: Record<string, unknown>, msg?: string) => {
+		if (isServer) {
+			(logger as pino.Logger).info(obj, msg);
+		} else {
+			(logger as BrowserLogger).info(obj, msg);
+		}
+	},
+	warn: (obj: Record<string, unknown>, msg?: string) => {
+		if (isServer) {
+			(logger as pino.Logger).warn(obj, msg);
+		} else {
+			(logger as BrowserLogger).warn(obj, msg);
+		}
+	},
+	error: (obj: Record<string, unknown>, msg?: string) => {
+		if (isServer) {
+			(logger as pino.Logger).error(obj, msg);
+		} else {
+			(logger as BrowserLogger).error(obj, msg);
+		}
+	},
+};
+

--- a/src/lib/milestones.ts
+++ b/src/lib/milestones.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
+import logger from "@/lib/logger";
 
 /**
  * マイルストーンのメタデータ
@@ -55,7 +56,12 @@ export async function getAllMilestones(): Promise<MilestoneMeta[]> {
 			return dateA.getTime() - dateB.getTime();
 		});
 	} catch (error) {
-		console.error("Error loading milestones:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error loading milestones",
+		);
 		return [];
 	}
 }
@@ -78,7 +84,13 @@ export async function getMilestoneBySlug(slug: string) {
 			content,
 		};
 	} catch (error) {
-		console.error("Error loading milestone:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				slug,
+			},
+			"Error loading milestone",
+		);
 		throw new Error(`Milestone not found: ${slug}`);
 	}
 }

--- a/src/lib/security/admin-2fa-enforcement.ts
+++ b/src/lib/security/admin-2fa-enforcement.ts
@@ -7,6 +7,7 @@ import { redirect } from "next/navigation";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logSecurityEvent } from "./security-logger";
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 export interface TwoFactorEnforcementResult {
 	isEnforced: boolean;
@@ -30,7 +31,13 @@ async function isTwoFactorEnabledDirect(userId: string): Promise<boolean> {
 
 		return !error && data?.two_factor_enabled === true;
 	} catch (error) {
-		console.error("Failed to check 2FA status:", error);
+		logger.error(
+			{
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Failed to check 2FA status",
+		);
 		return false;
 	}
 }
@@ -87,7 +94,14 @@ export async function enforceTwoFactorAuth(
 
 		return { isEnforced: true };
 	} catch (error) {
-		console.error("2FA enforcement check failed:", error);
+		logger.error(
+			{
+				userId,
+				currentPath,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"2FA enforcement check failed",
+		);
 		// エラー時は安全側に倒して設定ページにリダイレクト
 		return {
 			isEnforced: false,

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -16,6 +16,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 const CSRF_SECRET = process.env.CSRF_SECRET || "default-secret-change-in-production";
 
@@ -87,7 +88,7 @@ export function checkCSRFToken(request: NextRequest): boolean {
 
 	// 開発環境では緩和（デバッグ用）
 	if (process.env.NODE_ENV === "development" && process.env.CSRF_DEBUG === "true") {
-		console.warn("CSRF protection is disabled in development mode");
+		logger.warn({}, "CSRF protection is disabled in development mode");
 		return true;
 	}
 
@@ -95,13 +96,25 @@ export function checkCSRFToken(request: NextRequest): boolean {
 	const csrfToken = request.headers.get("x-csrf-token") || request.cookies.get("csrf-token")?.value;
 
 	if (!csrfToken) {
-		console.warn("CSRF token is missing");
+		logger.warn(
+			{
+				pathname: request.nextUrl.pathname,
+				method: request.method,
+			},
+			"CSRF token is missing",
+		);
 		return false;
 	}
 
 	const isValid = verifyCSRFToken(csrfToken);
 	if (!isValid) {
-		console.warn("CSRF token validation failed");
+		logger.warn(
+			{
+				pathname: request.nextUrl.pathname,
+				method: request.method,
+			},
+			"CSRF token validation failed",
+		);
 	}
 
 	return isValid;

--- a/src/lib/security/file-upload-validation.ts
+++ b/src/lib/security/file-upload-validation.ts
@@ -6,6 +6,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { NextRequest } from "next/server";
 import { logFileUploadBlocked } from "./security-logger";
+import logger from "@/lib/logger";
 
 export interface FileValidationResult {
 	isValid: boolean;
@@ -99,7 +100,14 @@ export async function validateFileUpload(
 
 		return { isValid: true };
 	} catch (error) {
-		console.error("File validation error:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				fileName: file.name,
+				userId,
+			},
+			"File validation error",
+		);
 		return {
 			isValid: false,
 			error: "ファイル検証中にエラーが発生しました",
@@ -283,7 +291,13 @@ async function getFileUploadRestrictions(): Promise<FileUploadRestriction[]> {
 			.select("file_extension, is_allowed, max_file_size, description");
 
 		if (error) {
-			console.error("Failed to fetch file upload restrictions:", error);
+			logger.error(
+				{
+					error: error.message,
+					code: error.code,
+				},
+				"Failed to fetch file upload restrictions",
+			);
 			return restrictionsCache; // フォールバック：古いキャッシュを使用
 		}
 
@@ -297,7 +311,12 @@ async function getFileUploadRestrictions(): Promise<FileUploadRestriction[]> {
 
 		return restrictionsCache;
 	} catch (error) {
-		console.error("Error fetching file upload restrictions:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Error fetching file upload restrictions",
+		);
 		return restrictionsCache; // フォールバック
 	}
 }

--- a/src/lib/security/ip-restrictions.ts
+++ b/src/lib/security/ip-restrictions.ts
@@ -4,6 +4,7 @@
  */
 
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 // 許可されたIPアドレスのリスト（環境変数から取得）
 const ALLOWED_ADMIN_IPS = process.env.ALLOWED_ADMIN_IPS?.split(",").map((ip) => ip.trim()) || [];
@@ -23,20 +24,20 @@ export function isAllowedAdminIP(request: NextRequest): boolean {
 	const clientIP = getClientIP(request);
 
 	if (!clientIP) {
-		console.warn("Could not determine client IP address");
+		logger.warn({}, "Could not determine client IP address");
 		return false;
 	}
 
 	// 許可されたIPリストが設定されていない場合は拒否
 	if (ALLOWED_ADMIN_IPS.length === 0) {
-		console.error("ALLOWED_ADMIN_IPS environment variable not configured");
+		logger.error({}, "ALLOWED_ADMIN_IPS environment variable not configured");
 		return false;
 	}
 
 	const isAllowed = ALLOWED_ADMIN_IPS.includes(clientIP);
 
 	if (!isAllowed) {
-		console.warn(`Admin access denied for IP: ${clientIP}`);
+		logger.warn({ ipAddress: clientIP }, "Admin access denied for IP");
 	}
 
 	return isAllowed;
@@ -85,7 +86,7 @@ export function verifyBasicAuth(request: NextRequest): boolean {
 	const adminPassword = process.env.ADMIN_BASIC_PASSWORD;
 
 	if (!(adminUsername && adminPassword)) {
-		console.error("ADMIN_BASIC_USERNAME or ADMIN_BASIC_PASSWORD not configured");
+		logger.error({}, "ADMIN_BASIC_USERNAME or ADMIN_BASIC_PASSWORD not configured");
 		return false;
 	}
 

--- a/src/lib/security/login-attempts.ts
+++ b/src/lib/security/login-attempts.ts
@@ -5,6 +5,7 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 export interface LoginAttempt {
 	id: string;
@@ -33,7 +34,12 @@ export async function recordLoginAttempt(
 	const ipAddress = getClientIP(request);
 
 	if (!ipAddress) {
-		console.warn("Could not determine IP address for login attempt");
+		logger.warn(
+			{
+				userId,
+			},
+			"Could not determine IP address for login attempt",
+		);
 		return;
 	}
 

--- a/src/lib/security/rate-limiting.ts
+++ b/src/lib/security/rate-limiting.ts
@@ -4,6 +4,7 @@
  */
 
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 interface RateLimitConfig {
 	windowMs: number; // 時間窓（ミリ秒）
@@ -41,7 +42,12 @@ export async function rateLimit(
 	const clientIP = getClientIP(request);
 	if (!clientIP) {
 		// IPが取得できない場合は通す（ログに記録）
-		console.warn("Could not determine client IP for rate limiting");
+		logger.warn(
+			{
+				pathname: request.nextUrl.pathname,
+			},
+			"Could not determine client IP for rate limiting",
+		);
 		return { success: true };
 	}
 

--- a/src/lib/security/security-logger.ts
+++ b/src/lib/security/security-logger.ts
@@ -5,6 +5,7 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { NextRequest } from "next/server";
+import logger from "@/lib/logger";
 
 export type SecurityEventType =
 	| "admin_login_success"
@@ -66,19 +67,36 @@ export async function logSecurityEvent(
 
 		// 重要度が高い場合は即座にアラート（将来的にSlack/Discord通知等）
 		if (entry.severity === "critical" || entry.severity === "error") {
-			console.error(`[SECURITY ALERT] ${entry.eventType}:`, {
-				userId: entry.userId,
-				ipAddress,
-				details: entry.details,
-			});
+			logger.error(
+				{
+					eventType: entry.eventType,
+					userId: entry.userId,
+					ipAddress,
+					details: entry.details,
+					severity: entry.severity,
+				},
+				`[SECURITY ALERT] ${entry.eventType}`,
+			);
 
 			// 即座に管理者に通知する場合（実装例）
 			await notifyAdmins(entry, ipAddress);
 		}
 	} catch (error) {
-		console.error("Failed to log security event:", error);
+		logger.error(
+			{
+				error: error instanceof Error ? error.message : String(error),
+				eventType: entry.eventType,
+			},
+			"Failed to log security event",
+		);
 		// セキュリティログの記録失敗は致命的なので、フォールバック処理
-		console.error(`[SECURITY LOG FAILURE] ${entry.eventType}:`, entry);
+		logger.error(
+			{
+				eventType: entry.eventType,
+				entry,
+			},
+			`[SECURITY LOG FAILURE] ${entry.eventType}`,
+		);
 	}
 }
 
@@ -312,10 +330,15 @@ async function notifyAdmins(entry: SecurityLogEntry, ipAddress: string | null): 
 			});
 
 			if (!response.ok) {
-				console.error("Failed to send Slack notification");
+				logger.error({}, "Failed to send Slack notification");
 			}
 		} catch (error) {
-			console.error("Error sending Slack notification:", error);
+			logger.error(
+				{
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Error sending Slack notification",
+			);
 		}
 	}
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,7 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from "@/types/supabase";
+import logger from "@/lib/logger";
 
 export async function createClient() {
 	const cookieStore = await cookies();
@@ -24,7 +25,12 @@ export async function createClient() {
 						cookieStore.set({ name, value, ...options });
 					}
 				} catch (error) {
-					console.error("Error setting cookies:", error);
+					logger.error(
+						{
+							error: error instanceof Error ? error.message : String(error),
+						},
+						"Error setting cookies",
+					);
 					// Handle or log error if needed
 				}
 			},

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -8,5 +8,6 @@ declare namespace NodeJS {
 		GOOGLE_REDIRECT_URI: string;
 		APP_URL: string;
 		NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: string;
+		LOG_LEVEL?: "debug" | "info" | "warn" | "error";
 	}
 }


### PR DESCRIPTION
## 概要

issue #17に基づき、admin関連とfuneral関連のファイルで`console.log`/`console.error`/`console.warn`をpinoベースの構造化ログシステムに置き換えました。

## 変更内容

### admin関連（8ファイル、27箇所）
- `src/app/_actions/admin/users.ts` (1箇所)
- `src/app/_actions/admin/survey-export.ts` (4箇所)
- `src/app/_actions/admin/admin-2fa.ts` (3箇所)
- `src/app/_actions/admin/campaign-applications.ts` (7箇所)
- `src/app/_actions/admin/permissions.ts` (3箇所)
- `src/app/_actions/admin/contact-requests.ts` (6箇所)
- `src/app/_actions/admin/middleware.ts` (2箇所)
- `src/app/_actions/admin/announcements.ts` (1箇所)

### funeral関連（5ファイル、16箇所）
- `src/app/_actions/funeral/cases/getCase.ts` (1箇所)
- `src/app/_actions/funeral/kouden/create.ts` (5箇所)
- `src/app/_actions/funeral/customers/updateCustomer.ts` (4箇所)
- `src/app/_actions/funeral/customers/createCustomer.ts` (3箇所)
- `src/app/_actions/funeral/customers/getCustomer.ts` (3箇所)

## 主な変更点

- すべての`console.log`/`console.error`/`console.warn`を`logger`に置き換え
- 構造化ログの形式に統一（エラー情報、ユーザーID、リソースIDなどを含む）
- エラーハンドリングの改善

## 進捗状況

- **完了**: 約540箇所（約96%）
- **残り**: 約22箇所（約4%）

## 関連Issue

Refs: #17