### PR TITLE
Refactor error handling with structured error codes and utilities

### DIFF
--- a/src/app/_actions/relationships.ts
+++ b/src/app/_actions/relationships.ts
@@ -78,7 +78,7 @@ export async function getRelationshipsForAdmin(koudenId: string) {
 		const { isAdmin } = await import("@/app/_actions/admin/permissions");
 		const adminCheck = await isAdmin();
 		if (!adminCheck) {
-			throw new KoudenError("管理者権限が必要です", ErrorCodes.UNAUTHORIZED);
+			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
 		}
 
 		// 管理者用クライアント（RLSバイパス）を使用
@@ -180,20 +180,23 @@ export async function updateRelationship(
 export async function deleteRelationship(id: string) {
 	return withErrorHandling(async () => {
 		const supabase = await createClient();
+		// 削除は冪等にしたいため、対象が存在しない場合（PGRST116）は成功扱いとする。
+		// 以下では `.maybeSingle()` を使用し、null ↔ row 不在を区別する。
 		const { data: relationship, error: fetchError } = await supabase
 			.from("relationships")
 			.select("kouden_id")
 			.eq("id", id)
-			.single();
+			.maybeSingle();
 
 		if (fetchError) throw fetchError;
+
+		// 既に削除済み（または存在しない）：何もせず成功で終了
+		if (!relationship) return;
 
 		const { error: deleteError } = await supabase.from("relationships").delete().eq("id", id);
 
 		if (deleteError) throw deleteError;
-		if (relationship) {
-			revalidatePath(`/koudens/${relationship.kouden_id}`);
-		}
+		revalidatePath(`/koudens/${relationship.kouden_id}`);
 	}, "関係性の削除");
 }
 

--- a/src/app/_actions/relationships.ts
+++ b/src/app/_actions/relationships.ts
@@ -1,51 +1,43 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-import type { Database } from "@/types/supabase";
-import { revalidatePath } from "next/cache";
+import { ErrorCodes, KoudenError, withErrorHandling } from "@/lib/errors";
 import logger from "@/lib/logger";
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
 
 // すべての関係性を取得
 export async function getAllRelationships() {
-	const supabase = await createClient();
-	const { data, error } = await supabase
-		.from("relationships")
-		.select(`
-			*,
-			kouden:koudens(
-				id,
-				title
-			)
-		`)
-		.order("is_default", { ascending: false })
-		.order("name");
+	return withErrorHandling(async () => {
+		const supabase = await createClient();
+		const { data, error } = await supabase
+			.from("relationships")
+			.select(`
+				*,
+				kouden:koudens(
+					id,
+					title
+				)
+			`)
+			.order("is_default", { ascending: false })
+			.order("name");
 
-	if (error) throw error;
-	return data;
+		if (error) throw error;
+		return data;
+	}, "関係性一覧の取得");
 }
 
 // 香典帳の関係性を取得
 export async function getRelationships(koudenId: string) {
-	const supabase = await createClient();
+	return withErrorHandling(async () => {
+		const supabase = await createClient();
 
-	try {
 		// 1. まず関係性の存在確認
 		const { count, error: countError } = await supabase
 			.from("relationships")
 			.select("*", { count: "exact", head: true })
 			.eq("kouden_id", koudenId);
 
-		if (countError) {
-			logger.error(
-				{
-					error: countError.message,
-					code: countError.code,
-					koudenId,
-				},
-				"Failed to count relationships",
-			);
-			throw countError;
-		}
+		if (countError) throw countError;
 
 		// 関係性が存在しない場合はすぐに空配列を返す
 		if (count === 0) {
@@ -71,69 +63,35 @@ export async function getRelationships(koudenId: string) {
 			.order("is_default", { ascending: false })
 			.order("name");
 
-		if (error) {
-			logger.error(
-				{
-					error: error.message,
-					code: error.code,
-					koudenId,
-				},
-				"Failed to fetch relationships",
-			);
-			throw error;
-		}
+		if (error) throw error;
 
-		if (!data || data.length === 0) {
-			logger.warn({ koudenId }, "No relationships data returned for kouden");
-			return [];
-		}
-
-		return data;
-	} catch (error) {
-		logger.error(
-			{
-				error: error instanceof Error ? error.message : String(error),
-				koudenId,
-			},
-			"Error in getRelationships",
-		);
-		throw error;
-	}
+		return data ?? [];
+	}, "香典帳の関係性取得");
 }
 
 /**
  * 管理者用: 香典帳の関係性を取得
  */
 export async function getRelationshipsForAdmin(koudenId: string) {
-	// 管理者権限をチェック
-	const { isAdmin } = await import("@/app/_actions/admin/permissions");
-	const adminCheck = await isAdmin();
-	if (!adminCheck) {
-		throw new Error("管理者権限が必要です");
-	}
+	return withErrorHandling(async () => {
+		// 管理者権限をチェック
+		const { isAdmin } = await import("@/app/_actions/admin/permissions");
+		const adminCheck = await isAdmin();
+		if (!adminCheck) {
+			throw new KoudenError("管理者権限が必要です", ErrorCodes.UNAUTHORIZED);
+		}
 
-	// 管理者用クライアント（RLSバイパス）を使用
-	const { createAdminClient } = await import("@/lib/supabase/admin");
-	const supabase = createAdminClient();
+		// 管理者用クライアント（RLSバイパス）を使用
+		const { createAdminClient } = await import("@/lib/supabase/admin");
+		const supabase = createAdminClient();
 
-	try {
 		// 1. まず関係性の存在確認
 		const { count, error: countError } = await supabase
 			.from("relationships")
 			.select("*", { count: "exact", head: true })
 			.eq("kouden_id", koudenId);
 
-		if (countError) {
-			logger.error(
-				{
-					error: countError.message,
-					code: countError.code,
-					koudenId,
-				},
-				"Failed to count relationships for admin",
-			);
-			throw countError;
-		}
+		if (countError) throw countError;
 
 		// 関係性が存在しない場合はすぐに空配列を返す
 		if (count === 0) {
@@ -159,34 +117,10 @@ export async function getRelationshipsForAdmin(koudenId: string) {
 			.order("is_default", { ascending: false })
 			.order("name");
 
-		if (error) {
-			logger.error(
-				{
-					error: error.message,
-					code: error.code,
-					koudenId,
-				},
-				"Failed to fetch relationships for admin",
-			);
-			throw error;
-		}
+		if (error) throw error;
 
-		if (!data || data.length === 0) {
-			logger.warn({ koudenId }, "No relationships data returned for kouden");
-			return [];
-		}
-
-		return data;
-	} catch (error) {
-		logger.error(
-			{
-				error: error instanceof Error ? error.message : String(error),
-				koudenId,
-			},
-			"Error in getRelationshipsForAdmin",
-		);
-		throw error;
-	}
+		return data ?? [];
+	}, "管理者用の香典帳関係性取得");
 }
 
 // 香典帳に新しい関係性を追加
@@ -195,27 +129,29 @@ export async function createRelationship(input: {
 	name: string;
 	description?: string;
 }) {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-	if (!user) throw new Error("Not authenticated");
+	return withErrorHandling(async () => {
+		const supabase = await createClient();
+		const {
+			data: { user },
+		} = await supabase.auth.getUser();
+		if (!user) throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
 
-	const { data, error } = await supabase
-		.from("relationships")
-		.insert({
-			kouden_id: input.koudenId,
-			name: input.name,
-			description: input.description,
-			is_default: false,
-			created_by: user.id,
-		})
-		.select()
-		.single();
+		const { data, error } = await supabase
+			.from("relationships")
+			.insert({
+				kouden_id: input.koudenId,
+				name: input.name,
+				description: input.description,
+				is_default: false,
+				created_by: user.id,
+			})
+			.select()
+			.single();
 
-	if (error) throw error;
-	revalidatePath(`/koudens/${input.koudenId}`);
-	return data;
+		if (error) throw error;
+		revalidatePath(`/koudens/${input.koudenId}`);
+		return data;
+	}, "関係性の追加");
 }
 
 // 関係性を更新
@@ -223,47 +159,51 @@ export async function updateRelationship(
 	id: string,
 	input: { name?: string; description?: string; is_default?: boolean },
 ) {
-	const supabase = await createClient();
-	const { data, error } = await supabase
-		.from("relationships")
-		.update({
-			...input,
-		})
-		.eq("id", id)
-		.select()
-		.single();
+	return withErrorHandling(async () => {
+		const supabase = await createClient();
+		const { data, error } = await supabase
+			.from("relationships")
+			.update({
+				...input,
+			})
+			.eq("id", id)
+			.select()
+			.single();
 
-	if (error) throw error;
-	revalidatePath(`/koudens/${data.kouden_id}`);
-	return data;
+		if (error) throw error;
+		revalidatePath(`/koudens/${data.kouden_id}`);
+		return data;
+	}, "関係性の更新");
 }
 
 // 関係性を削除
 export async function deleteRelationship(id: string) {
-	const supabase = await createClient();
-	const { data: relationship } = await supabase
-		.from("relationships")
-		.select("kouden_id")
-		.eq("id", id)
-		.single();
+	return withErrorHandling(async () => {
+		const supabase = await createClient();
+		const { data: relationship } = await supabase
+			.from("relationships")
+			.select("kouden_id")
+			.eq("id", id)
+			.single();
 
-	const { error } = await supabase.from("relationships").delete().eq("id", id);
+		const { error } = await supabase.from("relationships").delete().eq("id", id);
 
-	if (error) throw error;
-	if (relationship) {
-		revalidatePath(`/koudens/${relationship.kouden_id}`);
-	}
+		if (error) throw error;
+		if (relationship) {
+			revalidatePath(`/koudens/${relationship.kouden_id}`);
+		}
+	}, "関係性の削除");
 }
 
 // 香典帳作成時にデフォルトの関係性を初期化
 // TODO: デフォルトの関係性作成はfunctionsの方で実装していた気がするので確認する
 export async function initializeDefaultRelationships(koudenId: string) {
-	try {
+	return withErrorHandling(async () => {
 		const supabase = await createClient();
 		const {
 			data: { user },
 		} = await supabase.auth.getUser();
-		if (!user) throw new Error("Not authenticated");
+		if (!user) throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
 
 		const defaultRelationships = [
 			{ name: "仕事関係", description: "職場や仕事上の関係者" },
@@ -286,14 +226,5 @@ export async function initializeDefaultRelationships(koudenId: string) {
 
 		if (error) throw error;
 		revalidatePath(`/koudens/${koudenId}`);
-	} catch (error) {
-		logger.error(
-			{
-				error: error instanceof Error ? error.message : String(error),
-				koudenId,
-			},
-			"Error initializing default relationships",
-		);
-		throw new Error("デフォルトの関係性の初期化に失敗しました");
-	}
+	}, "デフォルト関係性の初期化");
 }

--- a/src/app/_actions/relationships.ts
+++ b/src/app/_actions/relationships.ts
@@ -180,15 +180,17 @@ export async function updateRelationship(
 export async function deleteRelationship(id: string) {
 	return withErrorHandling(async () => {
 		const supabase = await createClient();
-		const { data: relationship } = await supabase
+		const { data: relationship, error: fetchError } = await supabase
 			.from("relationships")
 			.select("kouden_id")
 			.eq("id", id)
 			.single();
 
-		const { error } = await supabase.from("relationships").delete().eq("id", id);
+		if (fetchError) throw fetchError;
 
-		if (error) throw error;
+		const { error: deleteError } = await supabase.from("relationships").delete().eq("id", id);
+
+		if (deleteError) throw deleteError;
 		if (relationship) {
 			revalidatePath(`/koudens/${relationship.kouden_id}`);
 		}

--- a/src/app/_actions/relationships.ts
+++ b/src/app/_actions/relationships.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { ErrorCodes, KoudenError, withErrorHandling } from "@/lib/errors";
-import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
@@ -39,9 +38,8 @@ export async function getRelationships(koudenId: string) {
 
 		if (countError) throw countError;
 
-		// 関係性が存在しない場合はすぐに空配列を返す
+		// 関係性が存在しない場合はすぐに空配列を返す（正常系）
 		if (count === 0) {
-			logger.warn({ koudenId }, "No relationships found for kouden");
 			return [];
 		}
 
@@ -93,9 +91,8 @@ export async function getRelationshipsForAdmin(koudenId: string) {
 
 		if (countError) throw countError;
 
-		// 関係性が存在しない場合はすぐに空配列を返す
+		// 関係性が存在しない場合はすぐに空配列を返す（正常系）
 		if (count === 0) {
-			logger.warn({ koudenId }, "No relationships found for kouden");
 			return [];
 		}
 

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -55,11 +55,50 @@ describe("KoudenError", () => {
 });
 
 describe("KoudenError.fromSupabase", () => {
-	it("PostgREST PGRST116 を NOT_FOUND に変換する", () => {
-		const err = KoudenError.fromSupabase({ code: "PGRST116", message: "No rows" }, "メンバー取得");
+	it("PostgREST PGRST116（0行）を NOT_FOUND に変換する", () => {
+		const err = KoudenError.fromSupabase(
+			{
+				code: "PGRST116",
+				message: "JSON object requested, multiple (or no) rows returned",
+				details: "The result contains 0 rows",
+			},
+			"メンバー取得",
+		);
 		expect(err.code).toBe(ErrorCodes.NOT_FOUND);
 		expect(err.userMessage).toBe("対象のデータが見つかりませんでした。");
 		expect(err.status).toBe(404);
+	});
+
+	it("PostgREST PGRST116（複数行）は NOT_FOUND ではなく DB_FETCH_ERROR に分類する", () => {
+		const err = KoudenError.fromSupabase(
+			{
+				code: "PGRST116",
+				message: "JSON object requested, multiple (or no) rows returned",
+				details: "The result contains 3 rows",
+			},
+			"メンバー取得",
+		);
+		expect(err.code).toBe(ErrorCodes.DB_FETCH_ERROR);
+		expect(err.userMessage).toContain("想定と一致しませんでした");
+	});
+
+	it("PostgrestError（Error 継承）でも Supabase エラーとして変換される", () => {
+		class PostgrestError extends Error {
+			code = "23505";
+			details = "Key (name)=(foo) already exists.";
+			hint = null;
+			constructor(msg: string) {
+				super(msg);
+				this.name = "PostgrestError";
+			}
+		}
+		const err = KoudenError.fromSupabase(
+			new PostgrestError("duplicate key value violates unique constraint"),
+			"関係性の作成",
+		);
+		expect(err.code).toBe(ErrorCodes.ALREADY_EXISTS);
+		expect(err.status).toBe(409);
+		expect(err.userMessage).toContain("すでに同じデータ");
 	});
 
 	it("Postgres 23505（重複）を ALREADY_EXISTS に変換する", () => {
@@ -164,8 +203,24 @@ describe("toActionError", () => {
 				code: "FORBIDDEN",
 				message: "この操作を行う権限がありません。",
 				status: 403,
-				details: undefined,
 			},
 		});
+	});
+
+	it("内部の details はクライアント向け ActionResult には含めない（情報漏洩防止）", () => {
+		const err = KoudenError.fromSupabase(
+			{
+				code: "23505",
+				message: "dup",
+				details: "Key (name)=(x) already exists.",
+				hint: null,
+			},
+			"作成",
+		);
+		const result = toActionError(err, "作成");
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).not.toHaveProperty("details");
+		}
 	});
 });

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -134,6 +134,34 @@ describe("KoudenError.fromSupabase", () => {
 		expect(err.userMessage).toBe("処理に失敗しました。");
 		expect((err as Error & { cause?: unknown }).cause).toBeInstanceOf(Error);
 	});
+
+	it("KoudenError.message に生の Supabase メッセージを漏らさない（UI露出対策）", () => {
+		const rawMessage = 'duplicate key value violates unique constraint "relationships_name_key"';
+		const err = KoudenError.fromSupabase(
+			{
+				code: "23505",
+				message: rawMessage,
+				details: "Key (name)=(foo) already exists.",
+				hint: null,
+			},
+			"関係性の作成",
+		);
+		expect(err.message).not.toContain("duplicate key");
+		expect(err.message).not.toContain("relationships_name_key");
+		expect(err.message).toBe(err.userMessage);
+		// 生メッセージはログ向けに details / cause に退避される
+		expect(err.details).toMatchObject({ supabaseMessage: rawMessage });
+	});
+});
+
+describe("KoudenError.from", () => {
+	it("生の Error.message を KoudenError.message に反映しない（UI露出対策）", () => {
+		const raw = "Internal server detail: connection string=postgres://...";
+		const err = KoudenError.from(new Error(raw), "処理");
+		expect(err.message).toBe("処理に失敗しました。");
+		expect(err.message).not.toContain("connection string");
+		expect(err.details).toMatchObject({ originalMessage: raw });
+	});
 });
 
 describe("withErrorHandling", () => {

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="vitest" />
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+	default: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import {
+	ErrorCodes,
+	KoudenError,
+	toActionError,
+	withActionResult,
+	withErrorHandling,
+} from "../errors";
+import logger from "../logger";
+
+describe("KoudenError", () => {
+	it("エラーコードに対応するデフォルトHTTPステータスが設定される", () => {
+		const err = new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
+		expect(err.status).toBe(401);
+		expect(err.code).toBe("UNAUTHORIZED");
+	});
+
+	it("エラーコードに対応する既定のユーザーメッセージが設定される", () => {
+		const err = new KoudenError("internal", ErrorCodes.NOT_FOUND);
+		expect(err.userMessage).toBe("対象のデータが見つかりませんでした。");
+	});
+
+	it("オプションで status / userMessage / details を上書きできる", () => {
+		const err = new KoudenError("internal", ErrorCodes.DB_FETCH_ERROR, {
+			status: 418,
+			userMessage: "Tea time",
+			details: { reason: "teapot" },
+		});
+		expect(err.status).toBe(418);
+		expect(err.userMessage).toBe("Tea time");
+		expect(err.details).toEqual({ reason: "teapot" });
+	});
+
+	it("第3引数として数値を渡すと従来どおり status として扱う（後方互換）", () => {
+		const err = new KoudenError("msg", "CUSTOM", 422);
+		expect(err.status).toBe(422);
+	});
+
+	it("未知のエラーコードは既定値にフォールバックする", () => {
+		const err = new KoudenError("msg", "NOT_A_REAL_CODE");
+		expect(err.status).toBe(500);
+		expect(err.userMessage).toBe("msg");
+	});
+});
+
+describe("KoudenError.fromSupabase", () => {
+	it("PostgREST PGRST116 を NOT_FOUND に変換する", () => {
+		const err = KoudenError.fromSupabase({ code: "PGRST116", message: "No rows" }, "メンバー取得");
+		expect(err.code).toBe(ErrorCodes.NOT_FOUND);
+		expect(err.userMessage).toBe("対象のデータが見つかりませんでした。");
+		expect(err.status).toBe(404);
+	});
+
+	it("Postgres 23505（重複）を ALREADY_EXISTS に変換する", () => {
+		const err = KoudenError.fromSupabase(
+			{ code: "23505", message: "duplicate key" },
+			"関係性の作成",
+		);
+		expect(err.code).toBe(ErrorCodes.ALREADY_EXISTS);
+		expect(err.status).toBe(409);
+		expect(err.userMessage).toContain("すでに同じデータ");
+	});
+
+	it("Postgres 42501（権限）を FORBIDDEN に変換する", () => {
+		const err = KoudenError.fromSupabase({ code: "42501", message: "permission denied" }, "更新");
+		expect(err.code).toBe(ErrorCodes.FORBIDDEN);
+		expect(err.status).toBe(403);
+	});
+
+	it("既存の KoudenError はそのまま返す", () => {
+		const original = new KoudenError("msg", ErrorCodes.UNAUTHORIZED);
+		expect(KoudenError.fromSupabase(original, "x")).toBe(original);
+	});
+
+	it("未知のコードの場合は DB_FETCH_ERROR に分類する", () => {
+		const err = KoudenError.fromSupabase({ code: "99999", message: "mysterious" }, "取得");
+		expect(err.code).toBe(ErrorCodes.DB_FETCH_ERROR);
+		expect(err.userMessage).toBe("取得に失敗しました。");
+	});
+
+	it("Error インスタンスは from() に委譲される", () => {
+		const err = KoudenError.fromSupabase(new Error("boom"), "処理");
+		expect(err.code).toBe(ErrorCodes.UNKNOWN_ERROR);
+		expect(err.userMessage).toBe("処理に失敗しました。");
+		expect((err as Error & { cause?: unknown }).cause).toBeInstanceOf(Error);
+	});
+});
+
+describe("withErrorHandling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("成功時は結果をそのまま返す", async () => {
+		const result = await withErrorHandling(async () => 42, "数値取得");
+		expect(result).toBe(42);
+	});
+
+	it("失敗時は KoudenError を投げ、ログ出力する", async () => {
+		await expect(
+			withErrorHandling(async () => {
+				throw { code: "23505", message: "dup" };
+			}, "関係性の作成"),
+		).rejects.toMatchObject({
+			name: "KoudenError",
+			code: ErrorCodes.ALREADY_EXISTS,
+		});
+
+		expect(logger.error).toHaveBeenCalledTimes(1);
+	});
+
+	it("既存の KoudenError はコードを保持したまま再throwする", async () => {
+		const original = new KoudenError("auth", ErrorCodes.UNAUTHORIZED);
+		await expect(
+			withErrorHandling(async () => {
+				throw original;
+			}, "何か"),
+		).rejects.toBe(original);
+	});
+});
+
+describe("withActionResult", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("成功時は ok:true の ActionResult を返す", async () => {
+		const res = await withActionResult(async () => ({ id: "abc" }), "取得");
+		expect(res).toEqual({ ok: true, data: { id: "abc" } });
+	});
+
+	it("失敗時は ok:false の ActionResult を返す（throwしない）", async () => {
+		const res = await withActionResult(async () => {
+			throw { code: "PGRST116", message: "No rows" };
+		}, "メンバー取得");
+
+		expect(res.ok).toBe(false);
+		if (!res.ok) {
+			expect(res.error.code).toBe(ErrorCodes.NOT_FOUND);
+			expect(res.error.status).toBe(404);
+			expect(res.error.message).toContain("見つかりません");
+		}
+	});
+});
+
+describe("toActionError", () => {
+	it("KoudenError を ActionResult のエラー形式に変換する", () => {
+		const err = new KoudenError("ng", ErrorCodes.FORBIDDEN);
+		const result = toActionError(err, "x");
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				code: "FORBIDDEN",
+				message: "この操作を行う権限がありません。",
+				status: 403,
+				details: undefined,
+			},
+		});
+	});
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -150,9 +150,10 @@ function isSupabaseLikeError(error: unknown): error is SupabaseLikeError {
 	if (!error || typeof error !== "object") return false;
 	const e = error as Record<string, unknown>;
 	// Supabaseのエラー（PostgrestError / PostgREST / Postgres）は
-	// いずれも `code` プロパティを持つ。
+	// いずれも `code` と `message` を持つ。
 	// PostgrestError は Error を継承しているため、Errorインスタンスも除外しない。
-	return typeof e.code === "string";
+	// `code` だけ持つ任意オブジェクトを誤検出しないよう `message` の存在も要求する。
+	return typeof e.code === "string" && typeof e.message === "string";
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -81,34 +81,34 @@ const SUPABASE_ERROR_CODE_MAP: Record<string, { code: string; message: string }>
 	// PostgREST
 	PGRST116: {
 		code: ErrorCodes.NOT_FOUND,
-		message: "対象のデータが見つかりませんでした",
+		message: "対象のデータが見つかりませんでした。",
 	},
-	PGRST301: { code: ErrorCodes.UNAUTHORIZED, message: "認証が必要です" },
+	PGRST301: { code: ErrorCodes.UNAUTHORIZED, message: "認証が必要です。" },
 
 	// Postgres
 	"23505": {
 		code: ErrorCodes.ALREADY_EXISTS,
-		message: "すでに同じデータが存在します",
+		message: "すでに同じデータが存在します。",
 	},
 	"23503": {
 		code: ErrorCodes.DB_CONSTRAINT_ERROR,
-		message: "関連するデータが存在するため処理できませんでした",
+		message: "関連するデータが存在するため処理できませんでした。",
 	},
 	"23502": {
 		code: ErrorCodes.VALIDATION_ERROR,
-		message: "必須項目が入力されていません",
+		message: "必須項目が入力されていません。",
 	},
 	"23514": {
 		code: ErrorCodes.VALIDATION_ERROR,
-		message: "入力値が制約を満たしていません",
+		message: "入力値が制約を満たしていません。",
 	},
 	"42501": {
 		code: ErrorCodes.FORBIDDEN,
-		message: "この操作を行う権限がありません",
+		message: "この操作を行う権限がありません。",
 	},
 	"42P01": {
 		code: ErrorCodes.DB_FETCH_ERROR,
-		message: "データの取得に失敗しました",
+		message: "データの取得に失敗しました。",
 	},
 };
 
@@ -148,12 +148,45 @@ interface SupabaseLikeError {
 
 function isSupabaseLikeError(error: unknown): error is SupabaseLikeError {
 	if (!error || typeof error !== "object") return false;
-	// Errorインスタンスは Supabase のエラーオブジェクトではなく、
-	// 通常の JavaScript エラーとして扱う
-	if (error instanceof Error) return false;
 	const e = error as Record<string, unknown>;
-	// Supabaseのエラーは `code` プロパティを持つ（PostgREST/Postgres由来）
+	// Supabaseのエラー（PostgrestError / PostgREST / Postgres）は
+	// いずれも `code` プロパティを持つ。
+	// PostgrestError は Error を継承しているため、Errorインスタンスも除外しない。
 	return typeof e.code === "string";
+}
+
+/**
+ * Supabase エラーコードを `KoudenError` の分類にマッピングする。
+ *
+ * 一部のエラーコード（`PGRST116` 等）は状況によって意味が変わるため、
+ * `details` や `message` の内容から推定して分岐する。
+ */
+function resolveSupabaseMapping(
+	error: SupabaseLikeError,
+): { code: string; message: string } | undefined {
+	const code = error.code;
+	if (!code) return undefined;
+
+	// PGRST116 は「想定外の行数」で発火する。
+	// 0 行 → NOT_FOUND、それ以外（複数行） → データ整合性エラーとして DB_FETCH_ERROR に倒す。
+	if (code === "PGRST116") {
+		const details = typeof error.details === "string" ? error.details : "";
+		const message = typeof error.message === "string" ? error.message : "";
+		const combined = `${details} ${message}`.toLowerCase();
+		const isZeroRows = /\b0\s+rows?\b/.test(combined) || /no\s+rows/.test(combined);
+		if (isZeroRows) {
+			return {
+				code: ErrorCodes.NOT_FOUND,
+				message: "対象のデータが見つかりませんでした。",
+			};
+		}
+		return {
+			code: ErrorCodes.DB_FETCH_ERROR,
+			message: "データの取得結果が想定と一致しませんでした。",
+		};
+	}
+
+	return SUPABASE_ERROR_CODE_MAP[code];
 }
 
 export interface KoudenErrorOptions {
@@ -210,11 +243,11 @@ export class KoudenError extends Error {
 		if (error instanceof KoudenError) return error;
 
 		if (isSupabaseLikeError(error)) {
-			const mapped = error.code ? SUPABASE_ERROR_CODE_MAP[error.code] : undefined;
+			const mapped = resolveSupabaseMapping(error);
 			const code = mapped?.code ?? ErrorCodes.DB_FETCH_ERROR;
-			const userMessage = mapped?.message ?? `${context}に失敗しました`;
+			const userMessage = mapped?.message ?? `${context}に失敗しました。`;
 			return new KoudenError(error.message ?? `${context} failed`, code, {
-				userMessage: `${userMessage}。`,
+				userMessage,
 				details: {
 					supabaseCode: error.code,
 					supabaseDetails: error.details,
@@ -255,6 +288,10 @@ export class KoudenError extends Error {
  * Server Action等で利用する統一レスポンス型。
  *
  * `ok: true` の成功ケースと、`ok: false` の失敗ケースを判別可能ユニオンとして表現する。
+ *
+ * ※ `details` はサーバー内部情報（DBの制約名・テーブル名等）を含む恐れがあるため、
+ *   クライアントに返却するこの型からは意図的に除外している。
+ *   サーバーサイドでは `KoudenError.details` を直接参照すればよい。
  */
 export type ActionResult<T> =
 	| { ok: true; data: T }
@@ -264,12 +301,13 @@ export type ActionResult<T> =
 				code: string;
 				message: string;
 				status: number;
-				details?: Record<string, unknown>;
 			};
 	  };
 
 /**
  * `KoudenError`（または任意のエラー）を `ActionResult` のエラー形式に変換する。
+ *
+ * `details` は内部情報の漏洩を避けるためクライアントには返さない。
  */
 export function toActionError<T = never>(error: unknown, context: string): ActionResult<T> {
 	const kErr = error instanceof KoudenError ? error : KoudenError.from(error, context);
@@ -279,9 +317,25 @@ export function toActionError<T = never>(error: unknown, context: string): Actio
 			code: kErr.code,
 			message: kErr.userMessage,
 			status: kErr.status,
-			details: kErr.details,
 		},
 	};
+}
+
+/**
+ * `KoudenError` を構造化ログとして出力する内部ヘルパー。
+ */
+function logKoudenError(err: KoudenError, errorContext: string): void {
+	logger.error(
+		{
+			errorContext,
+			error: err.message,
+			errorCode: err.code,
+			errorStatus: err.status,
+			errorStack: err.stack,
+			errorDetails: err.details,
+		},
+		`[ERROR] ${errorContext}`,
+	);
 }
 
 /**
@@ -299,19 +353,7 @@ export const withErrorHandling = async <T>(
 		return await action();
 	} catch (error) {
 		const koudenError = KoudenError.fromSupabase(error, errorContext);
-
-		logger.error(
-			{
-				errorContext,
-				error: koudenError.message,
-				errorCode: koudenError.code,
-				errorStatus: koudenError.status,
-				errorStack: koudenError.stack,
-				errorDetails: koudenError.details,
-			},
-			`[ERROR] ${errorContext}`,
-		);
-
+		logKoudenError(koudenError, errorContext);
 		throw koudenError;
 	}
 };
@@ -331,18 +373,7 @@ export const withActionResult = async <T>(
 		return { ok: true, data };
 	} catch (error) {
 		const koudenError = KoudenError.fromSupabase(error, errorContext);
-
-		logger.error(
-			{
-				errorContext,
-				error: koudenError.message,
-				errorCode: koudenError.code,
-				errorStatus: koudenError.status,
-				errorDetails: koudenError.details,
-			},
-			`[ERROR] ${errorContext}`,
-		);
-
+		logKoudenError(koudenError, errorContext);
 		return toActionError<T>(koudenError, errorContext);
 	}
 };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,18 +1,296 @@
 import logger from "./logger";
 
-// カスタムエラークラスの定義
+/**
+ * エラーコードの体系化
+ *
+ * カテゴリー別に整理されたエラーコード定数。
+ * - AUTH_*: 認証・認可エラー
+ * - RESOURCE_*: リソース関連エラー
+ * - VALIDATION_*: 入力値検証エラー
+ * - DB_*: データベース関連エラー
+ * - PAYMENT_*: 決済関連エラー
+ * - UNKNOWN_ERROR: 分類不能なエラー
+ */
+export const ErrorCodes = {
+	// 認証・認可
+	UNAUTHORIZED: "UNAUTHORIZED",
+	FORBIDDEN: "FORBIDDEN",
+	INSUFFICIENT_PERMISSION: "INSUFFICIENT_PERMISSION",
+	UNKNOWN_PERMISSION: "UNKNOWN_PERMISSION",
+
+	// リソース
+	NOT_FOUND: "NOT_FOUND",
+	ALREADY_EXISTS: "ALREADY_EXISTS",
+	INVALID_OPERATION: "INVALID_OPERATION",
+
+	// 入力検証
+	VALIDATION_ERROR: "VALIDATION_ERROR",
+	INVALID_INPUT: "INVALID_INPUT",
+
+	// データベース
+	DB_FETCH_ERROR: "DB_FETCH_ERROR",
+	DB_INSERT_ERROR: "DB_INSERT_ERROR",
+	DB_UPDATE_ERROR: "DB_UPDATE_ERROR",
+	DB_DELETE_ERROR: "DB_DELETE_ERROR",
+	DB_CONSTRAINT_ERROR: "DB_CONSTRAINT_ERROR",
+	DB_CONNECTION_ERROR: "DB_CONNECTION_ERROR",
+
+	// 決済
+	PAYMENT_ERROR: "PAYMENT_ERROR",
+
+	// その他
+	NETWORK_ERROR: "NETWORK_ERROR",
+	UNKNOWN_ERROR: "UNKNOWN_ERROR",
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes] | (string & {});
+
+/**
+ * HTTPステータスコードのデフォルトマッピング
+ */
+const DEFAULT_STATUS_BY_CODE: Record<string, number> = {
+	[ErrorCodes.UNAUTHORIZED]: 401,
+	[ErrorCodes.FORBIDDEN]: 403,
+	[ErrorCodes.INSUFFICIENT_PERMISSION]: 403,
+	[ErrorCodes.UNKNOWN_PERMISSION]: 403,
+	[ErrorCodes.NOT_FOUND]: 404,
+	[ErrorCodes.ALREADY_EXISTS]: 409,
+	[ErrorCodes.INVALID_OPERATION]: 400,
+	[ErrorCodes.VALIDATION_ERROR]: 400,
+	[ErrorCodes.INVALID_INPUT]: 400,
+	[ErrorCodes.DB_FETCH_ERROR]: 500,
+	[ErrorCodes.DB_INSERT_ERROR]: 500,
+	[ErrorCodes.DB_UPDATE_ERROR]: 500,
+	[ErrorCodes.DB_DELETE_ERROR]: 500,
+	[ErrorCodes.DB_CONSTRAINT_ERROR]: 409,
+	[ErrorCodes.DB_CONNECTION_ERROR]: 503,
+	[ErrorCodes.PAYMENT_ERROR]: 402,
+	[ErrorCodes.NETWORK_ERROR]: 503,
+	[ErrorCodes.UNKNOWN_ERROR]: 500,
+};
+
+/**
+ * Supabase（PostgREST / Postgres）のエラーコードから
+ * `KoudenError` の内部コードへのマッピング。
+ *
+ * 参照:
+ * - PostgREST: https://postgrest.org/en/stable/errors.html
+ * - Postgres : https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+const SUPABASE_ERROR_CODE_MAP: Record<string, { code: string; message: string }> = {
+	// PostgREST
+	PGRST116: {
+		code: ErrorCodes.NOT_FOUND,
+		message: "対象のデータが見つかりませんでした",
+	},
+	PGRST301: { code: ErrorCodes.UNAUTHORIZED, message: "認証が必要です" },
+
+	// Postgres
+	"23505": {
+		code: ErrorCodes.ALREADY_EXISTS,
+		message: "すでに同じデータが存在します",
+	},
+	"23503": {
+		code: ErrorCodes.DB_CONSTRAINT_ERROR,
+		message: "関連するデータが存在するため処理できませんでした",
+	},
+	"23502": {
+		code: ErrorCodes.VALIDATION_ERROR,
+		message: "必須項目が入力されていません",
+	},
+	"23514": {
+		code: ErrorCodes.VALIDATION_ERROR,
+		message: "入力値が制約を満たしていません",
+	},
+	"42501": {
+		code: ErrorCodes.FORBIDDEN,
+		message: "この操作を行う権限がありません",
+	},
+	"42P01": {
+		code: ErrorCodes.DB_FETCH_ERROR,
+		message: "データの取得に失敗しました",
+	},
+};
+
+/**
+ * エラーコードから既定の日本語メッセージを生成する
+ */
+const DEFAULT_USER_MESSAGE_BY_CODE: Record<string, string> = {
+	[ErrorCodes.UNAUTHORIZED]: "認証が必要です。ログインしてください。",
+	[ErrorCodes.FORBIDDEN]: "この操作を行う権限がありません。",
+	[ErrorCodes.INSUFFICIENT_PERMISSION]: "この操作を行う権限がありません。",
+	[ErrorCodes.UNKNOWN_PERMISSION]: "権限を判定できませんでした。",
+	[ErrorCodes.NOT_FOUND]: "対象のデータが見つかりませんでした。",
+	[ErrorCodes.ALREADY_EXISTS]: "すでに同じデータが存在します。",
+	[ErrorCodes.INVALID_OPERATION]: "この操作は実行できません。",
+	[ErrorCodes.VALIDATION_ERROR]: "入力内容に誤りがあります。",
+	[ErrorCodes.INVALID_INPUT]: "入力内容に誤りがあります。",
+	[ErrorCodes.DB_FETCH_ERROR]: "データの取得に失敗しました。",
+	[ErrorCodes.DB_INSERT_ERROR]: "データの登録に失敗しました。",
+	[ErrorCodes.DB_UPDATE_ERROR]: "データの更新に失敗しました。",
+	[ErrorCodes.DB_DELETE_ERROR]: "データの削除に失敗しました。",
+	[ErrorCodes.DB_CONSTRAINT_ERROR]: "関連するデータが存在するため処理できませんでした。",
+	[ErrorCodes.DB_CONNECTION_ERROR]: "データベースに接続できませんでした。",
+	[ErrorCodes.PAYMENT_ERROR]: "決済処理に失敗しました。",
+	[ErrorCodes.NETWORK_ERROR]: "通信エラーが発生しました。時間をおいて再度お試しください。",
+	[ErrorCodes.UNKNOWN_ERROR]: "予期せぬエラーが発生しました。",
+};
+
+/**
+ * Supabase由来のエラーオブジェクトかどうかを判定する
+ */
+interface SupabaseLikeError {
+	code?: string;
+	message?: string;
+	details?: string | null;
+	hint?: string | null;
+}
+
+function isSupabaseLikeError(error: unknown): error is SupabaseLikeError {
+	if (!error || typeof error !== "object") return false;
+	// Errorインスタンスは Supabase のエラーオブジェクトではなく、
+	// 通常の JavaScript エラーとして扱う
+	if (error instanceof Error) return false;
+	const e = error as Record<string, unknown>;
+	// Supabaseのエラーは `code` プロパティを持つ（PostgREST/Postgres由来）
+	return typeof e.code === "string";
+}
+
+export interface KoudenErrorOptions {
+	/** HTTPステータスコード（未指定時はコードから自動決定） */
+	status?: number;
+	/** エンドユーザーに見せるメッセージ。未指定時はエラーコードから自動生成 */
+	userMessage?: string;
+	/** 詳細情報（ログ用） */
+	details?: Record<string, unknown>;
+	/** 元のエラー（ラップ時に原因を保持） */
+	cause?: unknown;
+}
+
+/**
+ * 本アプリケーション独自のエラークラス。
+ *
+ * - `code`: エラーコード（機械可読）
+ * - `message`: 開発者向けメッセージ
+ * - `userMessage`: エンドユーザー向け日本語メッセージ
+ * - `status`: 対応するHTTPステータス
+ */
 export class KoudenError extends Error {
+	public readonly code: string;
+	public readonly status: number;
+	public readonly userMessage: string;
+	public readonly details?: Record<string, unknown>;
+
 	constructor(
 		message: string,
-		public code: string,
-		public status = 400,
+		code: string = ErrorCodes.UNKNOWN_ERROR,
+		options: KoudenErrorOptions | number = {},
 	) {
 		super(message);
 		this.name = "KoudenError";
+		this.code = code;
+
+		const opts: KoudenErrorOptions = typeof options === "number" ? { status: options } : options;
+		this.status = opts.status ?? DEFAULT_STATUS_BY_CODE[code] ?? 500;
+		this.userMessage = opts.userMessage ?? DEFAULT_USER_MESSAGE_BY_CODE[code] ?? message;
+		this.details = opts.details;
+
+		if (opts.cause !== undefined) {
+			(this as Error & { cause?: unknown }).cause = opts.cause;
+		}
+	}
+
+	/**
+	 * Supabase（PostgREST/Postgres）由来のエラーを `KoudenError` に変換する。
+	 *
+	 * @param error Supabaseから返されたエラー
+	 * @param context 失敗した操作の説明（「メンバー一覧の取得」など）
+	 */
+	static fromSupabase(error: unknown, context: string): KoudenError {
+		if (error instanceof KoudenError) return error;
+
+		if (isSupabaseLikeError(error)) {
+			const mapped = error.code ? SUPABASE_ERROR_CODE_MAP[error.code] : undefined;
+			const code = mapped?.code ?? ErrorCodes.DB_FETCH_ERROR;
+			const userMessage = mapped?.message ?? `${context}に失敗しました`;
+			return new KoudenError(error.message ?? `${context} failed`, code, {
+				userMessage: `${userMessage}。`,
+				details: {
+					supabaseCode: error.code,
+					supabaseDetails: error.details,
+					supabaseHint: error.hint,
+				},
+				cause: error,
+			});
+		}
+
+		return KoudenError.from(error, context);
+	}
+
+	/**
+	 * 任意のthrowされた値を `KoudenError` に変換する。
+	 */
+	static from(error: unknown, context: string): KoudenError {
+		if (error instanceof KoudenError) return error;
+
+		if (error instanceof Error) {
+			return new KoudenError(error.message || `${context} failed`, ErrorCodes.UNKNOWN_ERROR, {
+				userMessage: `${context}に失敗しました。`,
+				cause: error,
+			});
+		}
+
+		return new KoudenError(
+			typeof error === "string" ? error : `${context} failed`,
+			ErrorCodes.UNKNOWN_ERROR,
+			{
+				userMessage: `${context}に失敗しました。`,
+				cause: error,
+			},
+		);
 	}
 }
 
-// エラーハンドリングのユーティリティ関数
+/**
+ * Server Action等で利用する統一レスポンス型。
+ *
+ * `ok: true` の成功ケースと、`ok: false` の失敗ケースを判別可能ユニオンとして表現する。
+ */
+export type ActionResult<T> =
+	| { ok: true; data: T }
+	| {
+			ok: false;
+			error: {
+				code: string;
+				message: string;
+				status: number;
+				details?: Record<string, unknown>;
+			};
+	  };
+
+/**
+ * `KoudenError`（または任意のエラー）を `ActionResult` のエラー形式に変換する。
+ */
+export function toActionError<T = never>(error: unknown, context: string): ActionResult<T> {
+	const kErr = error instanceof KoudenError ? error : KoudenError.from(error, context);
+	return {
+		ok: false,
+		error: {
+			code: kErr.code,
+			message: kErr.userMessage,
+			status: kErr.status,
+			details: kErr.details,
+		},
+	};
+}
+
+/**
+ * 統一的なエラーハンドリングを提供するユーティリティ関数。
+ *
+ * - 失敗時は必ず `KoudenError` を投げる（非 `KoudenError` は変換）
+ * - 構造化ログを自動で出力する
+ * - Supabaseエラーは自動で変換する
+ */
 export const withErrorHandling = async <T>(
 	action: () => Promise<T>,
 	errorContext: string,
@@ -20,18 +298,51 @@ export const withErrorHandling = async <T>(
 	try {
 		return await action();
 	} catch (error) {
+		const koudenError = KoudenError.fromSupabase(error, errorContext);
+
 		logger.error(
 			{
 				errorContext,
-				error: error instanceof Error ? error.message : String(error),
-				errorStack: error instanceof Error ? error.stack : undefined,
-				errorCode: error instanceof KoudenError ? error.code : undefined,
+				error: koudenError.message,
+				errorCode: koudenError.code,
+				errorStatus: koudenError.status,
+				errorStack: koudenError.stack,
+				errorDetails: koudenError.details,
 			},
 			`[ERROR] ${errorContext}`,
 		);
-		if (error instanceof KoudenError) {
-			throw error;
-		}
-		throw new KoudenError(`${errorContext}に失敗しました`, "UNKNOWN_ERROR");
+
+		throw koudenError;
+	}
+};
+
+/**
+ * `withErrorHandling` の結果型バリアント。
+ *
+ * 例外をthrowせず、成功/失敗をオブジェクトで返すので、
+ * Server Actionからクライアントに渡しやすい。
+ */
+export const withActionResult = async <T>(
+	action: () => Promise<T>,
+	errorContext: string,
+): Promise<ActionResult<T>> => {
+	try {
+		const data = await action();
+		return { ok: true, data };
+	} catch (error) {
+		const koudenError = KoudenError.fromSupabase(error, errorContext);
+
+		logger.error(
+			{
+				errorContext,
+				error: koudenError.message,
+				errorCode: koudenError.code,
+				errorStatus: koudenError.status,
+				errorDetails: koudenError.details,
+			},
+			`[ERROR] ${errorContext}`,
+		);
+
+		return toActionError<T>(koudenError, errorContext);
 	}
 };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -205,9 +205,13 @@ export interface KoudenErrorOptions {
  * 本アプリケーション独自のエラークラス。
  *
  * - `code`: エラーコード（機械可読）
- * - `message`: 開発者向けメッセージ
+ * - `message`: UIにも露出しうる安全な文脈メッセージ（`userMessage` と同等）
  * - `userMessage`: エンドユーザー向け日本語メッセージ
  * - `status`: 対応するHTTPステータス
+ *
+ * ※ `message` は `Error.message` として UI（例: Next.js の `error.tsx`）で
+ *   そのまま表示されることがあるため、DB/内部情報は含めないこと。
+ *   生のSupabaseメッセージや例外の詳細は `details` と `cause` に保持する。
  */
 export class KoudenError extends Error {
 	public readonly code: string;
@@ -237,6 +241,9 @@ export class KoudenError extends Error {
 	/**
 	 * Supabase（PostgREST/Postgres）由来のエラーを `KoudenError` に変換する。
 	 *
+	 * `KoudenError.message` には UI に露出しうるため安全な文脈メッセージを設定し、
+	 * 生の Supabase メッセージはログ用途に `details.supabaseMessage` と `cause` に保持する。
+	 *
 	 * @param error Supabaseから返されたエラー
 	 * @param context 失敗した操作の説明（「メンバー一覧の取得」など）
 	 */
@@ -247,10 +254,11 @@ export class KoudenError extends Error {
 			const mapped = resolveSupabaseMapping(error);
 			const code = mapped?.code ?? ErrorCodes.DB_FETCH_ERROR;
 			const userMessage = mapped?.message ?? `${context}に失敗しました。`;
-			return new KoudenError(error.message ?? `${context} failed`, code, {
+			return new KoudenError(userMessage, code, {
 				userMessage,
 				details: {
 					supabaseCode: error.code,
+					supabaseMessage: error.message,
 					supabaseDetails: error.details,
 					supabaseHint: error.hint,
 				},
@@ -263,25 +271,22 @@ export class KoudenError extends Error {
 
 	/**
 	 * 任意のthrowされた値を `KoudenError` に変換する。
+	 *
+	 * 元の例外メッセージは UI 露出を避けるため `message` には反映せず、
+	 * ログ用途として `details.originalMessage` と `cause` に保持する。
 	 */
 	static from(error: unknown, context: string): KoudenError {
 		if (error instanceof KoudenError) return error;
 
-		if (error instanceof Error) {
-			return new KoudenError(error.message || `${context} failed`, ErrorCodes.UNKNOWN_ERROR, {
-				userMessage: `${context}に失敗しました。`,
-				cause: error,
-			});
-		}
+		const userMessage = `${context}に失敗しました。`;
+		const originalMessage =
+			error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 
-		return new KoudenError(
-			typeof error === "string" ? error : `${context} failed`,
-			ErrorCodes.UNKNOWN_ERROR,
-			{
-				userMessage: `${context}に失敗しました。`,
-				cause: error,
-			},
-		);
+		return new KoudenError(userMessage, ErrorCodes.UNKNOWN_ERROR, {
+			userMessage,
+			details: originalMessage !== undefined ? { originalMessage } : undefined,
+			cause: error,
+		});
 	}
 }
 

--- a/src/utils/__tests__/get-error-message.test.ts
+++ b/src/utils/__tests__/get-error-message.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="vitest" />
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+	default: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { getErrorMessage } from "../get-error-message";
+
+describe("getErrorMessage", () => {
+	it("KoudenError は userMessage を返す", () => {
+		const err = new KoudenError("internal", ErrorCodes.UNAUTHORIZED);
+		expect(getErrorMessage(err)).toBe("認証が必要です。ログインしてください。");
+	});
+
+	it("英語の既知メッセージを日本語に翻訳する", () => {
+		expect(getErrorMessage(new Error("Something went wrong"))).toBe("予期せぬエラーが発生しました");
+		expect(getErrorMessage(new Error("User not authenticated."))).toBe("認証が必要です");
+		expect(getErrorMessage(new Error("Not found"))).toBe("対象のデータが見つかりませんでした");
+	});
+
+	it("部分一致の英語メッセージも翻訳する", () => {
+		expect(getErrorMessage(new Error("Failed to fetch"))).toBe("通信エラーが発生しました");
+	});
+
+	it("未知の日本語メッセージはそのまま返す", () => {
+		expect(getErrorMessage(new Error("独自のエラーメッセージ"))).toBe("独自のエラーメッセージ");
+	});
+
+	it("文字列エラーも受け取る", () => {
+		expect(getErrorMessage("Something went wrong")).toBe("予期せぬエラーが発生しました");
+	});
+
+	it("nullや未知の型の場合は既定メッセージを返す", () => {
+		expect(getErrorMessage(null)).toBe("予期せぬエラーが発生しました");
+		expect(getErrorMessage(undefined)).toBe("予期せぬエラーが発生しました");
+		expect(getErrorMessage(123)).toBe("予期せぬエラーが発生しました");
+	});
+
+	it("message プロパティを持つオブジェクトを受け取る", () => {
+		expect(getErrorMessage({ message: "Network error" })).toBe("通信エラーが発生しました");
+	});
+});

--- a/src/utils/get-error-message.ts
+++ b/src/utils/get-error-message.ts
@@ -13,7 +13,10 @@ const ENGLISH_TO_JAPANESE_MESSAGES: Array<{ pattern: RegExp; translation: string
 	{ pattern: /^forbidden$/i, translation: "この操作を行う権限がありません" },
 	{ pattern: /^not found$/i, translation: "対象のデータが見つかりませんでした" },
 	{ pattern: /failed to fetch/i, translation: "通信エラーが発生しました" },
-	{ pattern: /timeout/i, translation: "通信がタイムアウトしました" },
+	{
+		pattern: /(?:request\s+timeout|timeout\s+occurred|timed?\s+out)/i,
+		translation: "通信がタイムアウトしました",
+	},
 ];
 
 function translateEnglishMessage(message: string): string {

--- a/src/utils/get-error-message.ts
+++ b/src/utils/get-error-message.ts
@@ -1,15 +1,55 @@
-export const getErrorMessage = (error: unknown): string => {
-	let message: string;
+import { KoudenError } from "@/lib/errors";
 
+/**
+ * よくある英語エラーメッセージの日本語訳。
+ * 完全一致と部分一致の両方で使用する。
+ */
+const ENGLISH_TO_JAPANESE_MESSAGES: Array<{ pattern: RegExp; translation: string }> = [
+	{ pattern: /^something went wrong$/i, translation: "予期せぬエラーが発生しました" },
+	{ pattern: /^network error$/i, translation: "通信エラーが発生しました" },
+	{ pattern: /^not authenticated$/i, translation: "認証が必要です" },
+	{ pattern: /^user not authenticated\.?$/i, translation: "認証が必要です" },
+	{ pattern: /^unauthorized$/i, translation: "認証が必要です" },
+	{ pattern: /^forbidden$/i, translation: "この操作を行う権限がありません" },
+	{ pattern: /^not found$/i, translation: "対象のデータが見つかりませんでした" },
+	{ pattern: /failed to fetch/i, translation: "通信エラーが発生しました" },
+	{ pattern: /timeout/i, translation: "通信がタイムアウトしました" },
+];
+
+function translateEnglishMessage(message: string): string {
+	for (const { pattern, translation } of ENGLISH_TO_JAPANESE_MESSAGES) {
+		if (pattern.test(message)) return translation;
+	}
+	return message;
+}
+
+/**
+ * 任意のエラー値からユーザーに表示するメッセージを取得する。
+ *
+ * 優先順位:
+ * 1. `KoudenError` の場合 → `userMessage` をそのまま返す
+ * 2. `Error` インスタンスの場合 → `message` を日本語に翻訳して返す
+ * 3. `{ message: string }` の場合 → `message` を日本語に翻訳して返す
+ * 4. 文字列の場合 → 日本語に翻訳して返す
+ * 5. それ以外 → 既定メッセージ
+ */
+export const getErrorMessage = (error: unknown): string => {
+	if (error instanceof KoudenError) {
+		return error.userMessage;
+	}
+
+	let message: string;
 	if (error instanceof Error) {
 		message = error.message;
 	} else if (error && typeof error === "object" && "message" in error) {
-		message = String(error.message);
+		message = String((error as { message: unknown }).message);
 	} else if (typeof error === "string") {
 		message = error;
 	} else {
-		message = "Something went wrong";
+		return "予期せぬエラーが発生しました";
 	}
 
-	return message;
+	if (!message) return "予期せぬエラーが発生しました";
+
+	return translateEnglishMessage(message);
 };


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive error handling system with structured error codes, automatic HTTP status mapping, and user-friendly error messages. The new system provides better error categorization, Supabase error translation, and unified error handling utilities for both exception-based and result-based patterns.

## Key Changes

- **Structured Error Codes**: Added `ErrorCodes` constant with categorized error codes (AUTH, RESOURCE, VALIDATION, DB, PAYMENT, NETWORK, UNKNOWN)
- **Enhanced KoudenError Class**: 
  - Automatic HTTP status mapping based on error code
  - User-friendly Japanese messages for end-users
  - Support for error details and cause tracking
  - New static methods: `fromSupabase()` and `from()` for error conversion
- **Supabase Error Translation**: Added `SUPABASE_ERROR_CODE_MAP` to convert PostgREST and PostgreSQL error codes to application error codes
- **Error Handling Utilities**:
  - `withErrorHandling()`: Exception-based error handling with automatic logging
  - `withActionResult()`: Result-based error handling for Server Actions
  - `toActionError()`: Convert errors to standardized ActionResult format
- **ActionResult Type**: New discriminated union type for Server Action responses (`{ ok: true; data: T }` or `{ ok: false; error: {...} }`)
- **Improved getErrorMessage()**: Enhanced to handle KoudenError instances and translate common English error messages to Japanese
- **Comprehensive Tests**: Added test suites for error handling, Supabase error translation, and message translation

## Implementation Details

- Error codes are organized by category with clear prefixes (AUTH_, RESOURCE_, VALIDATION_, DB_, PAYMENT_)
- Default HTTP status codes and user messages are automatically determined from error codes
- Supabase errors are automatically detected and mapped to application error codes with context-aware messages
- All error handling functions include structured logging with error code, status, and details
- Backward compatibility maintained: `KoudenError` constructor accepts numeric status as third argument
- Updated `relationships.ts` to use new error handling utilities, removing redundant error logging

https://claude.ai/code/session_01C4ZN8yWosmpUK3CdyF3cwU
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/otomatty/kouden/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * サーバー側のエラーハンドリングを全面的に改善し、認可/認証失敗やデータ未取得時の挙動を一貫化しました（より確実で明確なエラー応答）。
  * 削除操作を冪等化し、既存データの欠如を正常終了として扱うようにしました。

* **New Features**
  * サーバーアクション向けにエラーを安全に返す新しい結果形式を導入しました。

* **Tests**
  * エラー処理とメッセージ翻訳の包括的なテストを追加しました。

* **Style**
  * エラーメッセージの英語→日本語翻訳を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->