### PR TITLE
Atomize Stripe checkout webhook with RPC function

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -94,8 +94,13 @@ export async function POST(req: Request) {
 				},
 				"Error processing stripe checkout completion (RPC)",
 			);
-			// 5xx を返して Stripe に再送させる (一時的なDB障害などに備える)
-			return new NextResponse("Failed to process checkout", { status: 500 });
+			// 恒久エラー (例: P0002 = plan_not_found) は Stripe の再送で解消しないため 4xx で
+			// 確定的に失敗させ、再送ループとログノイズを防ぐ。一時的なDB障害などは 5xx で再送させる。
+			const isPermanentError = rpcError.code === "P0002";
+			return new NextResponse(
+				isPermanentError ? "Invalid checkout metadata" : "Failed to process checkout",
+				{ status: isPermanentError ? 400 : 500 },
+			);
 		}
 
 		const purchaseRow = rpcRows?.[0];

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -56,106 +56,71 @@ export async function POST(req: Request) {
 			return new NextResponse("Invalid webhook metadata", { status: 400 });
 		}
 
-		// Supabase admin client
-		const supabase = createAdminClient();
-
-		// Create kouden record if not exists
-		const { data: existingKouden } = await supabase
-			.from("koudens")
-			.select("id")
-			.eq("id", koudenId)
-			.single();
-		if (!existingKouden) {
-			const planRes = await supabase.from("plans").select("id").eq("code", planCode).single();
-			if (planRes.error || !planRes.data) {
-				logger.error({ planCode, error: planRes.error }, "Plan not found for code");
-				return new NextResponse("Plan not found", { status: 400 });
-			}
-			const planId = planRes.data.id;
-			const { error: koudenError } = await supabase.from("koudens").insert({
-				id: koudenId,
-				title: metadata.title || "",
-				description: metadata.description || "",
-				owner_id: userId,
-				created_by: userId,
-				plan_id: planId,
-			});
-			if (koudenError) {
-				logger.error(
-					{
-						error: koudenError.message,
-						code: koudenError.code,
-						koudenId,
-						userId,
-					},
-					"Error creating kouden",
-				);
-			}
-		}
-
-		// Upsert purchase history
-		const planRes2 = await supabase.from("plans").select("id").eq("code", planCode).single();
-		if (planRes2.error || !planRes2.data) {
-			logger.error({ planCode, error: planRes2.error }, "Plan not found for code");
-			return new NextResponse("Plan not found", { status: 400 });
-		}
-		const planId2 = planRes2.data.id;
 		const amountTotal = session.amount_total;
 		if (amountTotal == null) {
 			logger.error({ sessionId: session.id }, "Session amount_total is missing");
 			return new NextResponse("Invalid session data", { status: 400 });
 		}
-		const { data: purchaseRow, error: purchaseError } = await supabase
-			.from("kouden_purchases")
-			.insert({
-				kouden_id: koudenId,
-				user_id: userId,
-				plan_id: planId2,
-				expected_count: metadata.expectedCount ? Number(metadata.expectedCount) : null,
-				amount_paid: amountTotal,
-				stripe_session_id: session.id,
-			})
-			.select("id")
-			.single();
-		if (purchaseError || !purchaseRow) {
+
+		// Supabase admin client (service-role)
+		const supabase = createAdminClient();
+
+		// koudens の upsert・kouden_purchases の INSERT・koudens.plan_id/status の更新を
+		// 単一のトランザクション (RPC 関数) で実行する。
+		// stripe_session_id を冪等性キーとして使い、Webhook の再送に対しても安全。
+		const { data: rpcRows, error: rpcError } = await supabase.rpc(
+			"process_stripe_checkout_completed",
+			{
+				p_kouden_id: koudenId,
+				p_user_id: userId,
+				p_plan_code: planCode,
+				p_title: metadata.title || "",
+				p_description: metadata.description || "",
+				p_expected_count: metadata.expectedCount ? Number(metadata.expectedCount) : null,
+				p_amount_paid: amountTotal,
+				p_stripe_session_id: session.id,
+			},
+		);
+
+		if (rpcError) {
 			logger.error(
 				{
-					error: purchaseError?.message,
-					code: purchaseError?.code,
+					error: rpcError.message,
+					code: rpcError.code,
 					koudenId,
 					userId,
+					planCode,
+					sessionId: session.id,
 				},
-				"Error inserting purchase",
+				"Error processing stripe checkout completion (RPC)",
 			);
-		} else {
+			// 5xx を返して Stripe に再送させる (一時的なDB障害などに備える)
+			return new NextResponse("Failed to process checkout", { status: 500 });
+		}
+
+		const purchaseRow = rpcRows?.[0];
+		if (!purchaseRow) {
+			logger.error(
+				{ koudenId, userId, sessionId: session.id },
+				"process_stripe_checkout_completed returned no rows",
+			);
+			return new NextResponse("Failed to process checkout", { status: 500 });
+		}
+
+		// 領収書PDFは新規購入時のみ生成する (再送イベントでの二重発行を防ぐ)。
+		// PDF生成失敗は購入処理のロールバック対象外 (ログのみ)。
+		if (purchaseRow.is_new_purchase) {
 			try {
-				await exportReceiptToPdf(purchaseRow.id);
+				await exportReceiptToPdf(purchaseRow.purchase_id);
 			} catch (err) {
 				logger.error(
 					{
 						error: err instanceof Error ? err.message : String(err),
-						purchaseId: purchaseRow.id,
+						purchaseId: purchaseRow.purchase_id,
 					},
 					"Receipt export error",
 				);
 			}
-		}
-
-		// Update kouden plan_id for upgrades
-		const { error: updateError } = await supabase
-			.from("koudens")
-			.update({ plan_id: planId2, status: "active" })
-			.eq("id", koudenId);
-		if (updateError) {
-			logger.error(
-				{
-					error: updateError.message,
-					code: updateError.code,
-					koudenId,
-					planId: planId2,
-				},
-				"Error updating kouden plan_id and status",
-			);
 		}
 	}
 

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -3445,6 +3445,22 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: string
       }
+      process_stripe_checkout_completed: {
+        Args: {
+          p_kouden_id: string
+          p_user_id: string
+          p_plan_code: string
+          p_title: string
+          p_description: string
+          p_expected_count: number | null
+          p_amount_paid: number
+          p_stripe_session_id: string
+        }
+        Returns: {
+          purchase_id: string
+          is_new_purchase: boolean
+        }[]
+      }
       remove_member: {
         Args: { p_kouden_id: string; p_user_id: string }
         Returns: undefined

--- a/supabase/migrations/20260516120000_add_process_stripe_checkout_completed_rpc.sql
+++ b/supabase/migrations/20260516120000_add_process_stripe_checkout_completed_rpc.sql
@@ -18,6 +18,30 @@
 -- ------------------------------------------------------------------------
 -- 1. 既存データの不整合チェック後、stripe_session_id にユニーク部分インデックス
 -- ------------------------------------------------------------------------
+-- 重複行の存在を事前検出する。重複は課金レコードなので自動 DELETE しない
+-- (誤って売上履歴を失わないため)。重複があれば運用者が手動で精査する前提で
+-- 分かりやすい例外を投げてマイグレーションを止める。
+DO $$
+DECLARE
+    v_dup_count integer;
+BEGIN
+    SELECT COUNT(*) INTO v_dup_count
+    FROM (
+        SELECT 1
+        FROM public.kouden_purchases
+        WHERE stripe_session_id IS NOT NULL
+        GROUP BY stripe_session_id
+        HAVING COUNT(*) > 1
+    ) dups;
+
+    IF v_dup_count > 0 THEN
+        RAISE EXCEPTION
+            'Cannot create unique index on kouden_purchases.stripe_session_id: % duplicate value(s) found. Investigate and resolve manually before re-running this migration (billing records, do not auto-delete).',
+            v_dup_count;
+    END IF;
+END;
+$$;
+
 -- NOT NULL の値に対してのみユニーク性を要求 (古い手動投入レコードでは NULL のまま)
 CREATE UNIQUE INDEX IF NOT EXISTS uq_kouden_purchases_stripe_session_id
     ON public.kouden_purchases (stripe_session_id)
@@ -105,7 +129,9 @@ BEGIN
     )
     ON CONFLICT (id) DO UPDATE
         SET plan_id = EXCLUDED.plan_id,
-            status  = 'active';
+            status  = 'active'
+        WHERE koudens.plan_id IS DISTINCT FROM EXCLUDED.plan_id
+           OR koudens.status  IS DISTINCT FROM 'active';
     -- title/description は既存値を温存 (upgrade 時に上書きしない)
 
     -- Step 2: 購入履歴を挿入

--- a/supabase/migrations/20260516120000_add_process_stripe_checkout_completed_rpc.sql
+++ b/supabase/migrations/20260516120000_add_process_stripe_checkout_completed_rpc.sql
@@ -1,0 +1,146 @@
+-- 2026-05-16: Stripe Webhook のアトミック化用 RPC 関数
+-- Issue: https://github.com/otomatty/kouden/issues/38
+--
+-- 背景:
+--   `checkout.session.completed` Webhook (src/app/api/stripe/webhook/route.ts)
+--   では以下の3操作が非アトミックに実行されており、途中失敗時に
+--   「購入レコードはあるが kouden が未更新」「kouden は作成されたが購入が記録されない」
+--   といったデータ不整合が起こり得る。
+--     1. koudens を必要に応じて INSERT
+--     2. kouden_purchases に INSERT
+--     3. koudens.plan_id / status を UPDATE
+--
+-- 本マイグレーションでは:
+--   - 3操作を単一の Postgres 関数 (= 1トランザクション) にまとめてロールバック可能にする
+--   - `stripe_session_id` を冪等性キーとして使い、Stripe Webhook の再試行に対応
+--   - `stripe_session_id` に部分ユニーク制約を追加してDB側でも重複登録を防ぐ
+
+-- ------------------------------------------------------------------------
+-- 1. 既存データの不整合チェック後、stripe_session_id にユニーク部分インデックス
+-- ------------------------------------------------------------------------
+-- NOT NULL の値に対してのみユニーク性を要求 (古い手動投入レコードでは NULL のまま)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kouden_purchases_stripe_session_id
+    ON public.kouden_purchases (stripe_session_id)
+    WHERE stripe_session_id IS NOT NULL;
+
+
+-- ------------------------------------------------------------------------
+-- 2. アトミックな checkout 処理用 RPC
+-- ------------------------------------------------------------------------
+-- 戻り値:
+--   purchase_id      ... 該当 (新規または既存) の kouden_purchases.id
+--   is_new_purchase  ... 今回新規に INSERT したかどうか (true=新規, false=冪等再実行)
+--
+-- 失敗ケース:
+--   - 指定 plan_code のプランが存在しない → 例外 (ERRCODE 'P0002')
+--
+-- 呼び出し元は service-role (Webhook の admin client) のみを想定。
+-- authenticated/anon からの実行は許可しない (EXECUTE を REVOKE)。
+
+CREATE OR REPLACE FUNCTION public.process_stripe_checkout_completed(
+    p_kouden_id uuid,
+    p_user_id uuid,
+    p_plan_code text,
+    p_title text,
+    p_description text,
+    p_expected_count integer,
+    p_amount_paid integer,
+    p_stripe_session_id text
+)
+RETURNS TABLE (
+    purchase_id uuid,
+    is_new_purchase boolean
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_plan_id uuid;
+    v_existing_purchase_id uuid;
+    v_new_purchase_id uuid;
+BEGIN
+    -- プラン解決
+    SELECT id INTO v_plan_id FROM public.plans WHERE code = p_plan_code;
+    IF v_plan_id IS NULL THEN
+        RAISE EXCEPTION 'plan_not_found: %', p_plan_code
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    -- 冪等性チェック: 同じ Stripe session で既に処理済みなら早期 return
+    -- (Stripe は同一 event を複数回送ることがあるため必須)
+    IF p_stripe_session_id IS NOT NULL THEN
+        SELECT id INTO v_existing_purchase_id
+        FROM public.kouden_purchases
+        WHERE stripe_session_id = p_stripe_session_id
+        LIMIT 1;
+
+        IF v_existing_purchase_id IS NOT NULL THEN
+            -- 念のため kouden 側の状態 (plan_id / status) を冪等に整える
+            UPDATE public.koudens
+            SET plan_id = v_plan_id,
+                status  = 'active'
+            WHERE id = p_kouden_id
+              AND (plan_id IS DISTINCT FROM v_plan_id OR status IS DISTINCT FROM 'active');
+
+            purchase_id := v_existing_purchase_id;
+            is_new_purchase := false;
+            RETURN NEXT;
+            RETURN;
+        END IF;
+    END IF;
+
+    -- Step 1: koudens を upsert
+    --   - 新規購入フロー: kouden がまだ存在しない (purchaseKouden 経由) → INSERT
+    --   - アップグレードフロー: 既存 kouden → plan_id と status のみ更新
+    INSERT INTO public.koudens (id, title, description, owner_id, created_by, plan_id, status)
+    VALUES (
+        p_kouden_id,
+        COALESCE(p_title, ''),
+        COALESCE(p_description, ''),
+        p_user_id,
+        p_user_id,
+        v_plan_id,
+        'active'
+    )
+    ON CONFLICT (id) DO UPDATE
+        SET plan_id = EXCLUDED.plan_id,
+            status  = 'active';
+    -- title/description は既存値を温存 (upgrade 時に上書きしない)
+
+    -- Step 2: 購入履歴を挿入
+    INSERT INTO public.kouden_purchases (
+        kouden_id,
+        user_id,
+        plan_id,
+        expected_count,
+        amount_paid,
+        stripe_session_id
+    )
+    VALUES (
+        p_kouden_id,
+        p_user_id,
+        v_plan_id,
+        p_expected_count,
+        p_amount_paid,
+        p_stripe_session_id
+    )
+    RETURNING id INTO v_new_purchase_id;
+
+    purchase_id := v_new_purchase_id;
+    is_new_purchase := true;
+    RETURN NEXT;
+    RETURN;
+END;
+$$;
+
+-- service-role のみが実行可能 (Webhook 経由の admin client から呼び出す想定)
+REVOKE ALL ON FUNCTION public.process_stripe_checkout_completed(
+    uuid, uuid, text, text, text, integer, integer, text
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.process_stripe_checkout_completed(
+    uuid, uuid, text, text, text, integer, integer, text
+) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.process_stripe_checkout_completed(
+    uuid, uuid, text, text, text, integer, integer, text
+) TO service_role;


### PR DESCRIPTION
## Summary
Refactors the Stripe `checkout.session.completed` webhook handler to use a single PostgreSQL RPC function, ensuring atomic transactions and idempotent processing. This prevents data inconsistencies that could occur when individual database operations fail mid-sequence.

## Key Changes
- **New migration**: Added `process_stripe_checkout_completed()` RPC function that atomically:
  - Resolves the plan by code
  - Upserts the kouden record
  - Inserts the purchase history
  - Updates kouden plan_id and status
  - All within a single transaction with automatic rollback on failure

- **Idempotency**: Uses `stripe_session_id` as an idempotency key with a partial unique index (NOT NULL values only) to safely handle Stripe webhook retries without duplicate records

- **Webhook handler simplification**: Replaced multiple sequential database calls with a single RPC invocation, reducing error handling complexity and eliminating race conditions

- **Receipt generation**: Now only generates PDFs for new purchases (`is_new_purchase = true`), preventing duplicate receipts on webhook retries

- **Type definitions**: Updated `supabase.d.ts` with the new RPC function signature

## Implementation Details
- RPC function uses `SECURITY INVOKER` with explicit `REVOKE` on public/anon/authenticated roles, restricting execution to `service_role` only
- Early return on idempotent re-execution ensures Stripe retries are handled efficiently
- Webhook handler returns 500 status on RPC errors to trigger Stripe's retry mechanism for transient failures
- Preserves existing kouden title/description during upgrades (only updates plan_id and status)

https://claude.ai/code/session_01RumJJEMoYjUDFzYi1UbM1Z