### PR TITLE
fix(perf): resolve N+1 queries in return records and admin users (#36)

### DIFF
--- a/src/app/(protected)/koudens/[id]/return_records/_components/index.tsx
+++ b/src/app/(protected)/koudens/[id]/return_records/_components/index.tsx
@@ -1,28 +1,27 @@
 "use client";
 
-// library
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { useTransition } from "react";
-// types
-import type {
-	ReturnManagementSummary,
-	ReturnItem,
-	ReturnStatus,
-	ReturnEntryRecord,
-} from "@/types/return-records/return-records";
-import type { Entry } from "@/types/entries";
-import type { Relationship } from "@/types/relationships";
-// hooks
-import { useMediaQuery } from "@/hooks/use-media-query";
-import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 // actions
 import { getReturnEntriesByKoudenPaginated } from "@/app/_actions/return-records/return-records";
-// utils
-import { convertToReturnManagementSummaries } from "@/utils/return-records-helpers";
+import { convertToReturnManagementSummaries } from "@/app/_actions/return-records/summaries";
+import { Loading } from "@/components/custom/loading";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
+// hooks
+import { useMediaQuery } from "@/hooks/use-media-query";
+import type { Entry } from "@/types/entries";
+import type { Relationship } from "@/types/relationships";
+// types
+import type {
+	ReturnEntryRecord,
+	ReturnItem,
+	ReturnManagementSummary,
+	ReturnStatus,
+} from "@/types/return-records/return-records";
+// library
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTransition } from "react";
+import { ReturnCardList } from "./card-list/return-card-list";
 // components
 import { DataTable } from "./table/data-table";
-import { ReturnCardList } from "./card-list/return-card-list";
-import { Loading } from "@/components/custom/loading";
 
 // Props
 interface ReturnRecordsViewProps {

--- a/src/app/(protected)/koudens/[id]/return_records/page.tsx
+++ b/src/app/(protected)/koudens/[id]/return_records/page.tsx
@@ -1,16 +1,16 @@
-import { notFound } from "next/navigation";
-import { getReturnEntriesByKoudenPaginated } from "@/app/_actions/return-records/return-records";
-import { getKouden } from "@/app/_actions/koudens";
 import { getEntries } from "@/app/_actions/entries";
+import { getKouden } from "@/app/_actions/koudens";
 import { getRelationships } from "@/app/_actions/relationships";
 import { getReturnItems } from "@/app/_actions/return-records/return-items";
-import { convertToReturnManagementSummaries } from "@/utils/return-records-helpers";
-import ReturnRecordsPageClient from "./ReturnRecordsPageClient";
+import { getReturnEntriesByKoudenPaginated } from "@/app/_actions/return-records/return-records";
+import { convertToReturnManagementSummaries } from "@/app/_actions/return-records/summaries";
 import type {
-	ReturnManagementSummary,
 	ReturnItem,
+	ReturnManagementSummary,
 	ReturnStatus,
 } from "@/types/return-records/return-records";
+import { notFound } from "next/navigation";
+import ReturnRecordsPageClient from "./ReturnRecordsPageClient";
 
 interface ReturnRecordsPageProps {
 	params: Promise<{

--- a/src/app/(protected)/koudens/[id]/statistics/page.tsx
+++ b/src/app/(protected)/koudens/[id]/statistics/page.tsx
@@ -1,5 +1,5 @@
 import { getEntries } from "@/app/_actions/entries";
-import { calculateEntryTotalAmount } from "@/app/_actions/offerings/queries";
+import { calculateEntryTotalAmountBulk } from "@/app/_actions/offerings/queries";
 import { KoudenStatistics } from "./_components";
 
 interface StatisticsPageProps {
@@ -16,21 +16,19 @@ export default async function StatisticsPage({ params }: StatisticsPageProps) {
 	const { id: koudenId } = await params;
 	const { entries } = await getEntries(koudenId, 1, Number.MAX_SAFE_INTEGER);
 
-	// 🎯 フェーズ7実装: 配分込み金額計算
-	// 各エントリーの配分込み総額を並列で取得
-	const entryTotalAmounts = await Promise.all(
-		entries.map(async (entry) => {
-			const result = await calculateEntryTotalAmount(entry.id);
-			return {
-				entryId: entry.id,
-				koudenAmount: entry.amount,
-				offeringTotal: result.success ? result.data?.offering_total || 0 : 0,
-				calculatedTotal: result.success
-					? result.data?.calculated_total || entry.amount
-					: entry.amount,
-			};
-		}),
-	);
+	// 配分込み金額をbulkで取得（N+1解消）
+	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((e) => e.id));
+	const amountsMap = bulkResult.success && bulkResult.data ? bulkResult.data : new Map();
+
+	const entryTotalAmounts = entries.map((entry) => {
+		const stats = amountsMap.get(entry.id);
+		return {
+			entryId: entry.id,
+			koudenAmount: entry.amount,
+			offeringTotal: stats?.offering_total ?? 0,
+			calculatedTotal: stats?.calculated_total ?? entry.amount,
+		};
+	});
 
 	// 配分込み合計金額の計算
 	const totalAmountWithAllocations = entryTotalAmounts.reduce(

--- a/src/app/(protected)/koudens/[id]/statistics/page.tsx
+++ b/src/app/(protected)/koudens/[id]/statistics/page.tsx
@@ -18,7 +18,13 @@ export default async function StatisticsPage({ params }: StatisticsPageProps) {
 
 	// 配分込み金額をbulkで取得（N+1解消）
 	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((e) => e.id));
-	const amountsMap = bulkResult.success && bulkResult.data ? bulkResult.data : new Map();
+	if (!(bulkResult.success && bulkResult.data)) {
+		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ
+		throw new Error(
+			`Failed to calculate entry totals in bulk: ${bulkResult.error ?? "unknown error"}`,
+		);
+	}
+	const amountsMap = bulkResult.data;
 
 	const entryTotalAmounts = entries.map((entry) => {
 		const stats = amountsMap.get(entry.id);

--- a/src/app/(protected)/koudens/[id]/statistics/page.tsx
+++ b/src/app/(protected)/koudens/[id]/statistics/page.tsx
@@ -19,10 +19,10 @@ export default async function StatisticsPage({ params }: StatisticsPageProps) {
 	// 配分込み金額をbulkで取得（N+1解消）
 	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((e) => e.id));
 	if (!(bulkResult.success && bulkResult.data)) {
-		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ
-		throw new Error(
-			`Failed to calculate entry totals in bulk: ${bulkResult.error ?? "unknown error"}`,
-		);
+		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ。
+		// 技術詳細はサーバーログにのみ残し、UI には汎用メッセージを返す。
+		console.error("[statistics] bulk fetch failed:", bulkResult.error);
+		throw new Error("統計情報の取得に失敗しました");
 	}
 	const amountsMap = bulkResult.data;
 

--- a/src/app/(system)/admin/koudens/[id]/statistics/error.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { useEffect } from "react";
+
+/**
+ * 管理者用統計のエラー表示コンポーネント
+ * - エラーメッセージとリトライボタンを表示
+ */
+export default function AdminStatisticsError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		console.error(error);
+	}, [error]);
+
+	return (
+		<Alert variant="destructive" className="mx-auto max-w-2xl">
+			<AlertCircle className="h-4 w-4" />
+			<AlertTitle>統計情報の取得に失敗しました</AlertTitle>
+			<AlertDescription className="mt-2 flex flex-col gap-2">
+				<p>{error.message}</p>
+				<button
+					type="button"
+					onClick={reset}
+					className="text-sm text-destructive underline hover:text-destructive/80"
+				>
+					もう一度試す
+				</button>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/src/app/(system)/admin/koudens/[id]/statistics/error.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/error.tsx
@@ -16,7 +16,8 @@ export default function AdminStatisticsError({
 	reset: () => void;
 }) {
 	useEffect(() => {
-		console.error(error);
+		// 詳細は診断用にログのみへ送る（UI へは内部情報を露出しない）
+		console.error("[AdminStatisticsError]", error);
 	}, [error]);
 
 	return (
@@ -24,7 +25,7 @@ export default function AdminStatisticsError({
 			<AlertCircle className="h-4 w-4" />
 			<AlertTitle>統計情報の取得に失敗しました</AlertTitle>
 			<AlertDescription className="mt-2 flex flex-col gap-2">
-				<p>{error.message}</p>
+				<p>統計情報の取得中に問題が発生しました。時間をおいて再試行してください。</p>
 				<button
 					type="button"
 					onClick={reset}

--- a/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
@@ -16,7 +16,13 @@ interface AdminStatisticsPageProps {
 async function calculateStatistics(entries: Entry[]) {
 	// 配分込み金額をbulkで取得（N+1解消）
 	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((entry) => entry.id));
-	const amountsMap = bulkResult.success && bulkResult.data ? bulkResult.data : new Map();
+	if (!(bulkResult.success && bulkResult.data)) {
+		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ
+		throw new Error(
+			`Failed to calculate entry totals in bulk: ${bulkResult.error ?? "unknown error"}`,
+		);
+	}
+	const amountsMap = bulkResult.data;
 
 	const entryTotalAmounts = entries.map((entry) => {
 		const stats = amountsMap.get(entry.id);

--- a/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
@@ -28,7 +28,7 @@ async function calculateStatistics(entries: Entry[]) {
 		const stats = amountsMap.get(entry.id);
 		return {
 			entryId: entry.id,
-			koudenAmount: entry.amount || 0,
+			koudenAmount: entry.amount ?? 0,
 			offeringTotal: stats?.offering_total ?? 0,
 			calculatedTotal: stats?.calculated_total ?? entry.amount ?? 0,
 		};

--- a/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
@@ -17,10 +17,10 @@ async function calculateStatistics(entries: Entry[]) {
 	// 配分込み金額をbulkで取得（N+1解消）
 	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((entry) => entry.id));
 	if (!(bulkResult.success && bulkResult.data)) {
-		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ
-		throw new Error(
-			`Failed to calculate entry totals in bulk: ${bulkResult.error ?? "unknown error"}`,
-		);
+		// 失敗時は0埋めではなく明示的に例外を投げ、誤った統計表示を防ぐ。
+		// 技術詳細はサーバーログにのみ残し、UI には汎用メッセージを返す。
+		console.error("[admin/statistics] bulk fetch failed:", bulkResult.error);
+		throw new Error("統計情報の取得に失敗しました");
 	}
 	const amountsMap = bulkResult.data;
 

--- a/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
@@ -1,8 +1,8 @@
 import { checkAdminPermission } from "@/app/_actions/admin/permissions";
 
-import { getEntriesForAdmin } from "@/app/_actions/entries";
-import { calculateEntryTotalAmount } from "@/app/_actions/offerings/queries";
 import { KoudenStatistics } from "@/app/(protected)/koudens/[id]/statistics/_components";
+import { getEntriesForAdmin } from "@/app/_actions/entries";
+import { calculateEntryTotalAmountBulk } from "@/app/_actions/offerings/queries";
 import type { Entry } from "@/types/entries";
 
 interface AdminStatisticsPageProps {
@@ -14,20 +14,19 @@ interface AdminStatisticsPageProps {
  * フェーズ7: 配分込み金額計算を含む
  */
 async function calculateStatistics(entries: Entry[]) {
-	// 🎯 フェーズ7実装: 配分込み金額計算
-	const entryTotalAmounts = await Promise.all(
-		entries.map(async (entry) => {
-			const result = await calculateEntryTotalAmount(entry.id);
-			return {
-				entryId: entry.id,
-				koudenAmount: entry.amount || 0,
-				offeringTotal: result.success ? result.data?.offering_total || 0 : 0,
-				calculatedTotal: result.success
-					? result.data?.calculated_total || entry.amount || 0
-					: entry.amount || 0,
-			};
-		}),
-	);
+	// 配分込み金額をbulkで取得（N+1解消）
+	const bulkResult = await calculateEntryTotalAmountBulk(entries.map((entry) => entry.id));
+	const amountsMap = bulkResult.success && bulkResult.data ? bulkResult.data : new Map();
+
+	const entryTotalAmounts = entries.map((entry) => {
+		const stats = amountsMap.get(entry.id);
+		return {
+			entryId: entry.id,
+			koudenAmount: entry.amount || 0,
+			offeringTotal: stats?.offering_total ?? 0,
+			calculatedTotal: stats?.calculated_total ?? entry.amount ?? 0,
+		};
+	});
 
 	// 配分込み総額計算
 	const totalAmountWithAllocations = entryTotalAmounts.reduce(

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -148,10 +148,12 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<{
 		]);
 
 		if (aggregateResult.error) {
+			// 失敗時は0埋めで継続せず、明示的に例外を投げる（admin UIで誤った0統計を出さないため）
 			logger.error(
 				{ error: aggregateResult.error.message, userIdsCount: userIds.length },
 				"Failed to fetch user aggregate stats",
 			);
+			throw new Error(`Failed to fetch user aggregate stats: ${aggregateResult.error.message}`);
 		}
 
 		type AggregateRow = {

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -1,8 +1,8 @@
 "use server";
 
+import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
-import logger from "@/lib/logger";
 
 /**
  * 全ユーザー管理用の型定義
@@ -133,47 +133,55 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<{
 			return { users: [], total: count || 0, hasMore: false };
 		}
 
-		// 2. 各ユーザーの詳細情報を並列取得（認証情報は一括取得）
+		// 2. 認証情報と集計統計をそれぞれ1クエリで一括取得（N+1解消）
 		const userIds = profiles.map((p) => p.id);
-		const [authInfoMap, usersWithDetails] = await Promise.all([
+		// 注: get_users_aggregate_stats は 20260513000000_add_get_users_aggregate_stats_rpc.sql で追加。
+		// マイグレーション適用後に `bun run db:types` を実行すれば、ここのキャストは不要になる。
+		const [authInfoMap, aggregateResult] = await Promise.all([
 			getAllUsersAuthInfo(userIds),
-			Promise.all(
-				profiles.map(async (profile) => {
-					try {
-						// 統計情報、管理者情報を並列取得
-						const [stats, adminInfo] = await Promise.all([
-							getUserStats(profile.id),
-							getUserAdminInfo(profile.id),
-						]);
-
-						return {
-							...profile,
-							stats,
-							admin_info: adminInfo,
-						};
-					} catch (error) {
-						logger.error(
-							{
-								userId: profile.id,
-								error: error instanceof Error ? error.message : String(error),
-							},
-							"Failed to get details for user",
-						);
-						// エラーが発生した場合は基本情報のみ返す
-						const stats = await getUserStats(profile.id).catch(() => ({
-							owned_koudens_count: 0,
-							participated_koudens_count: 0,
-							total_entries_count: 0,
-						}));
-
-						return {
-							...profile,
-							stats,
-						};
-					}
-				}),
-			),
+			(
+				supabase.rpc as unknown as (
+					fn: string,
+					args: unknown,
+				) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+			)("get_users_aggregate_stats", { p_user_ids: userIds }),
 		]);
+
+		if (aggregateResult.error) {
+			logger.error(
+				{ error: aggregateResult.error.message, userIdsCount: userIds.length },
+				"Failed to fetch user aggregate stats",
+			);
+		}
+
+		type AggregateRow = {
+			user_id: string;
+			owned_koudens_count: number | string;
+			participated_koudens_count: number | string;
+			total_entries_count: number | string;
+			admin_role: string | null;
+			admin_created_at: string | null;
+		};
+		const aggregateRows = (aggregateResult.data ?? []) as AggregateRow[];
+		const aggregateMap = new Map(aggregateRows.map((row) => [row.user_id, row]));
+
+		const usersWithDetails = profiles.map((profile) => {
+			const agg = aggregateMap.get(profile.id);
+			return {
+				...profile,
+				stats: {
+					owned_koudens_count: Number(agg?.owned_koudens_count ?? 0),
+					participated_koudens_count: Number(agg?.participated_koudens_count ?? 0),
+					total_entries_count: Number(agg?.total_entries_count ?? 0),
+				},
+				admin_info: agg?.admin_role
+					? {
+							role: agg.admin_role as "admin" | "super_admin",
+							granted_at: agg.admin_created_at ?? "",
+						}
+					: undefined,
+			};
+		});
 
 		// 認証情報をマージ
 		const finalUsersWithDetails = usersWithDetails.map((user) => ({

--- a/src/app/_actions/offerings/__tests__/queries.test.ts
+++ b/src/app/_actions/offerings/__tests__/queries.test.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	calculateEntryTotalAmount,
@@ -12,10 +13,15 @@ import {
 vi.mock("@/lib/supabase/admin", () => ({
 	createAdminClient: vi.fn(),
 }));
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
 
 describe("お供物配分クエリー機能", () => {
 	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
 	let supabaseMock: any;
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
+	let serverClientMock: any;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -24,6 +30,18 @@ describe("お供物配分クエリー機能", () => {
 			from: vi.fn(),
 		};
 		(createAdminClient as unknown as Mock).mockReturnValue(supabaseMock);
+
+		// 認証ユーザー(管理者)としてデフォルトモック。bulkテストでは認可フィルタを通り抜ける。
+		serverClientMock = {
+			auth: {
+				getUser: vi.fn().mockResolvedValue({
+					data: { user: { id: "test-admin-user-id" } },
+					error: null,
+				}),
+			},
+			rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
+		};
+		(createClient as unknown as Mock).mockResolvedValue(serverClientMock);
 	});
 
 	describe("getOfferingAllocations", () => {
@@ -339,9 +357,9 @@ describe("お供物配分クエリー機能", () => {
 	describe("calculateEntryTotalAmountBulk", () => {
 		it("複数エントリーの合計金額を1組のクエリで一括計算する", async () => {
 			const mockEntries = [
-				{ id: "entry1", amount: 10000 },
-				{ id: "entry2", amount: 20000 },
-				{ id: "entry3", amount: 5000 },
+				{ id: "entry1", amount: 10000, kouden_id: "k1" },
+				{ id: "entry2", amount: 20000, kouden_id: "k1" },
+				{ id: "entry3", amount: 5000, kouden_id: "k1" },
 			];
 			const mockAllocations = [
 				{ kouden_entry_id: "entry1", allocated_amount: 3000 },
@@ -422,7 +440,11 @@ describe("お供物配分クエリー機能", () => {
 			supabaseMock.from
 				.mockReturnValueOnce({
 					select: () => ({
-						in: () => Promise.resolve({ data: [{ id: "entry1", amount: 10000 }], error: null }),
+						in: () =>
+							Promise.resolve({
+								data: [{ id: "entry1", amount: 10000, kouden_id: "k1" }],
+								error: null,
+							}),
 					}),
 				})
 				.mockReturnValueOnce({
@@ -438,7 +460,7 @@ describe("お供物配分クエリー機能", () => {
 		});
 
 		it("配分が無いエントリーもMapに含まれ offering_total: 0 になる", async () => {
-			const mockEntries = [{ id: "entry1", amount: 8000 }];
+			const mockEntries = [{ id: "entry1", amount: 8000, kouden_id: "k1" }];
 
 			supabaseMock.from
 				.mockReturnValueOnce({
@@ -460,6 +482,72 @@ describe("お供物配分クエリー機能", () => {
 				offering_total: 0,
 				calculated_total: 8000,
 			});
+		});
+
+		it("未認証時はsuccess: falseを返す", async () => {
+			serverClientMock.auth.getUser.mockResolvedValueOnce({
+				data: { user: null },
+				error: null,
+			});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("認証が必要です");
+			// 認証失敗時はSupabaseアクセスを行わない
+			expect(supabaseMock.from).not.toHaveBeenCalled();
+		});
+
+		it("一般ユーザーは自分がアクセス権を持たないエントリーを取得できない", async () => {
+			// 非管理者
+			serverClientMock.rpc.mockResolvedValueOnce({ data: false, error: null });
+
+			const mockEntries = [
+				{ id: "entry1", amount: 10000, kouden_id: "k-owned" },
+				{ id: "entry2", amount: 20000, kouden_id: "k-other" }, // 権限なし
+			];
+
+			supabaseMock.from
+				// 1) kouden_entries 取得
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: mockEntries, error: null }),
+					}),
+				})
+				// 2) 所有 koudens 取得
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: [{ id: "k-owned" }], error: null }),
+					}),
+				})
+				// 3) メンバー koudens 取得
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: [], error: null }),
+					}),
+				})
+				// 4) 認可されたエントリーの allocations のみ取得
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () =>
+							Promise.resolve({
+								data: [{ kouden_entry_id: "entry1", allocated_amount: 1500 }],
+								error: null,
+							}),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1", "entry2"]);
+
+			expect(result.success).toBe(true);
+			expect(result.data?.size).toBe(1);
+			expect(result.data?.get("entry1")).toEqual({
+				kouden_amount: 10000,
+				offering_total: 1500,
+				calculated_total: 11500,
+			});
+			// entry2 は除外される
+			expect(result.data?.has("entry2")).toBe(false);
 		});
 	});
 });

--- a/src/app/_actions/offerings/__tests__/queries.test.ts
+++ b/src/app/_actions/offerings/__tests__/queries.test.ts
@@ -498,6 +498,20 @@ describe("お供物配分クエリー機能", () => {
 			expect(supabaseMock.from).not.toHaveBeenCalled();
 		});
 
+		it("is_admin RPC エラー時はsuccess: falseを返す", async () => {
+			serverClientMock.rpc.mockResolvedValueOnce({
+				data: null,
+				error: { message: "RPC実行エラー" },
+			});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("管理者権限の確認に失敗");
+			// RPC失敗時はSupabaseアクセスを行わない
+			expect(supabaseMock.from).not.toHaveBeenCalled();
+		});
+
 		it("一般ユーザーは自分がアクセス権を持たないエントリーを取得できない", async () => {
 			// 非管理者
 			serverClientMock.rpc.mockResolvedValueOnce({ data: false, error: null });

--- a/src/app/_actions/offerings/__tests__/queries.test.ts
+++ b/src/app/_actions/offerings/__tests__/queries.test.ts
@@ -563,5 +563,74 @@ describe("お供物配分クエリー機能", () => {
 			// entry2 は除外される
 			expect(result.data?.has("entry2")).toBe(false);
 		});
+
+		it("非管理者の所有koudens取得エラー時はsuccess: falseを返す", async () => {
+			serverClientMock.rpc.mockResolvedValueOnce({ data: false, error: null });
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () =>
+							Promise.resolve({
+								data: [{ id: "entry1", amount: 10000, kouden_id: "k1" }],
+								error: null,
+							}),
+					}),
+				})
+				// 所有 koudens でエラー
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: null, error: { message: "koudens lookup failed" } }),
+					}),
+				})
+				// メンバー koudens は成功
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: [], error: null }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("アクセス権限の確認に失敗");
+			// 認可スコープ取得失敗後に allocations を取得しないことを確認
+			expect(supabaseMock.from).toHaveBeenCalledTimes(3);
+			expect(supabaseMock.from).not.toHaveBeenCalledWith("offering_allocations");
+		});
+
+		it("非管理者のメンバーkoudens取得エラー時はsuccess: falseを返す", async () => {
+			serverClientMock.rpc.mockResolvedValueOnce({ data: false, error: null });
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () =>
+							Promise.resolve({
+								data: [{ id: "entry1", amount: 10000, kouden_id: "k1" }],
+								error: null,
+							}),
+					}),
+				})
+				// 所有 koudens は成功
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: [], error: null }),
+					}),
+				})
+				// メンバー koudens でエラー
+				.mockReturnValueOnce({
+					select: () => ({
+						eq: () => Promise.resolve({ data: null, error: { message: "members lookup failed" } }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("アクセス権限の確認に失敗");
+			expect(supabaseMock.from).toHaveBeenCalledTimes(3);
+			expect(supabaseMock.from).not.toHaveBeenCalledWith("offering_allocations");
+		});
 	});
 });

--- a/src/app/_actions/offerings/__tests__/queries.test.ts
+++ b/src/app/_actions/offerings/__tests__/queries.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import {
-	getOfferingAllocations,
-	getEntryOfferingAllocations,
-	checkOfferingAllocationIntegrity,
-	calculateEntryTotalAmount,
-} from "../queries";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	calculateEntryTotalAmount,
+	calculateEntryTotalAmountBulk,
+	checkOfferingAllocationIntegrity,
+	getEntryOfferingAllocations,
+	getOfferingAllocations,
+} from "../queries";
 
 // モック設定
 vi.mock("@/lib/supabase/admin", () => ({
@@ -332,6 +333,133 @@ describe("お供物配分クエリー機能", () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain("お供物配分データの取得に失敗");
+		});
+	});
+
+	describe("calculateEntryTotalAmountBulk", () => {
+		it("複数エントリーの合計金額を1組のクエリで一括計算する", async () => {
+			const mockEntries = [
+				{ id: "entry1", amount: 10000 },
+				{ id: "entry2", amount: 20000 },
+				{ id: "entry3", amount: 5000 },
+			];
+			const mockAllocations = [
+				{ kouden_entry_id: "entry1", allocated_amount: 3000 },
+				{ kouden_entry_id: "entry1", allocated_amount: 2000 },
+				{ kouden_entry_id: "entry2", allocated_amount: 1000 },
+				// entry3 は配分なし
+			];
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: mockEntries, error: null }),
+					}),
+				})
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: mockAllocations, error: null }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1", "entry2", "entry3"]);
+
+			expect(result.success).toBe(true);
+			expect(result.data?.size).toBe(3);
+			expect(result.data?.get("entry1")).toEqual({
+				kouden_amount: 10000,
+				offering_total: 5000,
+				calculated_total: 15000,
+			});
+			expect(result.data?.get("entry2")).toEqual({
+				kouden_amount: 20000,
+				offering_total: 1000,
+				calculated_total: 21000,
+			});
+			expect(result.data?.get("entry3")).toEqual({
+				kouden_amount: 5000,
+				offering_total: 0,
+				calculated_total: 5000,
+			});
+			// from は2回（kouden_entries + offering_allocations）しか呼ばれない
+			expect(supabaseMock.from).toHaveBeenCalledTimes(2);
+			expect(supabaseMock.from).toHaveBeenNthCalledWith(1, "kouden_entries");
+			expect(supabaseMock.from).toHaveBeenNthCalledWith(2, "offering_allocations");
+		});
+
+		it("空配列入力時はSupabaseを呼ばずに空Mapを返す", async () => {
+			const result = await calculateEntryTotalAmountBulk([]);
+
+			expect(result.success).toBe(true);
+			expect(result.data?.size).toBe(0);
+			expect(supabaseMock.from).not.toHaveBeenCalled();
+		});
+
+		it("kouden_entries取得エラー時はsuccess: falseを返す", async () => {
+			const mockError = { message: "DB接続エラー" };
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: null, error: mockError }),
+					}),
+				})
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: [], error: null }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("香典エントリーの取得に失敗");
+		});
+
+		it("offering_allocations取得エラー時はsuccess: falseを返す", async () => {
+			const mockError = { message: "配分データ取得失敗" };
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: [{ id: "entry1", amount: 10000 }], error: null }),
+					}),
+				})
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: null, error: mockError }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("お供物配分データの取得に失敗");
+		});
+
+		it("配分が無いエントリーもMapに含まれ offering_total: 0 になる", async () => {
+			const mockEntries = [{ id: "entry1", amount: 8000 }];
+
+			supabaseMock.from
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: mockEntries, error: null }),
+					}),
+				})
+				.mockReturnValueOnce({
+					select: () => ({
+						in: () => Promise.resolve({ data: [], error: null }),
+					}),
+				});
+
+			const result = await calculateEntryTotalAmountBulk(["entry1"]);
+
+			expect(result.success).toBe(true);
+			expect(result.data?.get("entry1")).toEqual({
+				kouden_amount: 8000,
+				offering_total: 0,
+				calculated_total: 8000,
+			});
 		});
 	});
 });

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import type { OfferingAllocation } from "@/types/entries";
 
 /**
@@ -283,32 +284,77 @@ export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): P
 			return { success: true, data: new Map() };
 		}
 
+		// 認証ユーザーを取得（Server Action は Client から任意の入力で呼べるため認可必須）
+		const userClient = await createClient();
+		const {
+			data: { user },
+			error: authError,
+		} = await userClient.auth.getUser();
+		if (authError || !user) {
+			return { success: false, error: "認証が必要です" };
+		}
+
+		// 管理者なら全エントリーへアクセス可能。それ以外は kouden 単位でアクセス権を確認する。
+		const { data: isAdminFlag } = await userClient.rpc("is_admin", { user_uid: user.id });
+		const isAdmin = isAdminFlag === true;
+
 		const supabase = createAdminClient();
 
-		const [entriesResult, allocationsResult] = await Promise.all([
-			supabase.from("kouden_entries").select("id, amount").in("id", koudenEntryIds),
-			supabase
-				.from("offering_allocations")
-				.select("kouden_entry_id, allocated_amount")
-				.in("kouden_entry_id", koudenEntryIds),
-		]);
+		// kouden_id も含めて取得し、認可フィルタに使う
+		const { data: rawEntries, error: entriesError } = await supabase
+			.from("kouden_entries")
+			.select("id, amount, kouden_id")
+			.in("id", koudenEntryIds);
 
-		if (entriesResult.error) {
+		if (entriesError) {
 			return { success: false, error: "香典エントリーの取得に失敗しました" };
 		}
-		if (allocationsResult.error) {
+
+		let allowedEntries = rawEntries ?? [];
+		if (!isAdmin) {
+			// 所有 kouden + メンバー kouden の id 集合を取得
+			const [{ data: owned }, { data: members }] = await Promise.all([
+				supabase.from("koudens").select("id").eq("owner_id", user.id),
+				supabase.from("kouden_members").select("kouden_id").eq("user_id", user.id),
+			]);
+			const allowedKoudenIds = new Set<string>();
+			for (const k of owned ?? []) allowedKoudenIds.add(k.id);
+			for (const m of members ?? []) {
+				if (m.kouden_id) allowedKoudenIds.add(m.kouden_id);
+			}
+			allowedEntries = allowedEntries.filter(
+				(e) => e.kouden_id != null && allowedKoudenIds.has(e.kouden_id),
+			);
+			if (allowedEntries.length !== (rawEntries ?? []).length) {
+				console.warn(
+					`[calculateEntryTotalAmountBulk] filtered ${(rawEntries ?? []).length - allowedEntries.length} unauthorized entries for user ${user.id}`,
+				);
+			}
+		}
+
+		const allowedEntryIds = allowedEntries.map((e) => e.id);
+		if (allowedEntryIds.length === 0) {
+			return { success: true, data: new Map() };
+		}
+
+		const { data: allocations, error: allocationError } = await supabase
+			.from("offering_allocations")
+			.select("kouden_entry_id, allocated_amount")
+			.in("kouden_entry_id", allowedEntryIds);
+
+		if (allocationError) {
 			return { success: false, error: "お供物配分データの取得に失敗しました" };
 		}
 
 		const totalsByEntry = new Map<string, number>();
-		for (const alloc of allocationsResult.data ?? []) {
+		for (const alloc of allocations ?? []) {
 			if (!alloc.kouden_entry_id) continue;
 			const prev = totalsByEntry.get(alloc.kouden_entry_id) ?? 0;
 			totalsByEntry.set(alloc.kouden_entry_id, prev + alloc.allocated_amount);
 		}
 
 		const data = new Map<string, EntryAmountStats>();
-		for (const entry of entriesResult.data ?? []) {
+		for (const entry of allowedEntries) {
 			const offeringTotal = totalsByEntry.get(entry.id) ?? 0;
 			const koudenAmount = entry.amount ?? 0;
 			data.set(entry.id, {

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -260,20 +260,22 @@ export async function calculateEntryTotalAmount(koudenEntryId: string): Promise<
 }
 
 /**
+ * 香典エントリーごとの合計金額情報（香典金額 + 配分されたお供物の合計）
+ */
+export type EntryAmountStats = {
+	kouden_amount: number;
+	offering_total: number;
+	calculated_total: number;
+};
+
+/**
  * 複数の香典エントリーの合計金額を一括計算（N+1解消用）
  * 個別呼び出しの`calculateEntryTotalAmount`は単一エントリー向け（getUserDetail等）に残し、
  * リスト処理ではこちらを利用する。
  */
 export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): Promise<{
 	success: boolean;
-	data?: Map<
-		string,
-		{
-			kouden_amount: number;
-			offering_total: number;
-			calculated_total: number;
-		}
-	>;
+	data?: Map<string, EntryAmountStats>;
 	error?: string;
 }> {
 	try {
@@ -305,10 +307,7 @@ export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): P
 			totalsByEntry.set(alloc.kouden_entry_id, prev + alloc.allocated_amount);
 		}
 
-		const data = new Map<
-			string,
-			{ kouden_amount: number; offering_total: number; calculated_total: number }
-		>();
+		const data = new Map<string, EntryAmountStats>();
 		for (const entry of entriesResult.data ?? []) {
 			const offeringTotal = totalsByEntry.get(entry.id) ?? 0;
 			const koudenAmount = entry.amount ?? 0;

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -295,7 +295,15 @@ export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): P
 		}
 
 		// 管理者なら全エントリーへアクセス可能。それ以外は kouden 単位でアクセス権を確認する。
-		const { data: isAdminFlag } = await userClient.rpc("is_admin", { user_uid: user.id });
+		// RPCエラーを silent に false 扱いすると、管理者が一般ユーザー扱いとなり認可フィルタで
+		// すべての entry が落ち、空の Map が success: true で返るため、明示的にエラーを返す。
+		const { data: isAdminFlag, error: rpcError } = await userClient.rpc("is_admin", {
+			user_uid: user.id,
+		});
+		if (rpcError) {
+			console.error("[calculateEntryTotalAmountBulk] is_admin RPC failed:", rpcError);
+			return { success: false, error: "管理者権限の確認に失敗しました" };
+		}
 		const isAdmin = isAdminFlag === true;
 
 		const supabase = createAdminClient();

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -258,3 +258,72 @@ export async function calculateEntryTotalAmount(koudenEntryId: string): Promise<
 		};
 	}
 }
+
+/**
+ * 複数の香典エントリーの合計金額を一括計算（N+1解消用）
+ * 個別呼び出しの`calculateEntryTotalAmount`は単一エントリー向け（getUserDetail等）に残し、
+ * リスト処理ではこちらを利用する。
+ */
+export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): Promise<{
+	success: boolean;
+	data?: Map<
+		string,
+		{
+			kouden_amount: number;
+			offering_total: number;
+			calculated_total: number;
+		}
+	>;
+	error?: string;
+}> {
+	try {
+		if (koudenEntryIds.length === 0) {
+			return { success: true, data: new Map() };
+		}
+
+		const supabase = createAdminClient();
+
+		const [entriesResult, allocationsResult] = await Promise.all([
+			supabase.from("kouden_entries").select("id, amount").in("id", koudenEntryIds),
+			supabase
+				.from("offering_allocations")
+				.select("kouden_entry_id, allocated_amount")
+				.in("kouden_entry_id", koudenEntryIds),
+		]);
+
+		if (entriesResult.error) {
+			return { success: false, error: "香典エントリーの取得に失敗しました" };
+		}
+		if (allocationsResult.error) {
+			return { success: false, error: "お供物配分データの取得に失敗しました" };
+		}
+
+		const totalsByEntry = new Map<string, number>();
+		for (const alloc of allocationsResult.data ?? []) {
+			if (!alloc.kouden_entry_id) continue;
+			const prev = totalsByEntry.get(alloc.kouden_entry_id) ?? 0;
+			totalsByEntry.set(alloc.kouden_entry_id, prev + alloc.allocated_amount);
+		}
+
+		const data = new Map<
+			string,
+			{ kouden_amount: number; offering_total: number; calculated_total: number }
+		>();
+		for (const entry of entriesResult.data ?? []) {
+			const offeringTotal = totalsByEntry.get(entry.id) ?? 0;
+			data.set(entry.id, {
+				kouden_amount: entry.amount,
+				offering_total: offeringTotal,
+				calculated_total: entry.amount + offeringTotal,
+			});
+		}
+
+		return { success: true, data };
+	} catch (error) {
+		console.error("合計金額一括計算エラー:", error);
+		return {
+			success: false,
+			error: "合計金額の一括計算に失敗しました",
+		};
+	}
+}

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -311,10 +311,11 @@ export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): P
 		>();
 		for (const entry of entriesResult.data ?? []) {
 			const offeringTotal = totalsByEntry.get(entry.id) ?? 0;
+			const koudenAmount = entry.amount ?? 0;
 			data.set(entry.id, {
-				kouden_amount: entry.amount,
+				kouden_amount: koudenAmount,
 				offering_total: offeringTotal,
-				calculated_total: entry.amount + offeringTotal,
+				calculated_total: koudenAmount + offeringTotal,
 			});
 		}
 

--- a/src/app/_actions/offerings/queries.ts
+++ b/src/app/_actions/offerings/queries.ts
@@ -320,11 +320,22 @@ export async function calculateEntryTotalAmountBulk(koudenEntryIds: string[]): P
 
 		let allowedEntries = rawEntries ?? [];
 		if (!isAdmin) {
-			// 所有 kouden + メンバー kouden の id 集合を取得
-			const [{ data: owned }, { data: members }] = await Promise.all([
-				supabase.from("koudens").select("id").eq("owner_id", user.id),
-				supabase.from("kouden_members").select("kouden_id").eq("user_id", user.id),
-			]);
+			// 所有 kouden + メンバー kouden の id 集合を取得。
+			// どちらかが失敗した状態で進むと allowedKoudenIds が不正に空集合となり、
+			// 全 entry を非認可として落として success:true で空 Map を返してしまうため、
+			// 明示的にエラーを返す（is_admin RPC と同じ理由）。
+			const [{ data: owned, error: ownedError }, { data: members, error: membersError }] =
+				await Promise.all([
+					supabase.from("koudens").select("id").eq("owner_id", user.id),
+					supabase.from("kouden_members").select("kouden_id").eq("user_id", user.id),
+				]);
+			if (ownedError || membersError) {
+				console.error("[calculateEntryTotalAmountBulk] auth-scope lookup failed:", {
+					ownedError,
+					membersError,
+				});
+				return { success: false, error: "アクセス権限の確認に失敗しました" };
+			}
 			const allowedKoudenIds = new Set<string>();
 			for (const k of owned ?? []) allowedKoudenIds.add(k.id);
 			for (const m of members ?? []) {

--- a/src/app/_actions/return-records/bulk-operations.ts
+++ b/src/app/_actions/return-records/bulk-operations.ts
@@ -5,15 +5,15 @@
  * @module return-records/bulk-operations
  */
 
-import { createClient } from "@/lib/supabase/server";
-import { revalidatePath } from "next/cache";
-import { convertToReturnManagementSummaries } from "@/utils/return-records-helpers";
-import type { Entry, AttendanceType } from "@/types/entries";
-import type {
-	ReturnManagementSummary,
-	BulkUpdateConfig,
-} from "@/types/return-records/return-records";
+import { convertToReturnManagementSummaries } from "@/app/_actions/return-records/summaries";
 import logger from "@/lib/logger";
+import { createClient } from "@/lib/supabase/server";
+import type { AttendanceType, Entry } from "@/types/entries";
+import type {
+	BulkUpdateConfig,
+	ReturnManagementSummary,
+} from "@/types/return-records/return-records";
+import { revalidatePath } from "next/cache";
 
 /**
  * 一括変更用：香典帳の全返礼記録を取得する（ReturnManagementSummary形式）

--- a/src/app/_actions/return-records/summaries.ts
+++ b/src/app/_actions/return-records/summaries.ts
@@ -1,0 +1,49 @@
+/**
+ * 返礼サマリー組み立て用のServer Action
+ * - お供物配分金額の一括取得 (`calculateEntryTotalAmountBulk`) と
+ *   `convertToReturnManagementSummary` の純粋変換を組み合わせ、
+ *   N+1 を避けつつ ReturnManagementSummary 配列を構築する。
+ * - 純粋変換ロジックは `@/utils/return-records-helpers` 側に残し、
+ *   このファイルは Server Action としてのデータ取得責務を担う。
+ */
+
+"use server";
+
+import { calculateEntryTotalAmountBulk } from "@/app/_actions/offerings/queries";
+import type { Entry } from "@/types/entries";
+import type { Relationship } from "@/types/relationships";
+import type {
+	ReturnEntryRecord,
+	ReturnManagementSummary,
+} from "@/types/return-records/return-records";
+import { convertToReturnManagementSummary } from "@/utils/return-records-helpers";
+
+export async function convertToReturnManagementSummaries(
+	returnRecords: ReturnEntryRecord[],
+	entries: Entry[],
+	relationships: Relationship[],
+	koudenId: string,
+): Promise<ReturnManagementSummary[]> {
+	const entryIds = Array.from(
+		new Set(
+			returnRecords
+				.map((r) => r.kouden_entry_id)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	);
+
+	const bulk = await calculateEntryTotalAmountBulk(entryIds);
+	if (!(bulk.success && bulk.data)) {
+		// 失敗時は0埋めではなく明示的に例外を投げる（誤った返礼サマリー表示を防ぐ）。
+		// 技術詳細はサーバーログにのみ残し、UI には汎用メッセージを返す。
+		console.error("[convertToReturnManagementSummaries] bulk fetch failed:", bulk.error);
+		throw new Error("返礼情報の取得に失敗しました");
+	}
+	const amountsMap = bulk.data;
+
+	return returnRecords
+		.map((record) =>
+			convertToReturnManagementSummary(record, entries, relationships, koudenId, amountsMap),
+		)
+		.filter((summary): summary is ReturnManagementSummary => summary !== null);
+}

--- a/src/utils/return-records-helpers.ts
+++ b/src/utils/return-records-helpers.ts
@@ -1,12 +1,13 @@
 /**
- * 返礼情報データ変換のヘルパー関数
+ * 返礼情報データ変換のヘルパー関数（純粋関数）
  * @module return-records-helpers
+ *
+ * このファイルは Server Action を呼び出さない、純粋なデータ変換ロジックに
+ * 限定しています。bulk取得を伴うリスト変換は
+ * `@/app/_actions/return-records/summaries` 側で行います。
  */
 
-import {
-	type EntryAmountStats,
-	calculateEntryTotalAmountBulk,
-} from "@/app/_actions/offerings/queries";
+import type { EntryAmountStats } from "@/app/_actions/offerings/queries";
 import type { Entry } from "@/types/entries";
 import type { Relationship } from "@/types/relationships";
 import type {
@@ -35,7 +36,7 @@ function getStatusDisplay(status: ReturnStatus): string {
 }
 
 /**
- * ReturnEntryRecordをReturnManagementSummary形式に変換する
+ * ReturnEntryRecordをReturnManagementSummary形式に変換する（純粋関数）
  * @param returnRecord - 返礼エントリーレコード
  * @param entries - 香典エントリー一覧
  * @param relationships - 関係性一覧
@@ -94,38 +95,4 @@ export function convertToReturnManagementSummary(
 		statusDisplay: getStatusDisplay(returnRecord.return_status as ReturnStatus),
 		needsAdditionalReturn: (returnRecord.additional_return_amount || 0) > 0,
 	};
-}
-
-/**
- * 複数のReturnEntryRecordを一括でReturnManagementSummary形式に変換する
- * お供物配分金額は1回のbulkクエリで取得しN+1を回避する。
- */
-export async function convertToReturnManagementSummaries(
-	returnRecords: ReturnEntryRecord[],
-	entries: Entry[],
-	relationships: Relationship[],
-	koudenId: string,
-): Promise<ReturnManagementSummary[]> {
-	const entryIds = Array.from(
-		new Set(
-			returnRecords
-				.map((r) => r.kouden_entry_id)
-				.filter((id): id is string => typeof id === "string" && id.length > 0),
-		),
-	);
-
-	const bulk = await calculateEntryTotalAmountBulk(entryIds);
-	if (!(bulk.success && bulk.data)) {
-		// 失敗時は0埋めではなく明示的に例外を投げる（誤った返礼サマリー表示を防ぐ）。
-		// 技術詳細はサーバーログにのみ残し、UI には汎用メッセージを返す。
-		console.error("[convertToReturnManagementSummaries] bulk fetch failed:", bulk.error);
-		throw new Error("返礼情報の取得に失敗しました");
-	}
-	const amountsMap: Map<string, EntryAmountStats> = bulk.data;
-
-	return returnRecords
-		.map((record) =>
-			convertToReturnManagementSummary(record, entries, relationships, koudenId, amountsMap),
-		)
-		.filter((summary): summary is ReturnManagementSummary => summary !== null);
 }

--- a/src/utils/return-records-helpers.ts
+++ b/src/utils/return-records-helpers.ts
@@ -3,7 +3,10 @@
  * @module return-records-helpers
  */
 
-import { calculateEntryTotalAmountBulk } from "@/app/_actions/offerings/queries";
+import {
+	type EntryAmountStats,
+	calculateEntryTotalAmountBulk,
+} from "@/app/_actions/offerings/queries";
 import type { Entry } from "@/types/entries";
 import type { Relationship } from "@/types/relationships";
 import type {
@@ -12,12 +15,6 @@ import type {
 	ReturnManagementSummary,
 	ReturnStatus,
 } from "@/types/return-records/return-records";
-
-type EntryAmountStats = {
-	kouden_amount: number;
-	offering_total: number;
-	calculated_total: number;
-};
 
 /**
  * 返礼状況の表示用テキストを取得

--- a/src/utils/return-records-helpers.ts
+++ b/src/utils/return-records-helpers.ts
@@ -118,8 +118,11 @@ export async function convertToReturnManagementSummaries(
 	);
 
 	const bulk = await calculateEntryTotalAmountBulk(entryIds);
-	const amountsMap: Map<string, EntryAmountStats> =
-		bulk.success && bulk.data ? bulk.data : new Map();
+	if (!(bulk.success && bulk.data)) {
+		// 失敗時は0埋めではなく明示的に例外を投げる（誤った返礼サマリー表示を防ぐ）
+		throw new Error(`Failed to calculate entry totals in bulk: ${bulk.error ?? "unknown error"}`);
+	}
+	const amountsMap: Map<string, EntryAmountStats> = bulk.data;
 
 	return returnRecords
 		.map((record) =>

--- a/src/utils/return-records-helpers.ts
+++ b/src/utils/return-records-helpers.ts
@@ -116,8 +116,10 @@ export async function convertToReturnManagementSummaries(
 
 	const bulk = await calculateEntryTotalAmountBulk(entryIds);
 	if (!(bulk.success && bulk.data)) {
-		// 失敗時は0埋めではなく明示的に例外を投げる（誤った返礼サマリー表示を防ぐ）
-		throw new Error(`Failed to calculate entry totals in bulk: ${bulk.error ?? "unknown error"}`);
+		// 失敗時は0埋めではなく明示的に例外を投げる（誤った返礼サマリー表示を防ぐ）。
+		// 技術詳細はサーバーログにのみ残し、UI には汎用メッセージを返す。
+		console.error("[convertToReturnManagementSummaries] bulk fetch failed:", bulk.error);
+		throw new Error("返礼情報の取得に失敗しました");
 	}
 	const amountsMap: Map<string, EntryAmountStats> = bulk.data;
 

--- a/src/utils/return-records-helpers.ts
+++ b/src/utils/return-records-helpers.ts
@@ -3,15 +3,21 @@
  * @module return-records-helpers
  */
 
+import { calculateEntryTotalAmountBulk } from "@/app/_actions/offerings/queries";
 import type { Entry } from "@/types/entries";
 import type { Relationship } from "@/types/relationships";
 import type {
 	ReturnEntryRecord,
+	ReturnItem,
 	ReturnManagementSummary,
 	ReturnStatus,
-	ReturnItem,
 } from "@/types/return-records/return-records";
-import { calculateEntryTotalAmount } from "@/app/_actions/offerings/queries";
+
+type EntryAmountStats = {
+	kouden_amount: number;
+	offering_total: number;
+	calculated_total: number;
+};
 
 /**
  * 返礼状況の表示用テキストを取得
@@ -37,14 +43,16 @@ function getStatusDisplay(status: ReturnStatus): string {
  * @param entries - 香典エントリー一覧
  * @param relationships - 関係性一覧
  * @param koudenId - 香典帳ID
+ * @param entryAmountsMap - 事前に一括計算した香典金額/お供物配分のMap
  * @returns ReturnManagementSummary
  */
-export async function convertToReturnManagementSummary(
+export function convertToReturnManagementSummary(
 	returnRecord: ReturnEntryRecord,
 	entries: Entry[],
 	relationships: Relationship[],
 	koudenId: string,
-): Promise<ReturnManagementSummary | null> {
+	entryAmountsMap: Map<string, EntryAmountStats>,
+): ReturnManagementSummary | null {
 	const entry = entries.find((e) => e.id === returnRecord.kouden_entry_id);
 	if (!entry) return null;
 
@@ -56,15 +64,10 @@ export async function convertToReturnManagementSummary(
 	// 関係性名を取得
 	const relationship = relationships.find((r) => r.id === entry.relationship_id);
 
-	// 実際のお供物配分金額を取得
-	const entryTotalAmountResult = await calculateEntryTotalAmount(entry.id);
-	let offeringTotal = 0;
-	let totalAmount = entry.amount || 0;
-
-	if (entryTotalAmountResult.success && entryTotalAmountResult.data) {
-		offeringTotal = entryTotalAmountResult.data.offering_total;
-		totalAmount = entryTotalAmountResult.data.calculated_total;
-	}
+	// 事前計算済みのお供物配分金額を参照（N+1回避）
+	const stats = entryAmountsMap.get(entry.id);
+	const offeringTotal = stats?.offering_total ?? 0;
+	const totalAmount = stats?.calculated_total ?? entry.amount ?? 0;
 
 	return {
 		koudenId: koudenId,
@@ -75,8 +78,8 @@ export async function convertToReturnManagementSummary(
 		relationshipName: relationship?.name || "",
 		koudenAmount: entry.amount || 0,
 		offeringCount: entry.has_offering ? 1 : 0,
-		offeringTotal: offeringTotal, // 実際の配分金額を使用
-		totalAmount: totalAmount, // 実際の合計金額を使用
+		offeringTotal: offeringTotal,
+		totalAmount: totalAmount,
 		returnStatus: returnRecord.return_status as ReturnStatus,
 		funeralGiftAmount: returnRecord.funeral_gift_amount || 0,
 		additionalReturnAmount: returnRecord.additional_return_amount || 0,
@@ -98,11 +101,7 @@ export async function convertToReturnManagementSummary(
 
 /**
  * 複数のReturnEntryRecordを一括でReturnManagementSummary形式に変換する
- * @param returnRecords - 返礼エントリーレコード配列
- * @param entries - 香典エントリー一覧
- * @param relationships - 関係性一覧
- * @param koudenId - 香典帳ID
- * @returns ReturnManagementSummary配列
+ * お供物配分金額は1回のbulkクエリで取得しN+1を回避する。
  */
 export async function convertToReturnManagementSummaries(
 	returnRecords: ReturnEntryRecord[],
@@ -110,11 +109,21 @@ export async function convertToReturnManagementSummaries(
 	relationships: Relationship[],
 	koudenId: string,
 ): Promise<ReturnManagementSummary[]> {
-	const results = await Promise.all(
-		returnRecords.map(async (record) => {
-			return await convertToReturnManagementSummary(record, entries, relationships, koudenId);
-		}),
+	const entryIds = Array.from(
+		new Set(
+			returnRecords
+				.map((r) => r.kouden_entry_id)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
 	);
 
-	return results.filter((summary): summary is ReturnManagementSummary => summary !== null);
+	const bulk = await calculateEntryTotalAmountBulk(entryIds);
+	const amountsMap: Map<string, EntryAmountStats> =
+		bulk.success && bulk.data ? bulk.data : new Map();
+
+	return returnRecords
+		.map((record) =>
+			convertToReturnManagementSummary(record, entries, relationships, koudenId, amountsMap),
+		)
+		.filter((summary): summary is ReturnManagementSummary => summary !== null);
 }

--- a/supabase/migrations/20260513000000_add_get_users_aggregate_stats_rpc.sql
+++ b/supabase/migrations/20260513000000_add_get_users_aggregate_stats_rpc.sql
@@ -1,0 +1,71 @@
+-- 管理者ユーザー一覧のN+1解消用RPC関数
+-- Issue: https://github.com/otomatty/kouden/issues/36
+--
+-- 指定された user_id 群について、以下を1クエリで一括取得:
+--   - 所有香典帳数 (koudens.owner_id)
+--   - 参加香典帳数 (kouden_members.user_id)
+--   - 作成エントリー数 (kouden_entries.created_by)
+--   - 管理者ロール / 付与日時 (admin_users)
+--
+-- 呼び出し元は必ず isAdmin() チェックを行ったServer Actionから使用する前提。
+
+CREATE OR REPLACE FUNCTION public.get_users_aggregate_stats(
+    p_user_ids uuid[]
+)
+RETURNS TABLE (
+    user_id uuid,
+    owned_koudens_count bigint,
+    participated_koudens_count bigint,
+    total_entries_count bigint,
+    admin_role text,
+    admin_created_at timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH input_ids AS (
+        SELECT unnest(p_user_ids) AS uid
+    ),
+    owned AS (
+        SELECT owner_id AS uid, COUNT(*)::bigint AS cnt
+        FROM koudens
+        WHERE owner_id = ANY(p_user_ids)
+        GROUP BY owner_id
+    ),
+    participated AS (
+        SELECT user_id AS uid, COUNT(*)::bigint AS cnt
+        FROM kouden_members
+        WHERE user_id = ANY(p_user_ids)
+        GROUP BY user_id
+    ),
+    entries_cnt AS (
+        SELECT created_by AS uid, COUNT(*)::bigint AS cnt
+        FROM kouden_entries
+        WHERE created_by = ANY(p_user_ids)
+        GROUP BY created_by
+    ),
+    admin AS (
+        SELECT user_id AS uid, role::text AS r, created_at AS ca
+        FROM admin_users
+        WHERE user_id = ANY(p_user_ids)
+    )
+    SELECT
+        i.uid,
+        COALESCE(o.cnt, 0),
+        COALESCE(p.cnt, 0),
+        COALESCE(e.cnt, 0),
+        a.r,
+        a.ca
+    FROM input_ids i
+    LEFT JOIN owned o ON o.uid = i.uid
+    LEFT JOIN participated p ON p.uid = i.uid
+    LEFT JOIN entries_cnt e ON e.uid = i.uid
+    LEFT JOIN admin a ON a.uid = i.uid;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_users_aggregate_stats(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_users_aggregate_stats(uuid[]) TO authenticated;
+
+COMMENT ON FUNCTION public.get_users_aggregate_stats(uuid[]) IS
+    '管理者ユーザー一覧用: 指定 user_id 群の koudens/members/entries 件数 + admin role を一括取得 (N+1解消)';

--- a/supabase/migrations/20260513000000_add_get_users_aggregate_stats_rpc.sql
+++ b/supabase/migrations/20260513000000_add_get_users_aggregate_stats_rpc.sql
@@ -7,7 +7,9 @@
 --   - 作成エントリー数 (kouden_entries.created_by)
 --   - 管理者ロール / 付与日時 (admin_users)
 --
--- 呼び出し元は必ず isAdmin() チェックを行ったServer Actionから使用する前提。
+-- セキュリティ:
+--   SECURITY DEFINER で RLS をバイパスして集計するため、関数内で
+--   is_admin(auth.uid()) をチェックして管理者以外からの呼び出しを拒否する。
 
 CREATE OR REPLACE FUNCTION public.get_users_aggregate_stats(
     p_user_ids uuid[]
@@ -20,10 +22,18 @@ RETURNS TABLE (
     admin_role text,
     admin_created_at timestamptz
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（RLSバイパスの保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_users_aggregate_stats'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
     WITH input_ids AS (
         SELECT unnest(p_user_ids) AS uid
     ),
@@ -34,10 +44,10 @@ AS $$
         GROUP BY owner_id
     ),
     participated AS (
-        SELECT user_id AS uid, COUNT(*)::bigint AS cnt
-        FROM kouden_members
-        WHERE user_id = ANY(p_user_ids)
-        GROUP BY user_id
+        SELECT km.user_id AS uid, COUNT(*)::bigint AS cnt
+        FROM kouden_members km
+        WHERE km.user_id = ANY(p_user_ids)
+        GROUP BY km.user_id
     ),
     entries_cnt AS (
         SELECT created_by AS uid, COUNT(*)::bigint AS cnt
@@ -46,9 +56,9 @@ AS $$
         GROUP BY created_by
     ),
     admin AS (
-        SELECT user_id AS uid, role::text AS r, created_at AS ca
-        FROM admin_users
-        WHERE user_id = ANY(p_user_ids)
+        SELECT au.user_id AS uid, au.role::text AS r, au.created_at AS ca
+        FROM admin_users au
+        WHERE au.user_id = ANY(p_user_ids)
     )
     SELECT
         i.uid,
@@ -62,10 +72,11 @@ AS $$
     LEFT JOIN participated p ON p.uid = i.uid
     LEFT JOIN entries_cnt e ON e.uid = i.uid
     LEFT JOIN admin a ON a.uid = i.uid;
+END;
 $$;
 
 REVOKE ALL ON FUNCTION public.get_users_aggregate_stats(uuid[]) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_users_aggregate_stats(uuid[]) TO authenticated;
 
 COMMENT ON FUNCTION public.get_users_aggregate_stats(uuid[]) IS
-    '管理者ユーザー一覧用: 指定 user_id 群の koudens/members/entries 件数 + admin role を一括取得 (N+1解消)';
+    '管理者ユーザー一覧用: 指定 user_id 群の koudens/members/entries 件数 + admin role を一括取得 (N+1解消)。関数内で is_admin(auth.uid()) を強制。';


### PR DESCRIPTION
- offerings/queries.ts: add calculateEntryTotalAmountBulk for batched fetch
- return-records-helpers: replace per-record awaits with single bulk lookup,
  reducing 100×2 → 2 queries on return management page (initial load,
  infinite scroll, bulk-update dialog)
- statistics pages (protected + admin): switch from per-entry awaits to the
  bulk lookup for the same N+1 fix
- admin/users.ts: replace per-user getUserStats + getUserAdminInfo calls
  with a single get_users_aggregate_stats RPC, reducing 20×4 → 2 queries
- supabase: add get_users_aggregate_stats(uuid[]) RPC (SECURITY DEFINER,
  pinned search_path) with LEFT JOIN aggregation across koudens,
  kouden_members, kouden_entries, admin_users
- tests: add 5 vitest cases for calculateEntryTotalAmountBulk including
  empty-input short-circuit and error paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 統計画面の管理者向けエラー表示（再試行ボタン付き）を追加しました
  * 返却管理サマリの一括生成をサーバー側で行うようにしました
* **パフォーマンス改善**
  * 複数エントリの合算を一括処理に置換し、統計・返却管理・ユーザー一覧の集計を高速化しました
* **バグ修正**
  * 一括集計失敗時に明示的にエラーを返し、不正な統計表示を防止しました
* **テスト**
  * 一括合算ロジックの単体テストを追加しました
* **データベース**
  * ユーザー集計用の新規DB関数とマイグレーションを追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->