### PR TITLE
Security hardening: RLS policies and input sanitization

### DIFF
--- a/database/kouden_entries.sql
+++ b/database/kouden_entries.sql
@@ -66,57 +66,79 @@ CREATE INDEX idx_kouden_entries_relationship_id ON kouden_entries(relationship_i
 -- Enable Row Level Security
 ALTER TABLE kouden_entries ENABLE ROW LEVEL SECURITY;
 
--- Drop existing policies
+-- Drop existing policies (本番ポリシーは supabase/migrations 配下が真の定義。
+--  以前は owner_id のみチェックする RLS だったが、editor/viewer ロールが
+--  拒否される問題があったため、現行マイグレーションに合わせて editor/owner/viewer
+--  の3ポリシーに分割している)
 DROP POLICY IF EXISTS "Users can view entries of their koudens" ON kouden_entries;
 DROP POLICY IF EXISTS "Users can insert entries to their koudens" ON kouden_entries;
 DROP POLICY IF EXISTS "Users can update entries of their koudens" ON kouden_entries;
 DROP POLICY IF EXISTS "Users can delete entries of their koudens" ON kouden_entries;
+DROP POLICY IF EXISTS "owner_crud_access" ON kouden_entries;
+DROP POLICY IF EXISTS "editor_crud_access" ON kouden_entries;
+DROP POLICY IF EXISTS "viewer_read_access" ON kouden_entries;
 
--- Create RLS policies for kouden_entries
-CREATE POLICY "Users can view entries of their koudens"
-    ON kouden_entries FOR SELECT
+-- オーナー / 作成者: CRUD すべて可能
+CREATE POLICY "owner_crud_access"
+    ON kouden_entries
+    AS PERMISSIVE
+    FOR ALL
+    TO authenticated
     USING (
         EXISTS (
-            SELECT 1 FROM koudens
-            WHERE koudens.id = kouden_entries.kouden_id
-            AND koudens.owner_id = auth.uid()::uuid
-        )
-    );
-
-CREATE POLICY "Users can insert entries to their koudens"
-    ON kouden_entries FOR INSERT
-    WITH CHECK (
-        EXISTS (
-            SELECT 1 FROM koudens
-            WHERE koudens.id = kouden_id
-            AND koudens.owner_id = auth.uid()::uuid
-        )
-        AND auth.uid()::uuid = created_by
-    );
-
-CREATE POLICY "Users can update entries of their koudens"
-    ON kouden_entries FOR UPDATE
-    USING (
-        EXISTS (
-            SELECT 1 FROM koudens
-            WHERE koudens.id = kouden_entries.kouden_id
-            AND koudens.owner_id = auth.uid()::uuid
+            SELECT 1 FROM koudens k
+            WHERE k.id = kouden_entries.kouden_id
+              AND (k.owner_id = auth.uid() OR k.created_by = auth.uid())
         )
     )
     WITH CHECK (
         EXISTS (
-            SELECT 1 FROM koudens
-            WHERE koudens.id = kouden_entries.kouden_id
-            AND koudens.owner_id = auth.uid()::uuid
+            SELECT 1 FROM koudens k
+            WHERE k.id = kouden_entries.kouden_id
+              AND (k.owner_id = auth.uid() OR k.created_by = auth.uid())
         )
     );
 
-CREATE POLICY "Users can delete entries of their koudens"
-    ON kouden_entries FOR DELETE
+-- editor ロール (または entry.write 権限) を持つメンバー: CRUD 可能
+CREATE POLICY "editor_crud_access"
+    ON kouden_entries
+    AS PERMISSIVE
+    FOR ALL
+    TO authenticated
     USING (
         EXISTS (
-            SELECT 1 FROM koudens
-            WHERE koudens.id = kouden_entries.kouden_id
-            AND koudens.owner_id = auth.uid()::uuid
+            SELECT 1
+            FROM kouden_members m
+            JOIN kouden_roles r ON r.id = m.role_id
+            WHERE m.kouden_id = kouden_entries.kouden_id
+              AND m.user_id = auth.uid()
+              AND (r.name = 'editor' OR 'entry.write' = ANY(r.permissions))
         )
-    ); 
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1
+            FROM kouden_members m
+            JOIN kouden_roles r ON r.id = m.role_id
+            WHERE m.kouden_id = kouden_entries.kouden_id
+              AND m.user_id = auth.uid()
+              AND (r.name = 'editor' OR 'entry.write' = ANY(r.permissions))
+        )
+    );
+
+-- viewer ロール (または entry.read 権限) を持つメンバー: SELECT のみ
+CREATE POLICY "viewer_read_access"
+    ON kouden_entries
+    AS PERMISSIVE
+    FOR SELECT
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1
+            FROM kouden_members m
+            JOIN kouden_roles r ON r.id = m.role_id
+            WHERE m.kouden_id = kouden_entries.kouden_id
+              AND m.user_id = auth.uid()
+              AND (r.name = 'viewer' OR 'entry.read' = ANY(r.permissions))
+        )
+    );

--- a/database/kouden_roles_and_members.sql
+++ b/database/kouden_roles_and_members.sql
@@ -1,8 +1,13 @@
 -- ロールテーブルを作成
+-- 本番マイグレーション (supabase/migrations/20250128134809_remote_schema.sql) に合わせた定義。
+-- `permissions` は権限ベース判定 (例: 'entry.write' / 'entry.read') に使用される。
 CREATE TABLE IF NOT EXISTS kouden_roles (
     id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     kouden_id UUID NOT NULL REFERENCES koudens(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
+    description TEXT,
+    permissions TEXT[] NOT NULL DEFAULT '{}',
+    created_by UUID NOT NULL REFERENCES auth.users(id),
     created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
     updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
     UNIQUE(kouden_id, name)

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import logger from "@/lib/logger";
+import { escapeIlikePattern } from "@/lib/security/search-sanitize";
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
@@ -89,9 +90,9 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<{
 			{ count: "exact" },
 		);
 
-		// 検索条件
+		// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
 		if (search) {
-			query = query.ilike("display_name", `%${search}%`);
+			query = query.ilike("display_name", `%${escapeIlikePattern(search)}%`);
 		}
 
 		// フィルタリング
@@ -728,9 +729,9 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			{ count: "exact" },
 		);
 
-		// 検索条件
+		// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
 		if (search) {
-			query = query.ilike("title", `%${search}%`);
+			query = query.ilike("title", `%${escapeIlikePattern(search)}%`);
 		}
 
 		// ステータスフィルタリング

--- a/src/app/_actions/entries.ts
+++ b/src/app/_actions/entries.ts
@@ -2,6 +2,7 @@
 
 import { cacheTags } from "@/lib/cache-tags";
 import logger from "@/lib/logger";
+import { buildOrIlikePattern, parseEntrySortValue } from "@/lib/security/search-sanitize";
 import { createClient } from "@/lib/supabase/server";
 import type { CellValue } from "@/types/data-table/table";
 import type {
@@ -210,7 +211,7 @@ export async function getEntries(
 		}
 		// Apply global search filter
 		if (searchValue) {
-			const search = `%${searchValue}%`;
+			const search = buildOrIlikePattern(searchValue);
 			query = query.or(
 				`name.ilike.${search},address.ilike.${search},organization.ilike.${search},position.ilike.${search}`,
 			);
@@ -222,14 +223,10 @@ export async function getEntries(
 		if (dateTo) {
 			query = query.lte("created_at", dateTo);
 		}
-		// Apply sorting
-		if (sortValue && sortValue !== "default") {
-			const [field = "created_at", direction = "desc"] = sortValue.split("_");
-			const ascending = direction === "asc";
+		// Apply sorting (sortValue は信頼できないユーザー入力のためホワイトリスト経由で解決)
+		{
+			const { field, ascending } = parseEntrySortValue(sortValue);
 			query = query.order(field, { ascending });
-		} else {
-			// Default sorting by created_at desc
-			query = query.order("created_at", { ascending: false });
 		}
 		const { data: rawEntries, count, error: entriesError } = await query.range(from, to);
 		const entries = rawEntries ?? [];
@@ -342,7 +339,7 @@ export async function getEntriesForAdmin(
 		}
 		// Apply global search filter
 		if (searchValue) {
-			const search = `%${searchValue}%`;
+			const search = buildOrIlikePattern(searchValue);
 			query = query.or(
 				`name.ilike.${search},address.ilike.${search},organization.ilike.${search},position.ilike.${search}`,
 			);
@@ -354,14 +351,10 @@ export async function getEntriesForAdmin(
 		if (dateTo) {
 			query = query.lte("created_at", dateTo);
 		}
-		// Apply sorting
-		if (sortValue && sortValue !== "default") {
-			const [field = "created_at", direction = "desc"] = sortValue.split("_");
-			const ascending = direction === "asc";
+		// Apply sorting (sortValue は信頼できないユーザー入力のためホワイトリスト経由で解決)
+		{
+			const { field, ascending } = parseEntrySortValue(sortValue);
 			query = query.order(field, { ascending });
-		} else {
-			// Default sorting by created_at desc
-			query = query.order("created_at", { ascending: false });
 		}
 		const { data: rawEntries, count, error: entriesError } = await query.range(from, to);
 		const entries = rawEntries ?? [];

--- a/src/app/_actions/return-records/pagination.ts
+++ b/src/app/_actions/return-records/pagination.ts
@@ -6,6 +6,7 @@
  */
 
 import logger from "@/lib/logger";
+import { buildOrIlikePattern } from "@/lib/security/search-sanitize";
 import { createClient } from "@/lib/supabase/server";
 import type { ReturnEntryRecordWithKoudenEntry } from "@/types/return-records/return-records";
 
@@ -62,8 +63,9 @@ export async function getReturnEntriesByKoudenPaginated(
 		}
 
 		// 検索フィルター（JOIN先テーブルのカラムに対して直接 OR を適用）
+		// PostgREST .or() に渡す値は区切り文字と ILIKE ワイルドカードをサニタイズする
 		if (filters?.search) {
-			const search = `%${filters.search}%`;
+			const search = buildOrIlikePattern(filters.search);
 			query = query.or(`name.ilike.${search},organization.ilike.${search}`, {
 				referencedTable: "kouden_entries",
 			});

--- a/src/lib/security/__tests__/search-sanitize.test.ts
+++ b/src/lib/security/__tests__/search-sanitize.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+
+import {
+	buildOrIlikePattern,
+	escapeIlikePattern,
+	parseEntrySortValue,
+	sanitizePostgrestOrValue,
+} from "../search-sanitize";
+
+describe("escapeIlikePattern", () => {
+	it("通常文字はそのまま返す", () => {
+		expect(escapeIlikePattern("田中")).toBe("田中");
+	});
+
+	it("% と _ をエスケープする", () => {
+		expect(escapeIlikePattern("100% off")).toBe("100\\% off");
+		expect(escapeIlikePattern("a_b")).toBe("a\\_b");
+	});
+
+	it("エスケープ文字 \\ もエスケープする", () => {
+		expect(escapeIlikePattern("path\\to")).toBe("path\\\\to");
+	});
+});
+
+describe("sanitizePostgrestOrValue", () => {
+	it("PostgREST .or() の区切り文字を除去する", () => {
+		expect(sanitizePostgrestOrValue("a,b(c)d*e")).toBe("abcde");
+	});
+
+	it("通常文字列はそのまま返す", () => {
+		expect(sanitizePostgrestOrValue("田中太郎")).toBe("田中太郎");
+	});
+});
+
+describe("buildOrIlikePattern", () => {
+	it("ワイルドカードと区切り文字を同時に処理する", () => {
+		expect(buildOrIlikePattern("a,b%c_d")).toBe("%ab\\%c\\_d%");
+	});
+
+	it("通常文字列は前後を % で囲むのみ", () => {
+		expect(buildOrIlikePattern("田中")).toBe("%田中%");
+	});
+});
+
+describe("parseEntrySortValue", () => {
+	it("未指定/default の場合は created_at desc にフォールバックする", () => {
+		expect(parseEntrySortValue(undefined)).toEqual({ field: "created_at", ascending: false });
+		expect(parseEntrySortValue("default")).toEqual({ field: "created_at", ascending: false });
+		expect(parseEntrySortValue("")).toEqual({ field: "created_at", ascending: false });
+	});
+
+	it("許可リストに含まれるフィールドと方向をパースできる", () => {
+		expect(parseEntrySortValue("amount_asc")).toEqual({ field: "amount", ascending: true });
+		expect(parseEntrySortValue("name_desc")).toEqual({ field: "name", ascending: false });
+	});
+
+	it("アンダースコアを含むフィールド名 (created_at) を正しくパースできる", () => {
+		expect(parseEntrySortValue("created_at_asc")).toEqual({ field: "created_at", ascending: true });
+		expect(parseEntrySortValue("updated_at_desc")).toEqual({
+			field: "updated_at",
+			ascending: false,
+		});
+	});
+
+	it("許可されていないフィールド名は created_at にフォールバックする", () => {
+		expect(parseEntrySortValue("password_asc")).toEqual({ field: "created_at", ascending: true });
+		expect(parseEntrySortValue("id_desc")).toEqual({ field: "created_at", ascending: false });
+	});
+
+	it("許可されていない方向は desc にフォールバックする", () => {
+		expect(parseEntrySortValue("amount_DROP")).toEqual({ field: "amount", ascending: false });
+	});
+});

--- a/src/lib/security/search-sanitize.ts
+++ b/src/lib/security/search-sanitize.ts
@@ -4,8 +4,10 @@
  *
  * - `escapeIlikePattern`: ILIKE のワイルドカード (`%`, `_`) と
  *   エスケープ文字 (`\`) を文字どおりにマッチさせるためにエスケープする。
- * - `sanitizePostgrestOrValue`: PostgREST の `.or()` で構文として解釈される
- *   区切り文字 (`,` `(` `)`) を除去する。
+ * - `sanitizePostgrestOrValue`: PostgREST の `.or()` 内でメタ文字として
+ *   解釈される文字 (区切りの `,` `(` `)` および値を曖昧化する `*`) を除去する。
+ *   `*` は PostgREST の一部演算子で多目的のメタ文字となるため、リテラル検索の
+ *   一貫性を保つために除去している。
  * - `ALLOWED_ENTRY_SORT_FIELDS` / `ALLOWED_SORT_DIRECTIONS`:
  *   `order()` の列名・方向に渡せる値のホワイトリスト。
  */
@@ -25,7 +27,9 @@ export function escapeIlikePattern(input: string): string {
 
 /**
  * PostgREST の `.or()` クエリ文字列に補間する値から、
- * `,` `(` `)` といった区切り/メタ文字を除去する。
+ * 区切り/メタ文字 (`,` `(` `)` `*`) を除去する。
+ * `*` は PostgREST の値部分でメタ文字として解釈され得るため、
+ * リテラル検索の一貫性のため落としている。
  * `escapeIlikePattern` と組み合わせて使う想定。
  */
 export function sanitizePostgrestOrValue(input: string): string {
@@ -34,8 +38,8 @@ export function sanitizePostgrestOrValue(input: string): string {
 
 /**
  * `.or()` の中で ILIKE パターンとして安全に使える形に整形する。
- * - `,` `(` `)` `*` を除去
- * - `%` `_` `\` をエスケープ
+ * - `,` `(` `)` `*` を除去 (PostgREST 区切り/メタ文字)
+ * - `%` `_` `\` をエスケープ (ILIKE ワイルドカード)
  */
 export function buildOrIlikePattern(input: string): string {
 	return `%${escapeIlikePattern(sanitizePostgrestOrValue(input))}%`;

--- a/src/lib/security/search-sanitize.ts
+++ b/src/lib/security/search-sanitize.ts
@@ -1,0 +1,92 @@
+/**
+ * PostgREST のフィルタ式 (`.or()` / `.ilike()`) にユーザー入力を補間する際の
+ * サニタイズ用ヘルパー。
+ *
+ * - `escapeIlikePattern`: ILIKE のワイルドカード (`%`, `_`) と
+ *   エスケープ文字 (`\`) を文字どおりにマッチさせるためにエスケープする。
+ * - `sanitizePostgrestOrValue`: PostgREST の `.or()` で構文として解釈される
+ *   区切り文字 (`,` `(` `)`) を除去する。
+ * - `ALLOWED_ENTRY_SORT_FIELDS` / `ALLOWED_SORT_DIRECTIONS`:
+ *   `order()` の列名・方向に渡せる値のホワイトリスト。
+ */
+
+const ILIKE_SPECIAL_CHARS = /[\\%_]/g;
+
+/**
+ * ILIKE のワイルドカード (% _) と エスケープ文字 (\) をエスケープして、
+ * ユーザー入力を「リテラル」として検索できるようにする。
+ *
+ * 注意: 返り値は `%pattern%` のような前後ラップ前の値。呼び出し側で
+ *   `` `%${escapeIlikePattern(input)}%` `` のように結合する。
+ */
+export function escapeIlikePattern(input: string): string {
+	return input.replace(ILIKE_SPECIAL_CHARS, "\\$&");
+}
+
+/**
+ * PostgREST の `.or()` クエリ文字列に補間する値から、
+ * `,` `(` `)` といった区切り/メタ文字を除去する。
+ * `escapeIlikePattern` と組み合わせて使う想定。
+ */
+export function sanitizePostgrestOrValue(input: string): string {
+	return input.replace(/[,()*]/g, "");
+}
+
+/**
+ * `.or()` の中で ILIKE パターンとして安全に使える形に整形する。
+ * - `,` `(` `)` `*` を除去
+ * - `%` `_` `\` をエスケープ
+ */
+export function buildOrIlikePattern(input: string): string {
+	return `%${escapeIlikePattern(sanitizePostgrestOrValue(input))}%`;
+}
+
+export const ALLOWED_ENTRY_SORT_FIELDS = [
+	"created_at",
+	"updated_at",
+	"amount",
+	"name",
+	"organization",
+	"position",
+	"address",
+] as const;
+
+export type AllowedEntrySortField = (typeof ALLOWED_ENTRY_SORT_FIELDS)[number];
+
+export const ALLOWED_SORT_DIRECTIONS = ["asc", "desc"] as const;
+
+export type AllowedSortDirection = (typeof ALLOWED_SORT_DIRECTIONS)[number];
+
+/**
+ * `field_direction` 形式のソート指定文字列を、ホワイトリストに基づいて
+ * 安全な `{ field, ascending }` に変換する。
+ *
+ * - 想定外のフィールド名・方向が指定された場合はデフォルト値を返す
+ *   (列名列挙やエラーリーク防止)。
+ */
+export function parseEntrySortValue(sortValue: string | undefined): {
+	field: AllowedEntrySortField;
+	ascending: boolean;
+} {
+	const fallback = { field: "created_at" as AllowedEntrySortField, ascending: false };
+	if (!sortValue || sortValue === "default") {
+		return fallback;
+	}
+
+	const lastUnderscore = sortValue.lastIndexOf("_");
+	if (lastUnderscore < 0) {
+		return fallback;
+	}
+
+	const rawField = sortValue.slice(0, lastUnderscore);
+	const rawDirection = sortValue.slice(lastUnderscore + 1);
+
+	const field = (ALLOWED_ENTRY_SORT_FIELDS as readonly string[]).includes(rawField)
+		? (rawField as AllowedEntrySortField)
+		: fallback.field;
+	const direction = (ALLOWED_SORT_DIRECTIONS as readonly string[]).includes(rawDirection)
+		? (rawDirection as AllowedSortDirection)
+		: "desc";
+
+	return { field, ascending: direction === "asc" };
+}

--- a/supabase/migrations/20260516130000_security_review_rls_hardening.sql
+++ b/supabase/migrations/20260516130000_security_review_rls_hardening.sql
@@ -1,0 +1,171 @@
+-- 2026-05-16: RLS ハードニング（グループA: 過剰権限ポリシーの是正）
+--
+-- 対象 Issue:
+--   #64 koudens.basic_access が viewer の UPDATE/DELETE を許してしまっていた
+--   #65 koudens_insert_policy が owner_id / created_by を強制していなかった
+--   #66 kouden_entry_audit_logs INSERT が `to public with check (true)` で誰でも偽造可能
+--   #67 kouden_members.members_basic_access が全件 SELECT を許していた
+--   #77 profiles が anon 含む public SELECT で全件公開だった
+--   #78 debug_logs INSERT に user_id 制約がなく、なりすましログ書き込みが可能だった
+--
+-- 全体方針:
+--   - `for all` の過剰ポリシーを SELECT / INSERT / UPDATE / DELETE に分割
+--   - 不要な `to public` を `to authenticated` に絞る
+--   - 監査ログ系の INSERT はトリガ (SECURITY DEFINER) 経由のみとし、
+--     クライアントロールの INSERT ポリシーを撤去
+--
+-- 注意: `*_grants` は Supabase デフォルトで anon にも与えられているが、
+--   RLS で実質拒否されるため本マイグレーションでは触らない。
+
+-- ========================================================================
+-- 共通ヘルパー: kouden_members に対する自己参照の再帰 RLS を避けるため
+-- SECURITY DEFINER で会員判定を行う関数を導入する。
+-- ========================================================================
+
+CREATE OR REPLACE FUNCTION public.is_kouden_member_for_current_user(p_kouden_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM public.kouden_members
+        WHERE kouden_id = p_kouden_id
+          AND user_id = auth.uid()
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_kouden_member_for_current_user(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_kouden_member_for_current_user(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.is_kouden_member_for_current_user(uuid) IS
+    'kouden_members RLS の自己参照を避けるため、現在の auth.uid() がメンバーかを SECURITY DEFINER で判定する。';
+
+
+-- ========================================================================
+-- #64 / #65: koudens
+-- 旧: basic_access (for all) と owner_access (for all)、insert_policy が混在
+-- 新: SELECT / INSERT / UPDATE / DELETE を明示的に分離
+-- ========================================================================
+
+DROP POLICY IF EXISTS "basic_access" ON public.koudens;
+DROP POLICY IF EXISTS "koudens_insert_policy" ON public.koudens;
+DROP POLICY IF EXISTS "owner_access" ON public.koudens;
+
+-- SELECT: オーナー / 作成者 / メンバーが閲覧可能
+CREATE POLICY "koudens_select_member" ON public.koudens
+    AS PERMISSIVE
+    FOR SELECT
+    TO authenticated
+    USING (
+        owner_id = auth.uid()
+        OR created_by = auth.uid()
+        OR public.is_kouden_member_for_current_user(id)
+    );
+
+-- INSERT: owner_id と created_by が自分自身でなければならない
+-- (admin client / service-role は RLS バイパスのため有料プラン作成や
+--  Stripe Webhook フローには影響しない)
+CREATE POLICY "koudens_insert_self" ON public.koudens
+    AS PERMISSIVE
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        owner_id = auth.uid()
+        AND created_by = auth.uid()
+    );
+
+-- UPDATE / DELETE: オーナー / 作成者のみ
+CREATE POLICY "koudens_update_owner" ON public.koudens
+    AS PERMISSIVE
+    FOR UPDATE
+    TO authenticated
+    USING (owner_id = auth.uid() OR created_by = auth.uid())
+    WITH CHECK (owner_id = auth.uid() OR created_by = auth.uid());
+
+CREATE POLICY "koudens_delete_owner" ON public.koudens
+    AS PERMISSIVE
+    FOR DELETE
+    TO authenticated
+    USING (owner_id = auth.uid() OR created_by = auth.uid());
+
+
+-- ========================================================================
+-- #67: kouden_members SELECT
+-- 旧: members_basic_access が全行 SELECT を許可
+-- 新: 自分自身 / 同じ kouden のオーナー / 同じ kouden のメンバー のみ
+-- ========================================================================
+
+DROP POLICY IF EXISTS "members_basic_access" ON public.kouden_members;
+
+CREATE POLICY "kouden_members_select" ON public.kouden_members
+    AS PERMISSIVE
+    FOR SELECT
+    TO authenticated
+    USING (
+        user_id = auth.uid()
+        OR EXISTS (
+            SELECT 1 FROM public.koudens k
+            WHERE k.id = kouden_members.kouden_id
+              AND (k.owner_id = auth.uid() OR k.created_by = auth.uid())
+        )
+        OR public.is_kouden_member_for_current_user(kouden_members.kouden_id)
+    );
+
+
+-- ========================================================================
+-- #66: kouden_entry_audit_logs INSERT
+-- 旧: to public with check (true) — anon を含む誰でも監査ログを偽造可能
+-- 新: クライアントロールに対する INSERT ポリシーは持たない。
+--     書き込みは log_kouden_entry_changes() トリガ (SECURITY DEFINER) のみ。
+-- ========================================================================
+
+DROP POLICY IF EXISTS "システムは監査ログを作成できる" ON public.kouden_entry_audit_logs;
+
+
+-- ========================================================================
+-- #77: profiles SELECT
+-- 旧: to public using (true) — 未認証 (anon) でも全プロフィール SELECT 可
+-- 新: authenticated のみ。
+--     (auth/contact 等は admin client = service-role を使うため影響なし)
+-- INSERT / UPDATE も to public を to authenticated に絞る
+-- ========================================================================
+
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON public.profiles;
+DROP POLICY IF EXISTS "Users can insert their own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+
+CREATE POLICY "profiles_authenticated_select" ON public.profiles
+    AS PERMISSIVE
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+CREATE POLICY "profiles_self_insert" ON public.profiles
+    AS PERMISSIVE
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "profiles_self_update" ON public.profiles
+    AS PERMISSIVE
+    FOR UPDATE
+    TO authenticated
+    USING (auth.uid() = id)
+    WITH CHECK (auth.uid() = id);
+
+
+-- ========================================================================
+-- #78: debug_logs INSERT
+-- 旧: with check (true) — 任意の user_id でログ書き込み可能 (なりすまし)
+-- 新: user_id = auth.uid() を強制
+-- ========================================================================
+
+DROP POLICY IF EXISTS "Allow insert debug logs" ON public.debug_logs;
+
+CREATE POLICY "debug_logs_self_insert" ON public.debug_logs
+    AS PERMISSIVE
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
This PR implements comprehensive security hardening across Row Level Security (RLS) policies and user input handling. It addresses multiple privilege escalation vulnerabilities and injection risks identified in the security review.

## Key Changes

### Database Security (RLS Hardening)
- **koudens table**: Split overly permissive `for all` policies into explicit SELECT/INSERT/UPDATE/DELETE policies
  - INSERT now enforces `owner_id = auth.uid()` and `created_by = auth.uid()`
  - UPDATE/DELETE restricted to owner or creator only
  - SELECT allows owner, creator, or kouden members
  
- **kouden_members table**: Replaced blanket SELECT policy with role-based access
  - Users can only view their own memberships or members of koudens they own/created
  - Added `is_kouden_member_for_current_user()` SECURITY DEFINER function to avoid recursive RLS issues

- **kouden_entry_audit_logs**: Removed client-side INSERT policy
  - Audit logs now written exclusively via SECURITY DEFINER trigger function
  - Prevents unauthorized log forgery

- **profiles table**: Restricted from public (anon) to authenticated users only
  - SELECT, INSERT, UPDATE all now require authentication
  - INSERT/UPDATE enforce self-ownership via `auth.uid() = id`

- **debug_logs table**: Added `user_id = auth.uid()` constraint on INSERT
  - Prevents impersonation attacks via arbitrary user_id values

### kouden_entries RLS Refinement
- Replaced single owner-only policy with three role-based policies:
  - `owner_crud_access`: Full CRUD for owner/creator
  - `editor_crud_access`: Full CRUD for members with editor role or `entry.write` permission
  - `viewer_read_access`: SELECT-only for members with viewer role or `entry.read` permission

### Input Sanitization
- **New module**: `src/lib/security/search-sanitize.ts`
  - `escapeIlikePattern()`: Escapes ILIKE wildcards (`%`, `_`) and backslashes for literal matching
  - `sanitizePostgrestOrValue()`: Removes PostgREST metacharacters (`,`, `(`, `)`) from `.or()` filters
  - `buildOrIlikePattern()`: Combines both for safe pattern building
  - `parseEntrySortValue()`: Validates sort field/direction against whitelist to prevent column enumeration
  - Comprehensive test coverage with 11 test cases

- **Applied sanitization** in:
  - `src/app/_actions/entries.ts`: Search and sort parameter handling
  - `src/app/_actions/admin/users.ts`: Display name search
  - `src/app/_actions/return-records/pagination.ts`: Return entry search

## Notable Implementation Details
- SECURITY DEFINER functions use explicit `SET search_path = public` to prevent search path attacks
- Whitelist-based sort field validation returns safe defaults rather than errors to prevent information leakage
- All changes maintain backward compatibility with admin/service-role clients (which bypass RLS)
- Audit trail preserved through trigger-based logging rather than client-side writes

https://claude.ai/code/session_01GMfExGPW6ZqnwUTESp7H7J