### PR TITLE
fix(blog): skeletonのkeyにインデックスベースキーを採用 (#49)

### DIFF
--- a/src/app/_actions/admin/admin-2fa.ts
+++ b/src/app/_actions/admin/admin-2fa.ts
@@ -29,6 +29,7 @@ export async function setupTwoFactorAuth(
 	secret: string,
 	verificationCode: string,
 ): Promise<TwoFactorActionResult> {
+	let userId: string | undefined;
 	try {
 		const supabase = await createClient();
 		const {
@@ -38,6 +39,7 @@ export async function setupTwoFactorAuth(
 		if (!user) {
 			return { success: false, error: "認証が必要です" };
 		}
+		userId = user.id;
 
 		// 管理者かどうかを確認
 		const { data: isAdmin } = await supabase.rpc("is_admin", {
@@ -88,7 +90,7 @@ export async function setupTwoFactorAuth(
 		logger.error(
 			{
 				error: error instanceof Error ? error.message : String(error),
-				userId: user?.id,
+				userId,
 			},
 			"2FA setup error",
 		);
@@ -103,6 +105,7 @@ export async function setupTwoFactorAuth(
  * 2FAを無効化する
  */
 export async function disableTwoFactorAuth(): Promise<TwoFactorActionResult> {
+	let userId: string | undefined;
 	try {
 		const supabase = await createClient();
 		const {
@@ -112,6 +115,7 @@ export async function disableTwoFactorAuth(): Promise<TwoFactorActionResult> {
 		if (!user) {
 			return { success: false, error: "認証が必要です" };
 		}
+		userId = user.id;
 
 		// 管理者かどうかを確認
 		const { data: isAdmin } = await supabase.rpc("is_admin", {
@@ -151,7 +155,7 @@ export async function disableTwoFactorAuth(): Promise<TwoFactorActionResult> {
 		logger.error(
 			{
 				error: error instanceof Error ? error.message : String(error),
-				userId: user?.id,
+				userId,
 			},
 			"2FA disable error",
 		);
@@ -168,6 +172,7 @@ export async function disableTwoFactorAuth(): Promise<TwoFactorActionResult> {
 export async function verifyTwoFactorLogin(
 	verificationCode: string,
 ): Promise<TwoFactorActionResult> {
+	let userId: string | undefined;
 	try {
 		const supabase = await createClient();
 		const {
@@ -177,6 +182,7 @@ export async function verifyTwoFactorLogin(
 		if (!user) {
 			return { success: false, error: "認証が必要です" };
 		}
+		userId = user.id;
 
 		// 管理者かどうかを確認
 		const { data: isAdmin } = await supabase.rpc("is_admin", {
@@ -225,7 +231,7 @@ export async function verifyTwoFactorLogin(
 		logger.error(
 			{
 				error: error instanceof Error ? error.message : String(error),
-				userId: user?.id,
+				userId,
 			},
 			"2FA verification error",
 		);

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -112,6 +112,7 @@ export async function createKoudenWithPlan({
 	planCode,
 	expectedCount,
 }: CreateKoudenWithPlanParams): Promise<{ koudenId?: string; error?: string }> {
+	// catch 内でユーザーIDをログ出力するため try の外に宣言している
 	let uid = userId;
 	try {
 		const supabase = createAdminClient();

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -112,9 +112,9 @@ export async function createKoudenWithPlan({
 	planCode,
 	expectedCount,
 }: CreateKoudenWithPlanParams): Promise<{ koudenId?: string; error?: string }> {
+	let uid = userId;
 	try {
 		const supabase = createAdminClient();
-		let uid = userId;
 		if (!uid) {
 			const {
 				data: { user },

--- a/src/app/_actions/offerings/__tests__/allocation.test.ts
+++ b/src/app/_actions/offerings/__tests__/allocation.test.ts
@@ -140,7 +140,7 @@ describe("お供物配分システム", () => {
 
 			await allocateOfferingToEntries(request);
 
-			const insertedData = insertMock.mock.calls[0][0];
+			const insertedData = insertMock.mock.calls[0]?.[0];
 			const primaryEntry = insertedData.find((data: any) => data.is_primary_contributor);
 			expect(primaryEntry.kouden_entry_id).toBe("entry2");
 		});
@@ -284,7 +284,7 @@ describe("お供物配分システム", () => {
 
 			await allocateOfferingToEntries(request);
 
-			const insertedData = insertMock.mock.calls[0][0];
+			const insertedData = insertMock.mock.calls[0]?.[0];
 			const totalAllocated = insertedData.reduce(
 				(sum: number, data: any) => sum + data.allocated_amount,
 				0,

--- a/src/app/_actions/offerings/__tests__/allocation.test.ts
+++ b/src/app/_actions/offerings/__tests__/allocation.test.ts
@@ -140,7 +140,9 @@ describe("お供物配分システム", () => {
 
 			await allocateOfferingToEntries(request);
 
+			expect(insertMock).toHaveBeenCalledTimes(1);
 			const insertedData = insertMock.mock.calls[0]?.[0];
+			expect(insertedData).toBeDefined();
 			const primaryEntry = insertedData.find((data: any) => data.is_primary_contributor);
 			expect(primaryEntry.kouden_entry_id).toBe("entry2");
 		});
@@ -284,7 +286,9 @@ describe("お供物配分システム", () => {
 
 			await allocateOfferingToEntries(request);
 
+			expect(insertMock).toHaveBeenCalledTimes(1);
 			const insertedData = insertMock.mock.calls[0]?.[0];
+			expect(insertedData).toBeDefined();
 			const totalAllocated = insertedData.reduce(
 				(sum: number, data: any) => sum + data.allocated_amount,
 				0,

--- a/src/app/_actions/return-records/return-items.ts
+++ b/src/app/_actions/return-records/return-items.ts
@@ -208,8 +208,8 @@ export async function updateReturnItem(
 		logger.error(
 			{
 				error: error instanceof Error ? error.message : String(error),
-				id,
-				koudenId: kouden_id,
+				id: input.id,
+				koudenId: input.kouden_id,
 			},
 			"返礼品マスター情報の更新エラー",
 		);

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -324,6 +324,7 @@ ${
 }
 
 export async function POST(request: NextRequest) {
+	let model: string | undefined;
 	try {
 		// APIキーの確認
 		if (!isGeminiConfigured()) {
@@ -331,7 +332,8 @@ export async function POST(request: NextRequest) {
 		}
 
 		const body: RequestBody = await request.json();
-		const { model = "gemini-2.5-flash", prompt, context, tools = [], thinkingConfig } = body;
+		const { prompt, context, tools = [], thinkingConfig } = body;
+		model = body.model ?? "gemini-2.5-flash";
 
 		if (!prompt) {
 			return NextResponse.json({ error: "Prompt is required" }, { status: 400 });

--- a/src/app/api/ai/translate/route.ts
+++ b/src/app/api/ai/translate/route.ts
@@ -8,6 +8,7 @@ interface TranslateRequestBody {
 }
 
 export async function POST(request: NextRequest) {
+	let targetLanguage: string | undefined;
 	try {
 		// APIキーの確認
 		if (!isGeminiConfigured()) {
@@ -15,7 +16,8 @@ export async function POST(request: NextRequest) {
 		}
 
 		const body: TranslateRequestBody = await request.json();
-		const { text, targetLanguage } = body;
+		const { text } = body;
+		targetLanguage = body.targetLanguage;
 
 		if (!text) {
 			return NextResponse.json({ error: "Text is required" }, { status: 400 });

--- a/src/components/blog/popular-posts.tsx
+++ b/src/components/blog/popular-posts.tsx
@@ -77,8 +77,9 @@ export function PopularPosts({
 
 	const skeletonItems = useMemo(
 		() =>
-			Array.from({ length: Math.min(limit, 5) }, () => (
-				<div key={crypto.randomUUID()} className="flex items-start gap-3 p-3">
+			Array.from({ length: Math.min(limit, 5) }, (_, index) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
+				<div key={`skeleton-${index}`} className="flex items-start gap-3 p-3">
 					<Skeleton className="w-8 h-8 rounded-full" />
 					<div className="flex-1 space-y-2">
 						<Skeleton className="h-4 w-3/4" />

--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -78,6 +78,28 @@ export function RelatedPosts({
 		}
 	}, [currentPostId, category, tags, limit]);
 
+	const skeletonItems = useMemo(
+		() =>
+			Array.from({ length: Math.min(limit, 3) }, (_, index) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
+				<div key={`skeleton-${index}`} className="space-y-2">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-3 w-3/4" />
+					<div className="flex justify-between items-center">
+						<div className="flex gap-2">
+							<Skeleton className="h-4 w-16" />
+							<Skeleton className="h-4 w-20" />
+						</div>
+						<div className="flex gap-2">
+							<Skeleton className="h-4 w-8" />
+							<Skeleton className="h-4 w-8" />
+						</div>
+					</div>
+				</div>
+			)),
+		[limit],
+	);
+
 	const renderPostItem = (post: RelatedPost) => (
 		<div key={post.id} className="border-b border-border last:border-b-0 pb-4 last:pb-0">
 			<Link href={`/blog/${post.slug}`} className="block hover:text-primary transition-colors">
@@ -141,27 +163,7 @@ export function RelatedPosts({
 
 	const renderContent = () => {
 		if (loading) {
-			return (
-				<div className="space-y-4">
-					{Array.from({ length: Math.min(limit, 3) }).map((_, index) => (
-						// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
-						<div key={`skeleton-${index}`} className="space-y-2">
-							<Skeleton className="h-4 w-full" />
-							<Skeleton className="h-3 w-3/4" />
-							<div className="flex justify-between items-center">
-								<div className="flex gap-2">
-									<Skeleton className="h-4 w-16" />
-									<Skeleton className="h-4 w-20" />
-								</div>
-								<div className="flex gap-2">
-									<Skeleton className="h-4 w-8" />
-									<Skeleton className="h-4 w-8" />
-								</div>
-							</div>
-						</div>
-					))}
-				</div>
-			);
+			return <div className="space-y-4">{skeletonItems}</div>;
 		}
 
 		if (error) {

--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -143,8 +143,9 @@ export function RelatedPosts({
 		if (loading) {
 			return (
 				<div className="space-y-4">
-					{Array.from({ length: Math.min(limit, 3) }).map(() => (
-						<div key={crypto.randomUUID()} className="space-y-2">
+					{Array.from({ length: Math.min(limit, 3) }).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
+						<div key={`skeleton-${index}`} className="space-y-2">
 							<Skeleton className="h-4 w-full" />
 							<Skeleton className="h-3 w-3/4" />
 							<div className="flex justify-between items-center">

--- a/src/components/blog/user-bookmarks.tsx
+++ b/src/components/blog/user-bookmarks.tsx
@@ -187,7 +187,7 @@ export function UserBookmarks({
 		if (loading) {
 			return (
 				<div className="space-y-4">
-					{Array.from({ length: Math.min(limit || 5, 5) }).map((_, index) => (
+					{Array.from({ length: Math.min(limit ?? 5, 5) }).map((_, index) => (
 						// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
 						<div key={`skeleton-${index}`} className="p-4 border border-border rounded-lg">
 							<Skeleton className="h-4 w-3/4 mb-2" />

--- a/src/components/blog/user-bookmarks.tsx
+++ b/src/components/blog/user-bookmarks.tsx
@@ -66,8 +66,9 @@ export function UserBookmarks({
 					},
 				})) as BookmarkInfo[];
 
-				// limitが指定されている場合はスライス
-				const finalData = limit ? transformedData.slice(0, limit) : transformedData;
+				// limitが指定されている場合はスライス（0の場合は0件として扱う）
+				const finalData =
+					limit == null ? transformedData : transformedData.slice(0, Math.max(0, limit));
 				setBookmarks(finalData);
 			} catch (err) {
 				console.error("Failed to fetch bookmarks:", err);

--- a/src/components/blog/user-bookmarks.tsx
+++ b/src/components/blog/user-bookmarks.tsx
@@ -187,8 +187,9 @@ export function UserBookmarks({
 		if (loading) {
 			return (
 				<div className="space-y-4">
-					{Array.from({ length: Math.min(limit || 5, 5) }).map(() => (
-						<div key={crypto.randomUUID()} className="p-4 border border-border rounded-lg">
+					{Array.from({ length: Math.min(limit || 5, 5) }).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは安定した順序のため
+						<div key={`skeleton-${index}`} className="p-4 border border-border rounded-lg">
 							<Skeleton className="h-4 w-3/4 mb-2" />
 							<Skeleton className="h-3 w-1/2 mb-3" />
 							<div className="flex justify-between items-center">


### PR DESCRIPTION
crypto.randomUUID() はレンダリング毎に新しい値を生成するため、Reactの差分検出が無効化されスケルトンのアンマウント→マウントが毎回発生していた。順序が安定しているスケルトンではインデックスキーで十分であり、該当箇所のみ biome-ignore を付与。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/kouden/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 読み込み用スケルトンのキーを決定的にして不要な再生成や過剰なDOM操作を削減しました。
  * ブックマーク表示で limit=0 を正しく扱うよう修正し、空の制限が意図通り反映されます。

* **Refactor**
  * スケルトン生成をメモ化してレンダー効率を改善し、不要な再計算を防止しました。

* **Chores**
  * エラー時のログ情報やPOSTハンドラの変数スコープを調整してログの一貫性を向上しました。

* **Tests**
  * テストの呼び出しチェックを堅牢化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->