### PR TITLE
fix(security): CSRF Cookie を HttpOnly 化し Double-submit パターンへ整備 (#33)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,9 @@ GOOGLE_SERVICE_ACCOUNT_EMAIL=
 GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY=
 
 # セキュリティ強化
-CSRF_SECRET= #自身で発行する
+# CSRF_SECRET: 必須・最低32文字。未設定だとアプリは起動失敗する。
+# 生成例: openssl rand -hex 32
+CSRF_SECRET=
 SLACK_WEBHOOK_URL= #オプションで設定するかも?
 SECURITY_LOG_LEVEL="info" #本番環境では空にするかfalseにする
 MAX_FILE_SIZE="10485760" #10MB

--- a/docs/security/environment-variables.md
+++ b/docs/security/environment-variables.md
@@ -19,12 +19,18 @@ ADMIN_BASIC_PASSWORD="your-strong-password-here"
 
 ### CSRF保護
 ```bash
-# CSRF攻撃防止用の秘密鍵（必須・本番環境では必ず変更）
-CSRF_SECRET="your-csrf-secret-key-change-in-production"
+# CSRF攻撃防止用の秘密鍵（必須・最低32文字・全環境で必ず設定すること）
+# 未設定 or 32文字未満の場合、アプリケーションは起動時にエラーで停止する。
+# 生成例: openssl rand -hex 32
+CSRF_SECRET="<openssl rand -hex 32 で生成した値>"
 
-# 開発環境でのCSRF保護デバッグ（オプション）
+# 開発環境でのCSRF保護デバッグ（オプション・development限定）
+# ⚠️ 本番環境では絶対に "true" にしないこと。
+#    NODE_ENV !== "development" の場合は無視される。
 CSRF_DEBUG="false"
 ```
+
+CSRF実装はDouble-submit Cookieパターンを採用しており、リクエスト時にCookie (`csrf-token`) とHTTPヘッダー (`X-CSRF-Token`) の両方が必須かつ値一致を要求する。クライアントは `/api/csrf-token` のJSONレスポンスからトークンを取得し、`X-CSRF-Token` ヘッダーで送信する。CookieはHttpOnly属性付きで発行され、JavaScriptから読み取れない。
 
 ### セキュリティアラート通知
 ```bash

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -3,12 +3,20 @@
  * フロントエンドからCSRFトークンを取得するためのエンドポイント
  */
 
-import { generateCSRFToken } from "@/lib/security/csrf-protection";
+import { generateCSRFToken, verifyCSRFToken } from "@/lib/security/csrf-protection";
+import type { NextRequest } from "next/server";
 import logger from "@/lib/logger";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
 	try {
-		const token = await generateCSRFToken();
+		// 既存の csrf-token Cookie が有効ならそれを再利用する。
+		// これにより複数タブで同時に /api/csrf-token を呼んだ際に
+		// Cookieが上書きされて他タブのトークンが失効する競合を防止する。
+		const existingToken = request.cookies.get("csrf-token")?.value;
+		const token =
+			existingToken && (await verifyCSRFToken(existingToken))
+				? existingToken
+				: await generateCSRFToken();
 
 		// JSONレスポンス: クライアントはここからトークンを取得し、X-CSRF-Token ヘッダーで送信する。
 		// Cache-Control: no-store でブラウザ・中間キャッシュからのトークン再利用を防止。

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -3,20 +3,54 @@
  * フロントエンドからCSRFトークンを取得するためのエンドポイント
  */
 
-import { generateCSRFToken, verifyCSRFToken } from "@/lib/security/csrf-protection";
+import {
+	CSRF_TOKEN_TTL_MS,
+	generateCSRFToken,
+	getCSRFTokenRemainingTTL,
+	verifyCSRFToken,
+} from "@/lib/security/csrf-protection";
 import type { NextRequest } from "next/server";
 import logger from "@/lib/logger";
 
+// 残存TTLがこの値未満の既存トークンは再利用せず、新規生成する。
+// 取得直後のフォーム送信が短時間で失効するのを防ぐため。
+const REUSE_MIN_REMAINING_MS = 5 * 60 * 1000;
+
+/**
+ * CSRFトークン配布エンドポイント。
+ *
+ * - 受信した `csrf-token` Cookie が署名・タイムスタンプともに有効、かつ
+ *   残存TTLが {@link REUSE_MIN_REMAINING_MS} を上回るときは、それを再利用する
+ *   （複数タブ間でトークンを安定化させる）。
+ * - それ以外（欠落・改ざん・期限切れ・残り少）は新規発行する。
+ * - レスポンスは JSON ボディの `csrfToken` と、同値の `Set-Cookie`
+ *   (`HttpOnly` / `SameSite=Strict` / 本番のみ `Secure`) で返す。
+ * - Cookie の `Max-Age` はトークン署名の残存TTLと一致させ、Cookieが
+ *   トークン本体より長生きしないようにする（残存超過時の 403 を防止）。
+ *
+ * @param request 受信リクエスト（Cookie の再利用判定に使用）
+ * @returns 200 with JSON body & Set-Cookie ／ 失敗時 500
+ */
 export async function GET(request: NextRequest) {
 	try {
-		// 既存の csrf-token Cookie が有効ならそれを再利用する。
-		// これにより複数タブで同時に /api/csrf-token を呼んだ際に
-		// Cookieが上書きされて他タブのトークンが失効する競合を防止する。
 		const existingToken = request.cookies.get("csrf-token")?.value;
-		const token =
-			existingToken && (await verifyCSRFToken(existingToken))
-				? existingToken
-				: await generateCSRFToken();
+
+		let token: string;
+		let cookieMaxAgeSec: number;
+
+		if (existingToken && (await verifyCSRFToken(existingToken))) {
+			const remainingMs = getCSRFTokenRemainingTTL(existingToken);
+			if (remainingMs !== null && remainingMs > REUSE_MIN_REMAINING_MS) {
+				token = existingToken;
+				cookieMaxAgeSec = Math.floor(remainingMs / 1000);
+			} else {
+				token = await generateCSRFToken();
+				cookieMaxAgeSec = Math.floor(CSRF_TOKEN_TTL_MS / 1000);
+			}
+		} else {
+			token = await generateCSRFToken();
+			cookieMaxAgeSec = Math.floor(CSRF_TOKEN_TTL_MS / 1000);
+		}
 
 		// JSONレスポンス: クライアントはここからトークンを取得し、X-CSRF-Token ヘッダーで送信する。
 		// Cache-Control: no-store でブラウザ・中間キャッシュからのトークン再利用を防止。
@@ -38,10 +72,11 @@ export async function GET(request: NextRequest) {
 
 		// CSRFトークンをCookieに設定（Double-submit Cookieパターンで使用）
 		// HttpOnly: JSからの読み取り防止。クライアントはJSONレスポンスから取得済み。
+		// Max-Age: トークン署名の残存TTLに揃え、Cookieがトークンより長生きしないようにする。
 		const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
 		response.headers.set(
 			"Set-Cookie",
-			`csrf-token=${token}; Path=/; HttpOnly; SameSite=Strict;${secureFlag} Max-Age=3600`,
+			`csrf-token=${token}; Path=/; HttpOnly; SameSite=Strict;${secureFlag} Max-Age=${cookieMaxAgeSec}`,
 		);
 
 		return response;

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -5,6 +5,16 @@
 
 import logger from "@/lib/logger";
 
+/**
+ * 起動時に `CSRF_SECRET` 環境変数を検証して返す。
+ *
+ * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
+ *   サーバー起動を停止する（フェイルクローズド）。
+ * - 推奨生成方法: `openssl rand -hex 32`
+ *
+ * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
+ * @returns 検証済みのCSRF秘密鍵
+ */
 function getCSRFSecret(): string {
 	const secret = process.env.CSRF_SECRET;
 	if (!secret || secret.length < 32) {
@@ -63,6 +73,9 @@ export async function GET() {
 				status: 200,
 				headers: {
 					"Content-Type": "application/json",
+					"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+					Pragma: "no-cache",
+					Expires: "0",
 				},
 			},
 		);

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -3,67 +3,15 @@
  * フロントエンドからCSRFトークンを取得するためのエンドポイント
  */
 
+import { generateCSRFToken } from "@/lib/security/csrf-protection";
 import logger from "@/lib/logger";
-
-/**
- * 起動時に `CSRF_SECRET` 環境変数を検証して返す。
- *
- * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
- *   サーバー起動を停止する（フェイルクローズド）。
- * - 推奨生成方法: `openssl rand -hex 32`
- *
- * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
- * @returns 検証済みのCSRF秘密鍵
- */
-function getCSRFSecret(): string {
-	const secret = process.env.CSRF_SECRET;
-	if (!secret || secret.length < 32) {
-		throw new Error(
-			"CSRF_SECRET environment variable is not set or too short (require >= 32 chars). " +
-				"Generate one with: openssl rand -hex 32",
-		);
-	}
-	return secret;
-}
-
-const CSRF_SECRET = getCSRFSecret();
-
-/**
- * Web Crypto APIを使ってSHA-256ハッシュを生成
- */
-async function createSha256Hash(data: string): Promise<string> {
-	const encoder = new TextEncoder();
-	const dataBuffer = encoder.encode(data);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
-	const hashArray = Array.from(new Uint8Array(hashBuffer));
-	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-/**
- * ランダムなトークンを生成（Web Crypto API使用）
- */
-function generateRandomToken(): string {
-	const array = new Uint8Array(32);
-	crypto.getRandomValues(array);
-	return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-/**
- * CSRFトークンを生成（サーバーサイド専用）
- */
-async function generateCSRFToken(): Promise<string> {
-	const token = generateRandomToken();
-	const timestamp = Date.now().toString();
-	const signature = await createSha256Hash(`${token}:${timestamp}:${CSRF_SECRET}`);
-
-	return `${token}:${timestamp}:${signature}`;
-}
 
 export async function GET() {
 	try {
 		const token = await generateCSRFToken();
 
-		// Cookieに設定（HttpOnly有効。クライアントはJSONレスポンスから取得し、X-CSRF-Tokenヘッダーで送信する）
+		// JSONレスポンス: クライアントはここからトークンを取得し、X-CSRF-Token ヘッダーで送信する。
+		// Cache-Control: no-store でブラウザ・中間キャッシュからのトークン再利用を防止。
 		const response = new Response(
 			JSON.stringify({
 				csrfToken: token,
@@ -81,6 +29,7 @@ export async function GET() {
 		);
 
 		// CSRFトークンをCookieに設定（Double-submit Cookieパターンで使用）
+		// HttpOnly: JSからの読み取り防止。クライアントはJSONレスポンスから取得済み。
 		const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
 		response.headers.set(
 			"Set-Cookie",

--- a/src/app/api/csrf-token/route.ts
+++ b/src/app/api/csrf-token/route.ts
@@ -5,7 +5,18 @@
 
 import logger from "@/lib/logger";
 
-const CSRF_SECRET = process.env.CSRF_SECRET || "default-secret-change-in-production";
+function getCSRFSecret(): string {
+	const secret = process.env.CSRF_SECRET;
+	if (!secret || secret.length < 32) {
+		throw new Error(
+			"CSRF_SECRET environment variable is not set or too short (require >= 32 chars). " +
+				"Generate one with: openssl rand -hex 32",
+		);
+	}
+	return secret;
+}
+
+const CSRF_SECRET = getCSRFSecret();
 
 /**
  * Web Crypto APIを使ってSHA-256ハッシュを生成
@@ -42,7 +53,7 @@ export async function GET() {
 	try {
 		const token = await generateCSRFToken();
 
-		// Cookieに設定（HttpOnly falseでJavaScriptからアクセス可能）
+		// Cookieに設定（HttpOnly有効。クライアントはJSONレスポンスから取得し、X-CSRF-Tokenヘッダーで送信する）
 		const response = new Response(
 			JSON.stringify({
 				csrfToken: token,
@@ -56,12 +67,11 @@ export async function GET() {
 			},
 		);
 
-		// CSRFトークンをCookieに設定
+		// CSRFトークンをCookieに設定（Double-submit Cookieパターンで使用）
+		const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
 		response.headers.set(
 			"Set-Cookie",
-			`csrf-token=${token}; Path=/; HttpOnly=false; SameSite=Strict; Secure=${
-				process.env.NODE_ENV === "production"
-			}; Max-Age=3600`,
+			`csrf-token=${token}; Path=/; HttpOnly; SameSite=Strict;${secureFlag} Max-Age=3600`,
 		);
 
 		return response;

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -18,7 +18,18 @@ import { createHash, randomBytes } from "node:crypto";
 import type { NextRequest } from "next/server";
 import logger from "@/lib/logger";
 
-const CSRF_SECRET = process.env.CSRF_SECRET || "default-secret-change-in-production";
+function getCSRFSecret(): string {
+	const secret = process.env.CSRF_SECRET;
+	if (!secret || secret.length < 32) {
+		throw new Error(
+			"CSRF_SECRET environment variable is not set or too short (require >= 32 chars). " +
+				"Generate one with: openssl rand -hex 32",
+		);
+	}
+	return secret;
+}
+
+const CSRF_SECRET = getCSRFSecret();
 
 /**
  * CSRFトークンを生成（サーバーサイド専用）
@@ -86,27 +97,47 @@ export function checkCSRFToken(request: NextRequest): boolean {
 		return true;
 	}
 
-	// 開発環境では緩和（デバッグ用）
+	// 開発環境では緩和（デバッグ用、本番では絶対に有効化しないこと）
 	if (process.env.NODE_ENV === "development" && process.env.CSRF_DEBUG === "true") {
-		logger.warn({}, "CSRF protection is disabled in development mode");
+		logger.error(
+			{
+				nodeEnv: process.env.NODE_ENV,
+				pid: process.pid,
+			},
+			"[CSRF_DEBUG] CSRF protection is DISABLED. NEVER enable this in production.",
+		);
 		return true;
 	}
 
-	// CSRFトークンを取得（ヘッダーまたはCookieから）
-	const csrfToken = request.headers.get("x-csrf-token") || request.cookies.get("csrf-token")?.value;
+	// Double-submit Cookie パターン: ヘッダーとCookieの両方が必須かつ値一致を要求
+	const headerToken = request.headers.get("x-csrf-token");
+	const cookieToken = request.cookies.get("csrf-token")?.value;
 
-	if (!csrfToken) {
+	if (!headerToken || !cookieToken) {
+		logger.warn(
+			{
+				pathname: request.nextUrl.pathname,
+				method: request.method,
+				hasHeader: Boolean(headerToken),
+				hasCookie: Boolean(cookieToken),
+			},
+			"CSRF token is missing (header or cookie)",
+		);
+		return false;
+	}
+
+	if (headerToken !== cookieToken) {
 		logger.warn(
 			{
 				pathname: request.nextUrl.pathname,
 				method: request.method,
 			},
-			"CSRF token is missing",
+			"CSRF token mismatch between header and cookie",
 		);
 		return false;
 	}
 
-	const isValid = verifyCSRFToken(csrfToken);
+	const isValid = verifyCSRFToken(headerToken);
 	if (!isValid) {
 		logger.warn(
 			{

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -220,7 +220,10 @@ export async function checkCSRFToken(request: NextRequest): Promise<boolean> {
 export function requiresCSRFProtection(pathname: string): boolean {
 	if (pathname.startsWith("/api/")) {
 		const exemptPaths = ["/api/stripe/webhook", "/api/health", "/api/csrf-token"];
-		return !exemptPaths.some((path) => pathname.startsWith(path));
+		// 完全一致または明示的なサブルート（`path + "/"`）のみを除外対象とする。
+		// 単純な startsWith だと "/api/csrf-tokenize" のような prefix 一致パスまで
+		// 誤って除外されてしまうため。
+		return !exemptPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`));
 	}
 
 	// Server Actions は Next.js が自動でCSRF保護するため対象外

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -18,6 +18,16 @@ import { createHash, randomBytes } from "node:crypto";
 import type { NextRequest } from "next/server";
 import logger from "@/lib/logger";
 
+/**
+ * 起動時に `CSRF_SECRET` 環境変数を検証して返す。
+ *
+ * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
+ *   Node.jsプロセス起動を停止する（フェイルクローズド）。
+ * - 推奨生成方法: `openssl rand -hex 32`
+ *
+ * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
+ * @returns 検証済みのCSRF秘密鍵
+ */
 function getCSRFSecret(): string {
 	const secret = process.env.CSRF_SECRET;
 	if (!secret || secret.length < 32) {
@@ -92,8 +102,8 @@ export function verifyCSRFToken(token: string): boolean {
  * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
 export function checkCSRFToken(request: NextRequest): boolean {
-	// GETリクエストはスキップ
-	if (request.method === "GET") {
+	// 安全メソッド（副作用なし）はスキップ。HEAD/OPTIONS（preflight）も含める。
+	if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") {
 		return true;
 	}
 

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -42,6 +42,31 @@ export function getCSRFSecret(): string {
 const CSRF_SECRET = getCSRFSecret();
 
 /**
+ * CSRFトークンの署名有効期間（ミリ秒）。
+ * Cookie の `Max-Age` を残存TTLに合わせる用途でも使用する。
+ */
+export const CSRF_TOKEN_TTL_MS = 3600 * 1000;
+
+/**
+ * 指定トークンの残存TTL（ミリ秒）を返す。期限切れ・改ざんなど無効なら `null`。
+ *
+ * @param token 検証済みのCSRFトークン
+ * @returns 残存TTL（ms）または `null`
+ */
+export function getCSRFTokenRemainingTTL(token: string): number | null {
+	const parts = token.split(":");
+	if (parts.length !== 3) {
+		return null;
+	}
+	const tokenTime = Number.parseInt(parts[1] ?? "");
+	if (Number.isNaN(tokenTime)) {
+		return null;
+	}
+	const remaining = CSRF_TOKEN_TTL_MS - (Date.now() - tokenTime);
+	return remaining > 0 ? remaining : null;
+}
+
+/**
  * Web Crypto APIでSHA-256ハッシュを生成し、16進文字列で返す。
  *
  * @param data ハッシュ化する文字列

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -1,34 +1,34 @@
 /**
- * CSRF保護機能（サーバーサイド専用）
+ * CSRF保護機能（Edge Runtime / Node.js 両対応）
  * Cross-Site Request Forgery攻撃を防止するためのトークン管理
  *
- * ⚠️ 【重要警告】: このファイルは絶対にクライアントサイドからインポートしないこと！
- * - API routes、Server Actions、Middlewareでのみ使用可能
- * - node:cryptoがブラウザで動作しないため、クライアントサイドでバンドルするとエラーになる
- * - クライアントサイドではCSRF Providerとuse-csrf-tokenフックを使用すること
- *
- * 使用可能場所：
- * ✅ src/app/api/*.ts (API routes)
- * ✅ src/middleware.ts
+ * Web Crypto API（`globalThis.crypto`）を使用しているため、以下すべてで利用可能：
+ * ✅ API routes (src/app/api/*)
+ * ✅ Middleware (src/middleware.ts, Edge Runtime)
  * ✅ Server Actions (_actions/admin/*.ts)
- * ❌ コンポーネント、フック、クライアント側プロバイダー
+ *
+ * クライアントサイドからは絶対にインポートしないこと（CSRF_SECRETがバンドルに含まれてしまうため）。
+ * クライアントではCSRF Providerとuse-csrf-tokenフックを使用すること。
+ *
+ * Double-submit Cookie パターン:
+ *   - `csrf-token` Cookie と `X-CSRF-Token` ヘッダーの両方が必須かつ値一致を要求
+ *   - クライアントは `/api/csrf-token` のJSONレスポンスからトークンを取得し、ヘッダーで送信
+ *   - CookieはHttpOnlyで発行され、JavaScriptから読めない
  */
 
-import { createHash, randomBytes } from "node:crypto";
 import type { NextRequest } from "next/server";
-import logger from "@/lib/logger";
 
 /**
  * 起動時に `CSRF_SECRET` 環境変数を検証して返す。
  *
  * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
- *   Node.jsプロセス起動を停止する（フェイルクローズド）。
+ *   プロセス起動を停止する（フェイルクローズド）。
  * - 推奨生成方法: `openssl rand -hex 32`
  *
  * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
  * @returns 検証済みのCSRF秘密鍵
  */
-function getCSRFSecret(): string {
+export function getCSRFSecret(): string {
 	const secret = process.env.CSRF_SECRET;
 	if (!secret || secret.length < 32) {
 		throw new Error(
@@ -42,31 +42,52 @@ function getCSRFSecret(): string {
 const CSRF_SECRET = getCSRFSecret();
 
 /**
- * CSRFトークンを生成（サーバーサイド専用）
- * タイムスタンプと署名を含む安全なトークンを作成
+ * Web Crypto APIでSHA-256ハッシュを生成し、16進文字列で返す。
+ *
+ * @param data ハッシュ化する文字列
+ * @returns SHA-256ハッシュの16進表現（64文字）
+ */
+async function createSha256Hash(data: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const dataBuffer = encoder.encode(data);
+	const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+	const hashArray = Array.from(new Uint8Array(hashBuffer));
+	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * ランダムな32バイトトークンを16進で生成する（Web Crypto API使用）。
+ *
+ * @returns 64文字の16進ランダム文字列
+ */
+function generateRandomToken(): string {
+	const array = new Uint8Array(32);
+	crypto.getRandomValues(array);
+	return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * CSRFトークンを生成する。
+ * フォーマット: `<random>:<timestamp>:<sha256-signature>`
  *
  * @returns 署名付きCSRFトークン
- * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
-export function generateCSRFToken(): string {
-	const token = randomBytes(32).toString("hex");
+export async function generateCSRFToken(): Promise<string> {
+	const token = generateRandomToken();
 	const timestamp = Date.now().toString();
-	const signature = createHash("sha256")
-		.update(`${token}:${timestamp}:${CSRF_SECRET}`)
-		.digest("hex");
+	const signature = await createSha256Hash(`${token}:${timestamp}:${CSRF_SECRET}`);
 
 	return `${token}:${timestamp}:${signature}`;
 }
 
 /**
- * CSRFトークンを検証（サーバーサイド専用）
- * タイムスタンプと署名の整合性をチェック
+ * CSRFトークンを検証する。
+ * タイムスタンプ（1時間以内）と署名の整合性をチェック。
  *
  * @param token 検証するCSRFトークン
  * @returns トークンが有効かどうか
- * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
-export function verifyCSRFToken(token: string): boolean {
+export async function verifyCSRFToken(token: string): Promise<boolean> {
 	try {
 		const [tokenPart, timestamp, signature] = token.split(":");
 
@@ -78,14 +99,11 @@ export function verifyCSRFToken(token: string): boolean {
 		const tokenTime = Number.parseInt(timestamp);
 		const now = Date.now();
 		if (now - tokenTime > 3600000) {
-			// 1時間
 			return false;
 		}
 
 		// 署名検証
-		const expectedSignature = createHash("sha256")
-			.update(`${tokenPart}:${timestamp}:${CSRF_SECRET}`)
-			.digest("hex");
+		const expectedSignature = await createSha256Hash(`${tokenPart}:${timestamp}:${CSRF_SECRET}`);
 
 		return signature === expectedSignature;
 	} catch {
@@ -94,14 +112,16 @@ export function verifyCSRFToken(token: string): boolean {
 }
 
 /**
- * リクエストのCSRFトークンをチェック
- * GETリクエストはスキップし、POST等でトークンを検証
+ * リクエストのCSRFトークンをチェックする（Double-submit Cookieパターン）。
+ *
+ * - 安全メソッド（GET / HEAD / OPTIONS）はスキップ
+ * - 開発環境で `CSRF_DEBUG=true` のときはバイパス（本番禁止）
+ * - ヘッダー `x-csrf-token` と Cookie `csrf-token` の両方が必須かつ値一致を要求
  *
  * @param request NextRequest オブジェクト
  * @returns CSRF検証結果
- * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
-export function checkCSRFToken(request: NextRequest): boolean {
+export async function checkCSRFToken(request: NextRequest): Promise<boolean> {
 	// 安全メソッド（副作用なし）はスキップ。HEAD/OPTIONS（preflight）も含める。
 	if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") {
 		return true;
@@ -109,12 +129,8 @@ export function checkCSRFToken(request: NextRequest): boolean {
 
 	// 開発環境では緩和（デバッグ用、本番では絶対に有効化しないこと）
 	if (process.env.NODE_ENV === "development" && process.env.CSRF_DEBUG === "true") {
-		logger.error(
-			{
-				nodeEnv: process.env.NODE_ENV,
-				pid: process.pid,
-			},
-			"[CSRF_DEBUG] CSRF protection is DISABLED. NEVER enable this in production.",
+		console.error(
+			`[CSRF_DEBUG] CSRF protection is DISABLED (NODE_ENV=${process.env.NODE_ENV}). NEVER enable this in production.`,
 		);
 		return true;
 	}
@@ -124,37 +140,23 @@ export function checkCSRFToken(request: NextRequest): boolean {
 	const cookieToken = request.cookies.get("csrf-token")?.value;
 
 	if (!headerToken || !cookieToken) {
-		logger.warn(
-			{
-				pathname: request.nextUrl.pathname,
-				method: request.method,
-				hasHeader: Boolean(headerToken),
-				hasCookie: Boolean(cookieToken),
-			},
-			"CSRF token is missing (header or cookie)",
+		console.warn(
+			`CSRF token is missing (header or cookie). pathname=${request.nextUrl.pathname} method=${request.method}`,
 		);
 		return false;
 	}
 
 	if (headerToken !== cookieToken) {
-		logger.warn(
-			{
-				pathname: request.nextUrl.pathname,
-				method: request.method,
-			},
-			"CSRF token mismatch between header and cookie",
+		console.warn(
+			`CSRF token mismatch between header and cookie. pathname=${request.nextUrl.pathname} method=${request.method}`,
 		);
 		return false;
 	}
 
-	const isValid = verifyCSRFToken(headerToken);
+	const isValid = await verifyCSRFToken(headerToken);
 	if (!isValid) {
-		logger.warn(
-			{
-				pathname: request.nextUrl.pathname,
-				method: request.method,
-			},
-			"CSRF token validation failed",
+		console.warn(
+			`CSRF token validation failed. pathname=${request.nextUrl.pathname} method=${request.method}`,
 		);
 	}
 
@@ -162,29 +164,29 @@ export function checkCSRFToken(request: NextRequest): boolean {
 }
 
 /**
- * CSRF保護が必要なパスかどうかを判定
+ * CSRF保護が必要なパスかどうかを判定する。
+ *
+ * - `/api/*` はデフォルトで保護対象（一部例外あり）
+ * - 例外: `/api/stripe/webhook`, `/api/health`, `/api/csrf-token`
+ * - Server Actions は Next.js のビルトインCSRF保護に委ねるため対象外
  *
  * @param pathname リクエストパス
  * @returns CSRF保護が必要かどうか
- * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
 export function requiresCSRFProtection(pathname: string): boolean {
-	// API routes
 	if (pathname.startsWith("/api/")) {
-		// CSRF保護が不要なAPI（webhook等）
 		const exemptPaths = ["/api/stripe/webhook", "/api/health", "/api/csrf-token"];
 		return !exemptPaths.some((path) => pathname.startsWith(path));
 	}
 
-	// Server Actions（POST/PUT/DELETE等）
-	return true;
+	// Server Actions は Next.js が自動でCSRF保護するため対象外
+	return false;
 }
 
 /**
- * CSRFエラーレスポンス用のヘルパー
+ * CSRF検証失敗時の 403 レスポンス。
  *
  * @returns 403 Forbiddenレスポンス
- * @serverOnly このファイルはサーバーサイドでのみ使用可能
  */
 export function createCSRFErrorResponse(): Response {
 	return new Response("CSRF token validation failed", {

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -106,6 +106,25 @@ export async function generateCSRFToken(): Promise<string> {
 }
 
 /**
+ * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
+ * 短絡評価せず全文字をXORして集約することで、最初の不一致位置を漏らさない。
+ *
+ * @param a 比較対象A
+ * @param b 比較対象B
+ * @returns 完全一致なら true
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) {
+		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return diff === 0;
+}
+
+/**
  * CSRFトークンを検証する。
  * タイムスタンプ（1時間以内）と署名の整合性をチェック。
  *
@@ -120,17 +139,17 @@ export async function verifyCSRFToken(token: string): Promise<boolean> {
 			return false;
 		}
 
-		// タイムスタンプチェック（1時間以内）
+		// タイムスタンプチェック（CSRF_TOKEN_TTL_MS 以内）
 		const tokenTime = Number.parseInt(timestamp);
 		const now = Date.now();
-		if (now - tokenTime > 3600000) {
+		if (now - tokenTime > CSRF_TOKEN_TTL_MS) {
 			return false;
 		}
 
-		// 署名検証
+		// 署名検証（タイミング攻撃を防ぐため定数時間比較）
 		const expectedSignature = await createSha256Hash(`${tokenPart}:${timestamp}:${CSRF_SECRET}`);
 
-		return signature === expectedSignature;
+		return timingSafeEqual(signature, expectedSignature);
 	} catch {
 		return false;
 	}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,18 @@ import { rateLimit } from "@/lib/security/rate-limiting";
 import { logRateLimitExceeded, logSuspiciousActivity } from "@/lib/security/security-logger";
 // 2FAチェックはMiddlewareではなくページレベルで実行（Edge Runtime制限のため）
 
-const CSRF_SECRET = process.env.CSRF_SECRET || "default-secret-change-in-production";
+function getCSRFSecret(): string {
+	const secret = process.env.CSRF_SECRET;
+	if (!secret || secret.length < 32) {
+		throw new Error(
+			"CSRF_SECRET environment variable is not set or too short (require >= 32 chars). " +
+				"Generate one with: openssl rand -hex 32",
+		);
+	}
+	return secret;
+}
+
+const CSRF_SECRET = getCSRFSecret();
 
 /**
  * Web Crypto APIを使ってSHA-256ハッシュを生成
@@ -58,21 +69,29 @@ async function checkCSRFToken(request: NextRequest): Promise<boolean> {
 		return true;
 	}
 
-	// 開発環境では緩和（デバッグ用）
+	// 開発環境では緩和（デバッグ用、本番では絶対に有効化しないこと）
 	if (process.env.NODE_ENV === "development" && process.env.CSRF_DEBUG === "true") {
-		console.warn("CSRF protection is disabled in development mode");
+		console.error(
+			`[CSRF_DEBUG] CSRF protection is DISABLED (NODE_ENV=${process.env.NODE_ENV}, pid=${typeof process !== "undefined" ? process.pid : "n/a"}). NEVER enable this in production.`,
+		);
 		return true;
 	}
 
-	// CSRFトークンを取得（ヘッダーまたはCookieから）
-	const csrfToken = request.headers.get("x-csrf-token") || request.cookies.get("csrf-token")?.value;
+	// Double-submit Cookie パターン: ヘッダーとCookieの両方が必須かつ値一致を要求
+	const headerToken = request.headers.get("x-csrf-token");
+	const cookieToken = request.cookies.get("csrf-token")?.value;
 
-	if (!csrfToken) {
-		console.warn("CSRF token is missing");
+	if (!headerToken || !cookieToken) {
+		console.warn("CSRF token is missing (header or cookie)");
 		return false;
 	}
 
-	const isValid = await verifyCSRFToken(csrfToken);
+	if (headerToken !== cookieToken) {
+		console.warn("CSRF token mismatch between header and cookie");
+		return false;
+	}
+
+	const isValid = await verifyCSRFToken(headerToken);
 	if (!isValid) {
 		console.warn("CSRF token validation failed");
 	}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,141 +1,16 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import {
+	checkCSRFToken,
+	createCSRFErrorResponse,
+	requiresCSRFProtection,
+} from "@/lib/security/csrf-protection";
 import { isAllowedAdminIP, verifyBasicAuth } from "@/lib/security/ip-restrictions";
 import { isAccountLocked } from "@/lib/security/login-attempts";
 import { rateLimit } from "@/lib/security/rate-limiting";
-// Web Crypto APIを使用（node:cryptoをEdge Runtimeで使用すると問題が起こる場合がある）
 import { logRateLimitExceeded, logSuspiciousActivity } from "@/lib/security/security-logger";
 // 2FAチェックはMiddlewareではなくページレベルで実行（Edge Runtime制限のため）
-
-/**
- * Middleware起動時に `CSRF_SECRET` 環境変数を検証して返す。
- *
- * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
- *   Edge Runtimeのインスタンス起動を停止する（フェイルクローズド）。
- * - 推奨生成方法: `openssl rand -hex 32`
- *
- * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
- * @returns 検証済みのCSRF秘密鍵
- */
-function getCSRFSecret(): string {
-	const secret = process.env.CSRF_SECRET;
-	if (!secret || secret.length < 32) {
-		throw new Error(
-			"CSRF_SECRET environment variable is not set or too short (require >= 32 chars). " +
-				"Generate one with: openssl rand -hex 32",
-		);
-	}
-	return secret;
-}
-
-const CSRF_SECRET = getCSRFSecret();
-
-/**
- * Web Crypto APIを使ってSHA-256ハッシュを生成
- */
-async function createSha256Hash(data: string): Promise<string> {
-	const encoder = new TextEncoder();
-	const dataBuffer = encoder.encode(data);
-	const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
-	const hashArray = Array.from(new Uint8Array(hashBuffer));
-	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-/**
- * CSRFトークンを検証（middleware専用）
- */
-async function verifyCSRFToken(token: string): Promise<boolean> {
-	try {
-		const [tokenPart, timestamp, signature] = token.split(":");
-
-		if (!(tokenPart && timestamp && signature)) {
-			return false;
-		}
-
-		// タイムスタンプチェック（1時間以内）
-		const tokenTime = Number.parseInt(timestamp);
-		const now = Date.now();
-		if (now - tokenTime > 3600000) {
-			// 1時間
-			return false;
-		}
-
-		// 署名検証
-		const expectedSignature = await createSha256Hash(`${tokenPart}:${timestamp}:${CSRF_SECRET}`);
-
-		return signature === expectedSignature;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * リクエストのCSRFトークンをチェック（middleware専用）
- */
-async function checkCSRFToken(request: NextRequest): Promise<boolean> {
-	// 安全メソッド（副作用なし）はスキップ。HEAD/OPTIONS（preflight）も含める。
-	if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") {
-		return true;
-	}
-
-	// 開発環境では緩和（デバッグ用、本番では絶対に有効化しないこと）
-	if (process.env.NODE_ENV === "development" && process.env.CSRF_DEBUG === "true") {
-		console.error(
-			`[CSRF_DEBUG] CSRF protection is DISABLED (NODE_ENV=${process.env.NODE_ENV}, pid=${typeof process !== "undefined" ? process.pid : "n/a"}). NEVER enable this in production.`,
-		);
-		return true;
-	}
-
-	// Double-submit Cookie パターン: ヘッダーとCookieの両方が必須かつ値一致を要求
-	const headerToken = request.headers.get("x-csrf-token");
-	const cookieToken = request.cookies.get("csrf-token")?.value;
-
-	if (!headerToken || !cookieToken) {
-		console.warn("CSRF token is missing (header or cookie)");
-		return false;
-	}
-
-	if (headerToken !== cookieToken) {
-		console.warn("CSRF token mismatch between header and cookie");
-		return false;
-	}
-
-	const isValid = await verifyCSRFToken(headerToken);
-	if (!isValid) {
-		console.warn("CSRF token validation failed");
-	}
-
-	return isValid;
-}
-
-/**
- * CSRF保護が必要なパスかどうかを判定（middleware専用）
- */
-function requiresCSRFProtection(pathname: string): boolean {
-	// API routes
-	if (pathname.startsWith("/api/")) {
-		// CSRF保護が不要なAPI（webhook等）
-		const exemptPaths = ["/api/stripe/webhook", "/api/health", "/api/csrf-token"];
-		return !exemptPaths.some((path) => pathname.startsWith(path));
-	}
-
-	// Server Actions は Next.js が自動でCSRF保護するため除外
-	// (実際のServer ActionsのパスはNext.jsが内部的に処理)
-	return false;
-}
-
-/**
- * CSRFエラーレスポンス（middleware専用）
- */
-function createCSRFErrorResponse(): Response {
-	return new Response("CSRF token validation failed", {
-		status: 403,
-		headers: {
-			"Content-Type": "text/plain",
-		},
-	});
-}
 
 export async function middleware(request: NextRequest) {
 	const supabase = await createClient();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,16 @@ import { rateLimit } from "@/lib/security/rate-limiting";
 import { logRateLimitExceeded, logSuspiciousActivity } from "@/lib/security/security-logger";
 // 2FAチェックはMiddlewareではなくページレベルで実行（Edge Runtime制限のため）
 
+/**
+ * Middleware起動時に `CSRF_SECRET` 環境変数を検証して返す。
+ *
+ * - 必須環境変数。未設定または32文字未満の場合はエラーをスローし、
+ *   Edge Runtimeのインスタンス起動を停止する（フェイルクローズド）。
+ * - 推奨生成方法: `openssl rand -hex 32`
+ *
+ * @throws {Error} `CSRF_SECRET` 未設定 / 32文字未満のとき
+ * @returns 検証済みのCSRF秘密鍵
+ */
 function getCSRFSecret(): string {
 	const secret = process.env.CSRF_SECRET;
 	if (!secret || secret.length < 32) {
@@ -64,8 +74,8 @@ async function verifyCSRFToken(token: string): Promise<boolean> {
  * リクエストのCSRFトークンをチェック（middleware専用）
  */
 async function checkCSRFToken(request: NextRequest): Promise<boolean> {
-	// GETリクエストはスキップ
-	if (request.method === "GET") {
+	// 安全メソッド（副作用なし）はスキップ。HEAD/OPTIONS（preflight）も含める。
+	if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") {
 		return true;
 	}
 


### PR DESCRIPTION
- csrf-token Cookie に HttpOnly フラグを付与し、XSSで盗まれないように修正
- Set-Cookie 構文を正規化 (HttpOnly=false / Secure=bool は仕様外だったため)
- Middleware / csrf-protection.ts の Cookie 単独フォールバックを廃止し、
  ヘッダーと Cookie の両方必須かつ値一致を要求する Double-submit Cookie パターンへ
- CSRF_SECRET のハードコードされたフォールバック値を3ファイルから削除し、
  未設定 or 32文字未満の場合は起動時 throw してフェイルクローズド
- CSRF_DEBUG 有効時のログを error レベルに昇格し、本番禁止を強調
- .env.example / docs/security/environment-variables.md を更新

https://claude.ai/code/session_016nrbtwuB7URQPmbSZ89PvT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメンテーション**
  * CSRF用環境変数を必須化（最低32文字推奨）し、生成コマンド例と開発時の挙動（CSRF_DEBUG）を明記しました。

* **セキュリティ改善**
  * 二重送信パターンでCSRF検証を厳格化し、Cookieとヘッダーの一致を必須化。
  * トークンの有効期限管理・TTL表記を追加し、トークンCookie属性とレスポンスのキャッシュ制御を強化。
  * 一部APIを除外する適用範囲の明確化と開発時の限定的バイパスを導入。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->