### PR TITLE
Fix critical RLS vulnerabilities and secure server actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY=
 # CSRF_SECRET: 必須・最低32文字。未設定だとアプリは起動失敗する。
 # 生成例: openssl rand -hex 32
 CSRF_SECRET=
+# CRON_SECRET: 必須・最低32文字。未設定だと /api/cron/* が起動失敗する。
+# Vercel Cron Jobs / 手動Cronから `Authorization: Bearer <CRON_SECRET>` で呼び出すこと。
+# 生成例: openssl rand -hex 32
+CRON_SECRET=
 SLACK_WEBHOOK_URL= #オプションで設定するかも?
 SECURITY_LOG_LEVEL="info" #本番環境では空にするかfalseにする
 MAX_FILE_SIZE="10485760" #10MB

--- a/src/app/(protected)/koudens/_components/create-kouden-form.tsx
+++ b/src/app/(protected)/koudens/_components/create-kouden-form.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { createKouden } from "@/app/_actions/koudens";
+import { ResponsiveDialog } from "@/components/custom/responsive-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { useRouter } from "next/navigation";
-import { createKouden } from "@/app/_actions/koudens";
-import { createClient } from "@/lib/supabase/client";
-import { ResponsiveDialog } from "@/components/custom/responsive-dialog";
-import { Plus } from "lucide-react";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { createClient } from "@/lib/supabase/client";
+import { Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
 
 export function CreateKoudenForm() {
 	const router = useRouter();
@@ -37,7 +37,6 @@ export function CreateKoudenForm() {
 			const result = await createKouden({
 				title,
 				description,
-				userId: user.id,
 			});
 
 			if (result.error) {

--- a/src/app/(protected)/koudens/new/page.tsx
+++ b/src/app/(protected)/koudens/new/page.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next";
 import { getPlans } from "@/app/_actions/plans";
 import { NewKoudenPlanSelector } from "@/components/custom/new-kouden-plan-selector";
 import { createClient } from "@/lib/supabase/server";
+import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "新規香典帳作成",
 	description: "香典帳の新規作成ページです",
@@ -11,17 +11,17 @@ export default async function NewKoudenPage() {
 	const { plans = [], error } = await getPlans();
 	if (error) throw new Error(error);
 
+	// 認証チェックのみ（userId はサーバーアクション側で auth.uid() から導出するため不要）
 	const supabase = await createClient();
 	const { data, error: userError } = await supabase.auth.getUser();
-	const user = data.user;
-	if (userError || !user) {
+	if (userError || !data.user) {
 		throw new Error("ユーザーが見つかりません");
 	}
 
 	return (
 		<div className="max-w-2xl mx-auto">
 			<h1 className="text-2xl font-bold mb-6">香典帳を作成する</h1>
-			<NewKoudenPlanSelector plans={plans} userId={user.id} />
+			<NewKoudenPlanSelector plans={plans} />
 		</div>
 	);
 }

--- a/src/app/_actions/invitations.ts
+++ b/src/app/_actions/invitations.ts
@@ -348,12 +348,22 @@ export async function acceptInvitation(token: string) {
 		}
 
 		// 5. 招待のステータスと使用回数を更新
+		// マルチユーズ招待 (max_uses > 1 もしくは max_uses IS NULL) は、まだ枠が
+		// 残っている間 status='pending' のままにする。`getInvitation` は
+		// status='pending' のレコードのみを返すため、初回受諾で 'accepted' に
+		// すると 2 人目以降がトークンを使えなくなる。
+		const newUsedCount = invitation.used_count + 1;
+		const isExhausted = invitation.max_uses !== null && newUsedCount >= invitation.max_uses;
+		const invitationUpdate: { used_count: number; status?: "accepted" } = {
+			used_count: newUsedCount,
+		};
+		if (isExhausted) {
+			invitationUpdate.status = "accepted";
+		}
+
 		const { error: updateError } = await supabase
 			.from("kouden_invitations")
-			.update({
-				status: "accepted",
-				used_count: invitation.used_count + 1,
-			})
+			.update(invitationUpdate)
 			.eq("id", invitation.id);
 
 		if (updateError) {

--- a/src/app/_actions/invitations.ts
+++ b/src/app/_actions/invitations.ts
@@ -1,11 +1,14 @@
 "use server";
 
+import logger from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
-import { z } from "zod";
-import ms from "ms";
 import type { Database } from "@/types/supabase";
 import type { PostgrestError } from "@supabase/supabase-js";
-import logger from "@/lib/logger";
+import ms from "ms";
+import { z } from "zod";
+
+const INVITATION_TOKEN_SCHEMA = z.string().uuid();
 
 const createInvitationSchema = z.object({
 	koudenId: z.string().uuid(),
@@ -82,13 +85,23 @@ export async function createShareInvitation(
 
 export async function getInvitation(token: string) {
 	try {
-		const supabase = await createClient();
+		// 入力検証: UUID 以外をDBに当てない
+		const parsedToken = INVITATION_TOKEN_SCHEMA.safeParse(token);
+		if (!parsedToken.success) {
+			throw new Error("招待情報が見つかりません");
+		}
+
+		// セッション取得は通常クライアントで行う（auth.uid を取り出すため）
+		const userClient = await createClient();
 		const {
 			data: { user },
-		} = await supabase.auth.getUser();
+		} = await userClient.auth.getUser();
 
-		// 招待情報を取得
-		const query = supabase
+		// 招待行のルックアップは admin client で実行する。
+		// kouden_invitations への匿名 SELECT は RLS で禁止しているため、
+		// トークン入力をサーバー側で検証してから service-role で取得する。
+		const adminClient = createAdminClient();
+		const query = adminClient
 			.from("kouden_invitations")
 			.select(`
 				*,
@@ -97,7 +110,7 @@ export async function getInvitation(token: string) {
 					name
 				)
 			`)
-			.eq("invitation_token", token)
+			.eq("invitation_token", parsedToken.data)
 			.eq("status", "pending")
 			.gt("expires_at", new Date().toISOString())
 			.single();
@@ -113,7 +126,6 @@ export async function getInvitation(token: string) {
 				{
 					error: invitationError.message,
 					code: invitationError.code,
-					token,
 				},
 				"Database error in getInvitation",
 			);
@@ -124,12 +136,12 @@ export async function getInvitation(token: string) {
 		}
 
 		if (!invitation) {
-			logger.error({ token }, "No invitation found for token");
+			logger.error({}, "No invitation found for token");
 			throw new Error("招待情報が見つかりません");
 		}
 
-		// 作成者の情報を取得
-		const { data: creatorProfile, error: creatorError } = await supabase
+		// 作成者の情報を取得（profiles は誰でも閲覧可能なため通常クライアントでも可）
+		const { data: creatorProfile, error: creatorError } = await adminClient
 			.from("profiles")
 			.select("display_name")
 			.eq("id", invitation.created_by)
@@ -149,9 +161,9 @@ export async function getInvitation(token: string) {
 		// ユーザーが既にメンバーかどうかをチェック
 		let isExistingMember = false;
 		if (user) {
-			const { data: existingMember, error: memberCheckError } = await supabase
+			const { data: existingMember, error: memberCheckError } = await adminClient
 				.from("kouden_members")
-				.select()
+				.select("id")
 				.eq("kouden_id", invitation.kouden_id)
 				.eq("user_id", user.id)
 				.single();
@@ -194,20 +206,33 @@ export async function getInvitation(token: string) {
 
 export async function acceptInvitation(token: string) {
 	try {
-		const supabase = await createClient();
+		// 入力検証: UUID 以外は弾く
+		const parsedToken = INVITATION_TOKEN_SCHEMA.safeParse(token);
+		if (!parsedToken.success) {
+			throw new Error("招待が見つかりません");
+		}
+
+		// 認証チェックは必ず通常クライアントから（auth.uid()）
+		const userClient = await createClient();
 		const {
 			data: { user },
-		} = await supabase.auth.getUser();
+		} = await userClient.auth.getUser();
 
 		if (!user) {
 			throw new Error("認証が必要です");
 		}
 
+		// 以降は service-role で操作する:
+		// - kouden_invitations は RLS で匿名/他人からのSELECTを禁止しているため admin で参照
+		// - kouden_members への INSERT は所有者のみ許可するポリシーに変更したため
+		//   招待経由の自分自身の追加もサーバー側で検証してから admin で実施する
+		const supabase = createAdminClient();
+
 		// 1. 招待情報を取得
 		const { data: invitation, error: invitationError } = await supabase
 			.from("kouden_invitations")
 			.select("*")
-			.eq("invitation_token", token)
+			.eq("invitation_token", parsedToken.data)
 			.single();
 
 		if (invitationError) {
@@ -215,7 +240,6 @@ export async function acceptInvitation(token: string) {
 				{
 					error: invitationError.message,
 					code: invitationError.code,
-					token,
 				},
 				"Failed to get invitation",
 			);
@@ -226,17 +250,16 @@ export async function acceptInvitation(token: string) {
 		}
 
 		if (!invitation) {
-			logger.error({ token }, "No invitation found for token");
+			logger.error({}, "No invitation found for token");
 			throw new Error("招待が見つかりません");
 		}
 
 		// 2. 招待の有効性チェック
 		if (invitation.status !== "pending") {
-			logger.error(
+			logger.warn(
 				{
 					invitationId: invitation.id,
 					status: invitation.status,
-					token,
 				},
 				"Invitation status is not pending",
 			);
@@ -246,12 +269,11 @@ export async function acceptInvitation(token: string) {
 		const now = new Date();
 		const expiresAt = new Date(invitation.expires_at);
 		if (expiresAt < now) {
-			logger.error(
+			logger.warn(
 				{
 					invitationId: invitation.id,
 					expiresAt: expiresAt.toISOString(),
 					now: now.toISOString(),
-					token,
 				},
 				"Invitation expired",
 			);
@@ -259,12 +281,11 @@ export async function acceptInvitation(token: string) {
 		}
 
 		if (invitation.max_uses && invitation.used_count >= invitation.max_uses) {
-			logger.error(
+			logger.warn(
 				{
 					invitationId: invitation.id,
 					used_count: invitation.used_count,
 					max_uses: invitation.max_uses,
-					token,
 				},
 				"Invitation usage limit exceeded",
 			);
@@ -274,7 +295,7 @@ export async function acceptInvitation(token: string) {
 		// 3. 既存メンバーチェック
 		const { data: existingMember, error: memberCheckError } = await supabase
 			.from("kouden_members")
-			.select()
+			.select("id")
 			.eq("kouden_id", invitation.kouden_id)
 			.eq("user_id", user.id)
 			.single();
@@ -293,24 +314,23 @@ export async function acceptInvitation(token: string) {
 		}
 
 		if (existingMember) {
-			logger.error(
+			logger.warn(
 				{
 					userId: user.id,
 					koudenId: invitation.kouden_id,
-					token,
 				},
 				"User is already a member",
 			);
 			throw new Error("すでにメンバーとして参加しています");
 		}
 
-		// 4. メンバー追加
+		// 4. メンバー追加（招待の created_by を added_by として記録する）
 		const { error: memberError } = await supabase.from("kouden_members").insert({
 			kouden_id: invitation.kouden_id,
 			user_id: user.id,
 			role_id: invitation.role_id,
 			invitation_id: invitation.id,
-			added_by: user.id,
+			added_by: invitation.created_by,
 		});
 
 		if (memberError) {

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -1,36 +1,46 @@
 "use server";
 
+import logger from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import type { CreateKoudenParams, Kouden } from "@/types/kouden";
 import { KOUDEN_ROLES } from "@/types/role";
-import logger from "@/lib/logger";
 
-export interface CreateKoudenWithPlanParams extends CreateKoudenParams {
+export interface CreateKoudenWithPlanParams extends Omit<CreateKoudenParams, "userId"> {
 	planCode: string;
 	expectedCount?: number;
 }
 
 /**
+ * 認証済みユーザーIDを取得する内部ヘルパー。
+ * service-role の admin client では `auth.getUser()` がセッションを持たないため、
+ * 必ず通常の server client から取得する。クライアントから渡された userId は信用しない。
+ */
+async function getAuthenticatedUserId(): Promise<string | null> {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+	return user?.id ?? null;
+}
+
+/**
  * 香典帳の作成
+ *
+ * 注意: `userId` パラメータが渡された場合でも信用せず、必ずセッションから
+ * 取得した auth.uid() を使用する。
  */
 export async function createKouden({
 	title,
 	description,
-	userId,
-}: CreateKoudenParams): Promise<{ kouden?: Kouden; error?: string }> {
-	try {
-		const supabase = await createAdminClient();
+}: Omit<CreateKoudenParams, "userId">): Promise<{ kouden?: Kouden; error?: string }> {
+	const userId = await getAuthenticatedUserId();
+	if (!userId) {
+		return { error: "認証が必要です" };
+	}
 
-		// ユーザーIDが渡されていない場合は現在のユーザーのIDを使用
-		if (!userId) {
-			const {
-				data: { user },
-			} = await supabase.auth.getUser();
-			if (!user) {
-				return { error: "認証が必要です" };
-			}
-			userId = user.id;
-		}
+	try {
+		const supabase = createAdminClient();
 
 		// freeプランIDを取得
 		const { data: freePlan, error: freePlanError } = await supabase
@@ -103,37 +113,51 @@ export async function createKouden({
 }
 
 /**
- * 有料プラン付き香典帳作成
+ * 無料プラン付き香典帳作成（クライアントから直接呼び出される唯一の経路）
+ *
+ * セキュリティ要件:
+ * - `planCode` は `"free"` のみ許可。有料プランの作成は `purchaseKouden`
+ *   → Stripe Webhook の経路でのみ可能（決済済みの事実を Stripe 署名で検証）。
+ * - `userId` パラメータは受け取らず、必ずセッションから取得する。
  */
 export async function createKoudenWithPlan({
 	title,
 	description,
-	userId,
 	planCode,
 	expectedCount,
 }: CreateKoudenWithPlanParams): Promise<{ koudenId?: string; error?: string }> {
-	// catch 内でユーザーIDをログ出力するため try の外に宣言している
-	let uid = userId;
+	const uid = await getAuthenticatedUserId();
+	if (!uid) {
+		return { error: "認証が必要です" };
+	}
+
+	// 有料プランの場合はこの経路を許可しない（Stripe Webhook 経由のみ）。
+	if (planCode !== "free") {
+		logger.warn(
+			{ planCode, userId: uid },
+			"createKoudenWithPlan called with non-free planCode; rejecting",
+		);
+		return { error: "有料プランは決済フローからのみ作成できます" };
+	}
+
 	try {
 		const supabase = createAdminClient();
-		if (!uid) {
-			const {
-				data: { user },
-				error: userError,
-			} = await supabase.auth.getUser();
-			if (userError || !user) {
-				return { error: "認証が必要です" };
-			}
-			uid = user.id;
-		}
 		// プラン取得（IDと価格）
 		const { data: plan, error: planError } = await supabase
 			.from("plans")
-			.select("id, price")
+			.select("id, price, code")
 			.eq("code", planCode)
 			.single();
 		if (planError || !plan) {
 			return { error: "プランが見つかりません" };
+		}
+		// 念のため price の0円も確認しておく（DB側で free が誤って課金プランに変わるのを防ぐ）
+		if (plan.code !== "free" || (plan.price ?? 0) !== 0) {
+			logger.error(
+				{ planCode, planPrice: plan.price, planDbCode: plan.code, userId: uid },
+				"createKoudenWithPlan: plan integrity check failed (expected free / price 0)",
+			);
+			return { error: "プラン整合性エラー" };
 		}
 		// 香典帳作成
 		const { data: kouden, error: koudenError } = await supabase
@@ -144,14 +168,13 @@ export async function createKoudenWithPlan({
 		if (koudenError || !kouden) {
 			throw koudenError;
 		}
-		// 購入履歴作成
-		const amountPaid = plan.price;
+		// 購入履歴作成（無料プランは amount_paid=0）
 		const { error: purchaseError } = await supabase.from("kouden_purchases").insert({
 			kouden_id: kouden.id,
 			user_id: uid,
 			plan_id: plan.id,
 			expected_count: expectedCount,
-			amount_paid: amountPaid,
+			amount_paid: 0,
 		});
 		if (purchaseError) {
 			throw purchaseError;

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
-import { createAdminClient } from "@/lib/supabase/admin";
-import { Resend } from "resend";
-import { buildReminderEmail } from "@/utils/emailTemplates/reminder";
 import logger from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { buildReminderEmail } from "@/utils/emailTemplates/reminder";
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
 
 const apiKey = process.env.RESEND_API_KEY;
 if (!apiKey) {
@@ -10,7 +10,54 @@ if (!apiKey) {
 }
 const resend = new Resend(apiKey);
 
-export async function GET() {
+const cronSecret = process.env.CRON_SECRET;
+if (!cronSecret || cronSecret.length < 32) {
+	throw new Error(
+		"CRON_SECRET environment variable is not set or too short (require >= 32 chars). " +
+			"Generate one with: openssl rand -hex 32",
+	);
+}
+
+/**
+ * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) {
+		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return diff === 0;
+}
+
+/**
+ * Cron リクエストの認証。`Authorization: Bearer <CRON_SECRET>` を必須にする。
+ * Vercel Cron は環境変数 `CRON_SECRET` を自動的に Authorization ヘッダーに載せて
+ * 呼び出すので、単一の Bearer チェックでカバーできる。
+ */
+function isAuthorizedCronRequest(request: Request): boolean {
+	const authHeader = request.headers.get("authorization");
+	if (!authHeader?.startsWith("Bearer ")) {
+		return false;
+	}
+	const provided = authHeader.slice("Bearer ".length).trim();
+	return timingSafeEqual(provided, cronSecret as string);
+}
+
+export async function GET(request: Request) {
+	if (!isAuthorizedCronRequest(request)) {
+		logger.warn(
+			{
+				path: "/api/cron/send-reminders",
+				hasAuthHeader: !!request.headers.get("authorization"),
+			},
+			"Unauthorized cron request rejected",
+		);
+		return new NextResponse("Unauthorized", { status: 401 });
+	}
+
 	// Supabase 管理クライアント取得
 	const supabase = createAdminClient();
 

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -5,15 +5,28 @@ import { NextResponse } from "next/server";
 import { Resend } from "resend";
 
 /**
- * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
+ * Web Crypto API で SHA-256 ハッシュを生成する。
  */
-function timingSafeEqual(a: string, b: string): boolean {
-	if (a.length !== b.length) {
-		return false;
-	}
+async function sha256(data: string): Promise<Uint8Array> {
+	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(data));
+	return new Uint8Array(buf);
+}
+
+/**
+ * SHA-256 ハッシュ後に定数時間比較することで、入力長の漏洩までを防ぐ。
+ *
+ * - 直接 `a.length !== b.length` を比較すると、誤った長さで早期 return することで
+ *   攻撃者がシークレットの長さを timing から推測できる可能性がある。
+ * - ハッシュ後は両方とも 32 バイト固定長になるため、length チェックの分岐は
+ *   入力に対して定数時間。XOR ループも全 32 バイトを必ず舐める。
+ */
+async function timingSafeEqualHashed(a: string, b: string): Promise<boolean> {
+	const [ha, hb] = await Promise.all([sha256(a), sha256(b)]);
+	// 両ハッシュとも 32 バイト固定。length 不一致は理論上発生しない防御線。
+	if (ha.length !== hb.length) return false;
 	let diff = 0;
-	for (let i = 0; i < a.length; i++) {
-		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	for (let i = 0; i < ha.length; i++) {
+		diff |= (ha[i] as number) ^ (hb[i] as number);
 	}
 	return diff === 0;
 }
@@ -28,13 +41,13 @@ function timingSafeEqual(a: string, b: string): boolean {
  * ビルドを落としてしまう（Vercel Preview 等で問題になる）。フェイルクローズドの
  * 性質はリクエスト時の戻り値 500/401 で維持できる。
  */
-function isAuthorizedCronRequest(request: Request, cronSecret: string): boolean {
+async function isAuthorizedCronRequest(request: Request, cronSecret: string): Promise<boolean> {
 	const authHeader = request.headers.get("authorization");
 	if (!authHeader?.startsWith("Bearer ")) {
 		return false;
 	}
 	const provided = authHeader.slice("Bearer ".length).trim();
-	return timingSafeEqual(provided, cronSecret);
+	return timingSafeEqualHashed(provided, cronSecret);
 }
 
 export async function GET(request: Request) {
@@ -50,15 +63,12 @@ export async function GET(request: Request) {
 
 	const apiKey = process.env.RESEND_API_KEY;
 	if (!apiKey) {
-		logger.error(
-			{ path: "/api/cron/send-reminders" },
-			"RESEND_API_KEY is not set",
-		);
+		logger.error({ path: "/api/cron/send-reminders" }, "RESEND_API_KEY is not set");
 		return new NextResponse("Server misconfiguration", { status: 500 });
 	}
 	const resend = new Resend(apiKey);
 
-	if (!isAuthorizedCronRequest(request, cronSecret)) {
+	if (!(await isAuthorizedCronRequest(request, cronSecret))) {
 		logger.warn(
 			{
 				path: "/api/cron/send-reminders",

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -4,20 +4,6 @@ import { buildReminderEmail } from "@/utils/emailTemplates/reminder";
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
 
-const apiKey = process.env.RESEND_API_KEY;
-if (!apiKey) {
-	throw new Error("Missing RESEND_API_KEY");
-}
-const resend = new Resend(apiKey);
-
-const cronSecret = process.env.CRON_SECRET;
-if (!cronSecret || cronSecret.length < 32) {
-	throw new Error(
-		"CRON_SECRET environment variable is not set or too short (require >= 32 chars). " +
-			"Generate one with: openssl rand -hex 32",
-	);
-}
-
 /**
  * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
  */
@@ -36,18 +22,43 @@ function timingSafeEqual(a: string, b: string): boolean {
  * Cron リクエストの認証。`Authorization: Bearer <CRON_SECRET>` を必須にする。
  * Vercel Cron は環境変数 `CRON_SECRET` を自動的に Authorization ヘッダーに載せて
  * 呼び出すので、単一の Bearer チェックでカバーできる。
+ *
+ * 環境変数は build 時ではなく **リクエスト時** に検証する。Next.js は build フェーズ
+ * で route モジュールを評価するため、トップレベルの throw は環境変数未設定時に
+ * ビルドを落としてしまう（Vercel Preview 等で問題になる）。フェイルクローズドの
+ * 性質はリクエスト時の戻り値 500/401 で維持できる。
  */
-function isAuthorizedCronRequest(request: Request): boolean {
+function isAuthorizedCronRequest(request: Request, cronSecret: string): boolean {
 	const authHeader = request.headers.get("authorization");
 	if (!authHeader?.startsWith("Bearer ")) {
 		return false;
 	}
 	const provided = authHeader.slice("Bearer ".length).trim();
-	return timingSafeEqual(provided, cronSecret as string);
+	return timingSafeEqual(provided, cronSecret);
 }
 
 export async function GET(request: Request) {
-	if (!isAuthorizedCronRequest(request)) {
+	// 環境変数チェック（リクエスト時に評価して build を落とさない）
+	const cronSecret = process.env.CRON_SECRET;
+	if (!cronSecret || cronSecret.length < 32) {
+		logger.error(
+			{ path: "/api/cron/send-reminders" },
+			"CRON_SECRET is not set or too short (require >= 32 chars). Generate one with: openssl rand -hex 32",
+		);
+		return new NextResponse("Server misconfiguration", { status: 500 });
+	}
+
+	const apiKey = process.env.RESEND_API_KEY;
+	if (!apiKey) {
+		logger.error(
+			{ path: "/api/cron/send-reminders" },
+			"RESEND_API_KEY is not set",
+		);
+		return new NextResponse("Server misconfiguration", { status: 500 });
+	}
+	const resend = new Resend(apiKey);
+
+	if (!isAuthorizedCronRequest(request, cronSecret)) {
 		logger.warn(
 			{
 				path: "/api/cron/send-reminders",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,6 +2,35 @@ import { acceptInvitation } from "@/app/_actions/invitations";
 import { createClient } from "@/lib/supabase/server";
 import { cookies } from "next/headers";
 
+/**
+ * オープンリダイレクト対策。リダイレクト先として安全な相対パスのみを許可する。
+ *
+ * 受理する値:
+ *   - "/" で始まる相対パス（"/koudens/123" など）
+ * 拒否する値:
+ *   - スキーム付き絶対URL（"https://evil.com" など）
+ *   - プロトコル相対URL（"//evil.com"）
+ *   - バックスラッシュで始まるパス（"\\evil.com" — ブラウザで "//evil.com" と解釈されうる）
+ *   - 空文字 / 不正な文字列
+ *
+ * 戻り値: そのまま `Response.redirect(new URL(value, origin))` に渡せる安全な相対パス、または `null`。
+ */
+function sanitizeRedirectPath(value: string | null | undefined): string | null {
+	if (!value) return null;
+	if (value.startsWith("//") || value.startsWith("\\")) return null;
+	if (!value.startsWith("/")) return null;
+	try {
+		// base URL を使えば相対パスでも URL としてパースできる。
+		// origin が変わった (= 絶対URLが指定されていた) ら拒否する。
+		const base = "https://internal.invalid";
+		const parsed = new URL(value, base);
+		if (parsed.origin !== base) return null;
+		return parsed.pathname + parsed.search + parsed.hash;
+	} catch {
+		return null;
+	}
+}
+
 export async function GET(request: Request) {
 	const requestUrl = new URL(request.url);
 	const code = requestUrl.searchParams.get("code");
@@ -9,8 +38,8 @@ export async function GET(request: Request) {
 	const invitationToken = cookieStore.get("invitation_token")?.value;
 	// URLパラメータからもトークンを取得（フォールバック）
 	const urlInvitationToken = requestUrl.searchParams.get("token");
-	// Read custom redirect target (deprecated, cookie override used)
-	const redirectToParam = requestUrl.searchParams.get("redirectTo");
+	// 認証後リダイレクト先（オープンリダイレクト対策で相対パスのみ許可）
+	const redirectToParam = sanitizeRedirectPath(requestUrl.searchParams.get("redirectTo"));
 
 	// Use cookie token first, fallback to URL parameter
 	const finalInvitationToken = invitationToken || urlInvitationToken;
@@ -32,9 +61,13 @@ export async function GET(request: Request) {
 		}
 
 		// Check for post-auth redirect cookie
-		const postRedirect = cookieStore.get("post_auth_redirect")?.value;
-		if (postRedirect) {
+		// Cookie値は document.cookie 経由で書き込まれるため、相対パスに正規化してから使う
+		const rawPostRedirect = cookieStore.get("post_auth_redirect")?.value;
+		const postRedirect = sanitizeRedirectPath(rawPostRedirect);
+		if (rawPostRedirect) {
 			cookieStore.delete("post_auth_redirect");
+		}
+		if (postRedirect) {
 			return Response.redirect(new URL(postRedirect, requestUrl.origin));
 		}
 

--- a/src/components/custom/new-kouden-plan-selector.tsx
+++ b/src/components/custom/new-kouden-plan-selector.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { createKoudenWithPlan } from "@/app/_actions/koudens/create";
+import { purchaseKouden } from "@/app/_actions/purchaseKouden";
+import { PlanSelector } from "@/components/custom/plan-selector";
+import { Button } from "@/components/ui/button";
 import {
 	Form,
 	FormControl,
@@ -14,26 +14,25 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
-import { PlanSelector } from "@/components/custom/plan-selector";
-import { purchaseKouden } from "@/app/_actions/purchaseKouden";
-import { createKoudenWithPlan } from "@/app/_actions/koudens/create";
 import {
-	newKoudenPlanSelectorSchema,
 	type NewKoudenPlanSelectorFormData,
+	newKoudenPlanSelectorSchema,
 } from "@/schemas/plan-selector";
 import type { Plan } from "@/types/plan-selector";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
 
 interface NewKoudenPlanSelectorProps {
 	plans: Plan[];
-	userId: string;
 }
 
 /**
  * 新規香典帳作成用のプラン選択フォームコンポーネント
  * 香典帳の基本情報とプラン選択を統合したフォーム
  */
-export function NewKoudenPlanSelector({ plans, userId }: NewKoudenPlanSelectorProps) {
+export function NewKoudenPlanSelector({ plans }: NewKoudenPlanSelectorProps) {
 	const router = useRouter();
 	const [loading, setLoading] = useState(false);
 
@@ -55,7 +54,6 @@ export function NewKoudenPlanSelector({ plans, userId }: NewKoudenPlanSelectorPr
 		try {
 			if (data.planCode === "free") {
 				const { koudenId, error } = await createKoudenWithPlan({
-					userId,
 					title: data.title,
 					description: data.description || undefined,
 					planCode: data.planCode,

--- a/supabase/migrations/20260516000000_security_review_critical_fixes.sql
+++ b/supabase/migrations/20260516000000_security_review_critical_fixes.sql
@@ -1,0 +1,151 @@
+-- 2026-05-16: Critical security fixes for review items C-2 / C-3 / C-6
+--
+-- このマイグレーションは "/security-review" レビューで Critical と判断された
+-- 以下の RLS 不備を是正する:
+--
+-- C-2 (kouden_invitations 公開SELECT):
+--     旧ポリシー `invitation_link_access` は status=pending の招待を匿名含む
+--     誰にでも SELECT させていた。invitation_token (UUID 秘密値) が漏れる。
+--     → 削除し、招待トークンのルックアップは Server Action 側で service-role
+--       クライアントを使って実施する。
+--
+-- C-3 (kouden_members 自由 INSERT):
+--     旧ポリシー `members_management` は `added_by = auth.uid()` のみで
+--     `kouden_id` / `user_id` / `role_id` を制約していなかった。
+--     → 削除し、所有者のみがメンバー管理できるポリシーへ置き換え。
+--       招待経由の追加は Server Action (acceptInvitation) で service-role
+--       クライアントを使って実施する。
+--
+-- C-6 (contact_requests 系の全件SELECT):
+--     `contact_requests` / `contact_request_attachments` / `contact_responses`
+--     の SELECT が `to authenticated using (true)` で誰でも全件参照可能だった。
+--     → 自分の問い合わせ or 管理者のみに絞る。
+--     `contact_request_attachments` の `to public with check (true)` INSERT も
+--     所有者限定に変更する。
+
+-- ========================================================================
+-- C-2: kouden_invitations
+-- ========================================================================
+
+DROP POLICY IF EXISTS "invitation_link_access" ON public.kouden_invitations;
+
+-- 招待トークンによるルックアップは Server Action から service-role で実施するため、
+-- 通常の `authenticated` / `anon` ロールに対しては SELECT 権限を持たせない。
+-- 既存の "owner_invitation_access" (所有者は管理可能) はそのまま残す。
+
+
+-- ========================================================================
+-- C-3: kouden_members
+-- ========================================================================
+
+DROP POLICY IF EXISTS "members_management" ON public.kouden_members;
+
+-- 所有者のみが自身の香典帳のメンバーを CRUD できる
+CREATE POLICY "members_owner_manage" ON public.kouden_members
+    AS PERMISSIVE
+    FOR ALL
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.koudens k
+            WHERE k.id = kouden_members.kouden_id
+              AND (k.owner_id = auth.uid() OR k.created_by = auth.uid())
+        )
+    )
+    WITH CHECK (
+        added_by = auth.uid()
+        AND EXISTS (
+            SELECT 1 FROM public.koudens k
+            WHERE k.id = kouden_members.kouden_id
+              AND (k.owner_id = auth.uid() OR k.created_by = auth.uid())
+        )
+    );
+
+-- ユーザーは自分自身のメンバーシップを抜けることができる（自分の行を削除）
+CREATE POLICY "members_self_leave" ON public.kouden_members
+    AS PERMISSIVE
+    FOR DELETE
+    TO authenticated
+    USING (user_id = auth.uid());
+
+
+-- ========================================================================
+-- C-6: contact_requests / contact_request_attachments / contact_responses
+-- ========================================================================
+
+-- contact_requests
+DROP POLICY IF EXISTS "Allow authenticated to select contact requests" ON public.contact_requests;
+
+CREATE POLICY "Users can view own contact requests" ON public.contact_requests
+    FOR SELECT
+    TO authenticated
+    USING (
+        user_id = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM public.admin_users au
+            WHERE au.user_id = auth.uid()
+        )
+    );
+
+-- contact_request_attachments
+DROP POLICY IF EXISTS "Allow authenticated to select attachments" ON public.contact_request_attachments;
+DROP POLICY IF EXISTS "Allow public to insert attachments" ON public.contact_request_attachments;
+
+CREATE POLICY "Owners or admins can view attachments" ON public.contact_request_attachments
+    FOR SELECT
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.contact_requests cr
+            WHERE cr.id = contact_request_attachments.request_id
+              AND (
+                  cr.user_id = auth.uid()
+                  OR EXISTS (
+                      SELECT 1 FROM public.admin_users au
+                      WHERE au.user_id = auth.uid()
+                  )
+              )
+        )
+    );
+
+CREATE POLICY "Owners can insert attachments" ON public.contact_request_attachments
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.contact_requests cr
+            WHERE cr.id = contact_request_attachments.request_id
+              AND cr.user_id = auth.uid()
+        )
+    );
+
+-- contact_responses
+DROP POLICY IF EXISTS "Allow authenticated to select responses" ON public.contact_responses;
+DROP POLICY IF EXISTS "Allow authenticated to insert responses" ON public.contact_responses;
+
+CREATE POLICY "Owners or admins can view responses" ON public.contact_responses
+    FOR SELECT
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.contact_requests cr
+            WHERE cr.id = contact_responses.request_id
+              AND (
+                  cr.user_id = auth.uid()
+                  OR EXISTS (
+                      SELECT 1 FROM public.admin_users au
+                      WHERE au.user_id = auth.uid()
+                  )
+              )
+        )
+    );
+
+CREATE POLICY "Admins can insert responses" ON public.contact_responses
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.admin_users au
+            WHERE au.user_id = auth.uid()
+        )
+    );


### PR DESCRIPTION
## Summary

This PR addresses three critical Row-Level Security (RLS) vulnerabilities identified in the security review (C-2, C-3, C-6) and implements security hardening across server actions and API endpoints.

## Key Changes

### Database Security (RLS Fixes)
- **C-2: kouden_invitations** - Removed overly permissive `invitation_link_access` policy that exposed invitation tokens to anonymous users. Token lookups now exclusively use service-role via server actions.
- **C-3: kouden_members** - Replaced unrestricted `members_management` policy with owner-only access control. Added `members_self_leave` policy allowing users to remove themselves. Member additions via invitations now use service-role verification.
- **C-6: contact_requests & related tables** - Restricted SELECT access from "allow all authenticated" to "owner or admin only". Updated INSERT policies for `contact_request_attachments` and `contact_responses` to enforce ownership/admin checks.

### Server Action Security
- **createKouden / createKoudenWithPlan** - Removed `userId` parameter; now derives authenticated user ID from session via `createClient()` instead of trusting client input. Added validation to reject non-free plan codes in `createKoudenWithPlan` (paid plans only via Stripe webhook).
- **getInvitation / acceptInvitation** - Added UUID validation for invitation tokens before database queries. Switched to `createAdminClient()` for token lookups (since RLS now blocks anonymous access). Changed `added_by` in member insertion to use invitation creator's ID instead of accepting user's ID.
- **Removed userId from component props** - `NewKoudenPlanSelector` and `CreateKoudenForm` no longer accept/pass userId; authentication is handled server-side.

### API Endpoint Security
- **send-reminders cron** - Added `CRON_SECRET` environment variable requirement (minimum 32 chars). Implemented timing-safe Bearer token validation to prevent unauthorized cron invocations. Rejects requests without valid `Authorization: Bearer <CRON_SECRET>` header.

### Auth Callback Security
- **Open redirect prevention** - Added `sanitizeRedirectPath()` function to validate redirect targets. Only allows relative paths starting with "/"; rejects absolute URLs, protocol-relative URLs, and backslash prefixes. Applied to both `redirectTo` query parameter and `post_auth_redirect` cookie.

### Configuration
- Added `CRON_SECRET` to `.env.example` with generation instructions.

## Implementation Details

- Service-role client (`createAdminClient()`) is now used for operations that bypass RLS (token verification, member additions via invitations).
- Regular authenticated client (`createClient()`) is used only for session/auth checks and public data.
- All user-provided IDs are validated against session identity before database operations.
- Logging updated to avoid leaking sensitive tokens in error messages.
- Timing-safe string comparison prevents timing attacks on cron secret validation.

https://claude.ai/code/session_01YNf3dYKQCgka1gH29MEN5w