### PR TITLE
Implement fine-grained cache invalidation with cache tags

### DIFF
--- a/src/app/(public)/changelogs/[slug]/page.tsx
+++ b/src/app/(public)/changelogs/[slug]/page.tsx
@@ -1,13 +1,15 @@
-import { getChangelogBySlug, getChangelogNavigation } from "@/lib/changelogs";
-import { MDXRemote } from "next-mdx-remote/rsc";
-import { mdxComponents } from "@/lib/mdx-components";
-import { mdxOptions } from "@/lib/mdx";
-import Container from "@/components/ui/container";
 import { ChangelogNavigation } from "@/components/changelogs/changelog-navigation";
-import { Badge } from "@/components/ui/badge";
 import { BackLink } from "@/components/custom/back-link";
+import { Badge } from "@/components/ui/badge";
+import Container from "@/components/ui/container";
+import { getChangelogBySlug, getChangelogNavigation } from "@/lib/changelogs";
+import { mdxOptions } from "@/lib/mdx";
+import { mdxComponents } from "@/lib/mdx-components";
 import { AlertCircle, AlertTriangle, Bug, Plus, Shield, Sparkles, Zap } from "lucide-react";
 import type { Metadata } from "next";
+import { MDXRemote } from "next-mdx-remote/rsc";
+
+export const revalidate = 3600;
 
 type PageParams = Promise<{
 	slug: string;

--- a/src/app/(public)/changelogs/page.tsx
+++ b/src/app/(public)/changelogs/page.tsx
@@ -1,8 +1,10 @@
-import { getAllChangelogs } from "@/lib/changelogs";
 import { ChangelogsTimeline } from "@/components/changelogs/changelogs-timeline";
 import Container from "@/components/ui/container";
-import { PageHero } from "../_components/page-hero";
+import { getAllChangelogs } from "@/lib/changelogs";
 import type { Metadata } from "next";
+import { PageHero } from "../_components/page-hero";
+
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
 	title: "更新履歴 - 香典帳アプリ",

--- a/src/app/(public)/milestones/[slug]/page.tsx
+++ b/src/app/(public)/milestones/[slug]/page.tsx
@@ -1,14 +1,16 @@
-import { getMilestoneBySlug, getMilestoneNavigation } from "@/lib/milestones";
-import { MDXRemote } from "next-mdx-remote/rsc";
-import { mdxComponents } from "@/lib/mdx-components";
-import { mdxOptions } from "@/lib/mdx";
-import Container from "@/components/ui/container";
+import { BackLink } from "@/components/custom/back-link";
 import { MilestoneNavigation } from "@/components/milestones/milestone-navigation";
 import { Badge } from "@/components/ui/badge";
+import Container from "@/components/ui/container";
 import { Progress } from "@/components/ui/progress";
-import { BackLink } from "@/components/custom/back-link";
+import { mdxOptions } from "@/lib/mdx";
+import { mdxComponents } from "@/lib/mdx-components";
+import { getMilestoneBySlug, getMilestoneNavigation } from "@/lib/milestones";
 import { CheckCircle, Clock, Loader } from "lucide-react";
 import type { Metadata } from "next";
+import { MDXRemote } from "next-mdx-remote/rsc";
+
+export const revalidate = 3600;
 
 type PageParams = Promise<{
 	slug: string;

--- a/src/app/(public)/milestones/page.tsx
+++ b/src/app/(public)/milestones/page.tsx
@@ -1,8 +1,10 @@
-import { getAllMilestones } from "@/lib/milestones";
 import { MilestonesTimeline } from "@/components/milestones/milestones-timeline";
 import Container from "@/components/ui/container";
-import { PageHero } from "../_components/page-hero";
+import { getAllMilestones } from "@/lib/milestones";
 import type { Metadata } from "next";
+import { PageHero } from "../_components/page-hero";
+
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
 	title: "開発マイルストーン - 香典帳アプリ",

--- a/src/app/_actions/entries.ts
+++ b/src/app/_actions/entries.ts
@@ -1,16 +1,31 @@
 "use server";
 
+import { cacheTags } from "@/lib/cache-tags";
+import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
-import { revalidatePath } from "next/cache";
 import type { CellValue } from "@/types/data-table/table";
 import type {
+	AttendanceType,
 	CreateEntryInput,
+	Entry,
 	EntryResponse,
 	UpdateEntryInput,
-	Entry,
-	AttendanceType,
 } from "@/types/entries";
-import logger from "@/lib/logger";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+/**
+ * Invalidate caches affected by an entry mutation.
+ *
+ * Entries are surfaced on the entries page and feed into statistics and
+ * return records, so we invalidate the whole kouden subtree via `layout`
+ * mode and emit cache tags for any future `unstable_cache` consumers.
+ */
+function revalidateEntriesCaches(koudenId: string) {
+	revalidatePath(`/koudens/${koudenId}`, "layout");
+	revalidateTag(cacheTags.entries(koudenId));
+	revalidateTag(cacheTags.statistics(koudenId));
+	revalidateTag(cacheTags.returnRecords(koudenId));
+}
 
 export async function createEntry(input: CreateEntryInput): Promise<EntryResponse> {
 	const supabase = await createClient();
@@ -69,9 +84,7 @@ export async function createEntry(input: CreateEntryInput): Promise<EntryRespons
 			throw new Error("香典情報の作成に失敗しました");
 		}
 
-		Promise.resolve().then(() => {
-			revalidatePath(`/koudens/${input.koudenId}`);
-		});
+		revalidateEntriesCaches(input.koudenId);
 
 		// スネークケースからキャメルケースへの変換
 		const response: EntryResponse = {
@@ -485,9 +498,7 @@ export async function updateEntry(id: string, input: UpdateEntryInput): Promise<
 			throw new Error("香典情報の更新に失敗しました");
 		}
 
-		Promise.resolve().then(() => {
-			revalidatePath(`/koudens/${updatedData.kouden_id}`);
-		});
+		revalidateEntriesCaches(updatedData.kouden_id);
 
 		return {
 			...updatedData,
@@ -522,9 +533,7 @@ export async function deleteEntry(id: string, koudenId: string): Promise<void> {
 		throw new Error("香典情報の削除に失敗しました");
 	}
 
-	Promise.resolve().then(() => {
-		revalidatePath(`/koudens/${koudenId}`);
-	});
+	revalidateEntriesCaches(koudenId);
 }
 
 // 複数エントリーの一括削除機能
@@ -544,9 +553,7 @@ export async function deleteEntries(ids: string[], koudenId: string): Promise<vo
 		throw new Error("香典情報の一括削除に失敗しました");
 	}
 
-	Promise.resolve().then(() => {
-		revalidatePath(`/koudens/${koudenId}`);
-	});
+	revalidateEntriesCaches(koudenId);
 }
 
 // セル単位の更新用に最適化した関数
@@ -589,9 +596,7 @@ export async function updateEntryField(
 			throw new Error(`${field}の更新に失敗しました`);
 		}
 
-		Promise.resolve().then(() => {
-			revalidatePath(`/koudens/${updatedData.kouden_id}`);
-		});
+		revalidateEntriesCaches(updatedData.kouden_id);
 
 		return {
 			...updatedData,

--- a/src/app/_actions/offerings.ts
+++ b/src/app/_actions/offerings.ts
@@ -15,6 +15,16 @@ import type { Database } from "@/types/supabase";
 import { snakeToCamel } from "@/utils/case-converter";
 import { revalidatePath, revalidateTag } from "next/cache";
 
+/**
+ * Invalidate caches affected by an offering mutation.
+ *
+ * Offerings are surfaced on the offerings page and reference kouden entries
+ * (for allocation/attribution), so this revalidates the whole kouden subtree
+ * via `layout` mode and emits the `offerings` and `entries` cache tags for
+ * any future `unstable_cache` consumers.
+ *
+ * @param koudenId - Target kouden ID whose caches should be invalidated.
+ */
 function revalidateOfferingsCaches(koudenId: string) {
 	revalidatePath(`/koudens/${koudenId}`, "layout");
 	revalidateTag(cacheTags.offerings(koudenId));

--- a/src/app/_actions/offerings.ts
+++ b/src/app/_actions/offerings.ts
@@ -1,18 +1,25 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-import { revalidatePath } from "next/cache";
-import type {
-	Offering,
-	CreateOfferingInput,
-	UpdateOfferingInput,
-	CreateOfferingPhotoInput,
-	UpdateOfferingPhotoInput,
-	OfferingWithKoudenEntries,
-} from "@/types/offerings";
-import { snakeToCamel } from "@/utils/case-converter";
-import type { Database } from "@/types/supabase";
+import { cacheTags } from "@/lib/cache-tags";
 import logger from "@/lib/logger";
+import { createClient } from "@/lib/supabase/server";
+import type {
+	CreateOfferingInput,
+	CreateOfferingPhotoInput,
+	Offering,
+	OfferingWithKoudenEntries,
+	UpdateOfferingInput,
+	UpdateOfferingPhotoInput,
+} from "@/types/offerings";
+import type { Database } from "@/types/supabase";
+import { snakeToCamel } from "@/utils/case-converter";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+function revalidateOfferingsCaches(koudenId: string) {
+	revalidatePath(`/koudens/${koudenId}`, "layout");
+	revalidateTag(cacheTags.offerings(koudenId));
+	revalidateTag(cacheTags.entries(koudenId));
+}
 
 //お供物情報を作成する
 export async function createOffering(input: Omit<CreateOfferingInput, "created_by">) {
@@ -100,7 +107,7 @@ export async function createOffering(input: Omit<CreateOfferingInput, "created_b
 			// 更新エラーは致命的ではないのでログのみ
 		}
 
-		revalidatePath(`/koudens/${input.kouden_id}`);
+		revalidateOfferingsCaches(input.kouden_id as string);
 		return data;
 	} catch (error) {
 		logger.error(
@@ -219,7 +226,7 @@ export async function updateOffering(id: string, input: UpdateOfferingInput) {
 			// 更新エラーは致命的ではないのでログのみ
 		}
 
-		revalidatePath(`/koudens/${input.kouden_id}`);
+		revalidateOfferingsCaches(input.kouden_id as string);
 		return data;
 	} catch (error) {
 		logger.error(
@@ -277,7 +284,7 @@ export async function deleteOffering(id: string, koudenId: string) {
 		// 更新エラーは致命的ではないのでログのみ
 	}
 
-	revalidatePath(`/koudens/${koudenId}`);
+	revalidateOfferingsCaches(koudenId);
 }
 
 // お供物情報を取得する
@@ -380,7 +387,7 @@ export async function addOfferingPhoto(
 		throw new Error("写真の登録に失敗しました");
 	}
 
-	revalidatePath(`/koudens/${offering.kouden_id}`);
+	revalidateOfferingsCaches(offering.kouden_id);
 	return data;
 }
 

--- a/src/app/_actions/telegrams.ts
+++ b/src/app/_actions/telegrams.ts
@@ -1,17 +1,23 @@
 "use server";
 
+import { cacheTags } from "@/lib/cache-tags";
+import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
-import { revalidatePath } from "next/cache";
+import { toCamelCase, toSnakeCase } from "@/store/telegrams";
 import type { CellValue } from "@/types/data-table/table";
+import type { AttendanceType, EntryResponse } from "@/types/entries";
 import type {
+	CreateTelegramInput,
 	Telegram,
 	TelegramRow,
-	CreateTelegramInput,
 	UpdateTelegramInput,
 } from "@/types/telegrams";
-import { toCamelCase, toSnakeCase } from "@/store/telegrams";
-import type { EntryResponse, AttendanceType } from "@/types/entries";
-import logger from "@/lib/logger";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+function revalidateTelegramsCaches(koudenId: string) {
+	revalidatePath(`/koudens/${koudenId}`, "layout");
+	revalidateTag(cacheTags.telegrams(koudenId));
+}
 
 // 弔電の取得（単一）
 export async function getTelegram(id: string) {
@@ -78,7 +84,7 @@ export async function createTelegram(
 			.single();
 
 		if (error) throw error;
-		revalidatePath("/koudens/[id]", "page");
+		revalidateTelegramsCaches(input.koudenId);
 		return toCamelCase(data as TelegramRow);
 	} catch (error) {
 		logger.error(
@@ -106,7 +112,7 @@ export async function updateTelegram(id: string, input: UpdateTelegramInput): Pr
 			.single();
 
 		if (error) throw error;
-		revalidatePath("/koudens/[id]", "page");
+		revalidateTelegramsCaches(data.kouden_id);
 		return toCamelCase(data as TelegramRow);
 	} catch (error) {
 		logger.error(
@@ -129,7 +135,7 @@ export async function deleteTelegram(id: string, koudenId: string): Promise<void
 		const { error } = await supabase.from("telegrams").delete().eq("id", id);
 
 		if (error) throw error;
-		revalidatePath(`/koudens/${koudenId}`);
+		revalidateTelegramsCaches(koudenId);
 	} catch (error) {
 		logger.error(
 			{
@@ -160,9 +166,7 @@ export async function deleteTelegrams(ids: string[], koudenId: string): Promise<
 		throw new Error("弔電の一括削除に失敗しました");
 	}
 
-	Promise.resolve().then(() => {
-		revalidatePath(`/koudens/${koudenId}`, "page");
-	});
+	revalidateTelegramsCaches(koudenId);
 }
 
 // セル単位の更新用に最適化した関数
@@ -220,9 +224,7 @@ export async function updateTelegramField(
 
 		const camelCaseResult = toCamelCase(updatedData as TelegramRow);
 
-		Promise.resolve().then(() => {
-			revalidatePath(`/koudens/${updatedData.kouden_id}`);
-		});
+		revalidateTelegramsCaches(updatedData.kouden_id);
 
 		return camelCaseResult;
 	} catch (error) {

--- a/src/app/_actions/telegrams.ts
+++ b/src/app/_actions/telegrams.ts
@@ -14,6 +14,14 @@ import type {
 } from "@/types/telegrams";
 import { revalidatePath, revalidateTag } from "next/cache";
 
+/**
+ * Invalidate caches affected by a telegram mutation.
+ *
+ * Revalidates the kouden subtree via `layout` mode and emits the `telegrams`
+ * cache tag for any future `unstable_cache` consumers.
+ *
+ * @param koudenId - Target kouden ID whose caches should be invalidated.
+ */
 function revalidateTelegramsCaches(koudenId: string) {
 	revalidatePath(`/koudens/${koudenId}`, "layout");
 	revalidateTag(cacheTags.telegrams(koudenId));

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,16 @@
+/**
+ * Cache tag helpers for fine-grained cache invalidation.
+ *
+ * Use with `revalidateTag` (from `next/cache`) and `unstable_cache` to
+ * invalidate only the data that actually changed, rather than re-rendering
+ * an entire route subtree with `revalidatePath`.
+ */
+export const cacheTags = {
+	kouden: (koudenId: string) => `kouden:${koudenId}` as const,
+	entries: (koudenId: string) => `kouden:${koudenId}:entries` as const,
+	offerings: (koudenId: string) => `kouden:${koudenId}:offerings` as const,
+	telegrams: (koudenId: string) => `kouden:${koudenId}:telegrams` as const,
+	relationships: (koudenId: string) => `kouden:${koudenId}:relationships` as const,
+	statistics: (koudenId: string) => `kouden:${koudenId}:statistics` as const,
+	returnRecords: (koudenId: string) => `kouden:${koudenId}:return-records` as const,
+} as const;


### PR DESCRIPTION
## Summary
This PR introduces a centralized cache invalidation strategy using Next.js cache tags alongside path-based revalidation. This enables more granular cache invalidation for data mutations while maintaining broad layout-level revalidation for UI consistency.

## Key Changes

- **New cache tags system** (`src/lib/cache-tags.ts`): Created a centralized module defining cache tag helpers for entries, offerings, telegrams, relationships, statistics, and return records scoped by kouden ID.

- **Refactored entries mutations** (`src/app/_actions/entries.ts`):
  - Introduced `revalidateEntriesCaches()` helper that combines layout-level path revalidation with specific cache tag invalidation
  - Replaced `Promise.resolve().then()` anti-pattern with direct function calls in `createEntry`, `updateEntry`, `deleteEntry`, `deleteEntries`, and `updateEntryField`
  - Now invalidates entries, statistics, and return records cache tags in addition to layout revalidation

- **Refactored telegrams mutations** (`src/app/_actions/telegrams.ts`):
  - Introduced `revalidateTelegramsCaches()` helper for consistent invalidation
  - Replaced `Promise.resolve().then()` pattern with direct calls
  - Updated `createTelegram` to use the new helper instead of generic page revalidation
  - Invalidates telegrams cache tag alongside layout revalidation

- **Refactored offerings mutations** (`src/app/_actions/offerings.ts`):
  - Introduced `revalidateOfferingsCaches()` helper that invalidates both offerings and entries cache tags
  - Replaced direct `revalidatePath` calls with the new helper across all mutation functions
  - Ensures dependent data (entries) is also invalidated when offerings change

- **Added revalidation hints to public pages**: Set `revalidate = 3600` (1 hour) on changelog and milestone pages for better ISR caching strategy.

- **Import organization**: Alphabetized imports across modified files for consistency.

## Implementation Details

The new cache tag system enables:
- **Dual invalidation strategy**: Layout-level revalidation ensures UI consistency while cache tags allow future `unstable_cache` consumers to invalidate only affected data
- **Dependency awareness**: Offerings mutations invalidate both offerings and entries tags since entries depend on offerings data
- **Cleaner code**: Centralized revalidation logic eliminates duplication and the problematic `Promise.resolve().then()` pattern
- **Future extensibility**: Cache tags are ready for use with `unstable_cache` for fine-grained data caching

https://claude.ai/code/session_01VRmSFTm8U6EjyvUmUryJcn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * チェンジログ・マイルストーンページのISR設定を有効化し、1時間ごとの自動再生成を実現
  * キャッシュ無効化処理を統一・最適化し、複数機能にわたるコンテンツ更新の一貫性と鮮度を向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->