### PR TITLE
Improve auth security: HttpOnly cookies, timing-safe comparison

### DIFF
--- a/src/app/api/auth/cookies/invitation-token/route.ts
+++ b/src/app/api/auth/cookies/invitation-token/route.ts
@@ -52,7 +52,6 @@ export async function POST(request: Request) {
 		return NextResponse.json({ error: "token contains invalid characters" }, { status: 400 });
 	}
 
-	const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
 	const response = NextResponse.json(
 		{ ok: true },
 		{
@@ -62,9 +61,12 @@ export async function POST(request: Request) {
 			},
 		},
 	);
-	response.headers.set(
-		"Set-Cookie",
-		`invitation_token=${token}; Path=/; HttpOnly; SameSite=Lax;${secureFlag} Max-Age=3600`,
-	);
+	response.cookies.set("invitation_token", token, {
+		path: "/",
+		httpOnly: true,
+		sameSite: "lax",
+		secure: process.env.NODE_ENV === "production",
+		maxAge: 3600,
+	});
 	return response;
 }

--- a/src/app/api/auth/cookies/invitation-token/route.ts
+++ b/src/app/api/auth/cookies/invitation-token/route.ts
@@ -70,3 +70,35 @@ export async function POST(request: Request) {
 	});
 	return response;
 }
+
+/**
+ * 招待トークン Cookie を明示的に破棄する。
+ *
+ * 認証フロー中断時のロールバック用。`setupAuthCookies` で Cookie を確定したあと
+ * 後続の `signInWith*` が失敗した／プロバイダ画面でユーザーが中止した場合に
+ * 呼び出されることを想定する。これがないと Cookie は Max-Age=3600 が切れる
+ * までブラウザに残存し、次回ログインで `/auth/callback` が古い招待トークンを
+ * 自動適用してしまう。
+ *
+ * Cookie 削除は `maxAge: 0` で実現する。Path / SameSite / Secure などの属性は
+ * 設定時と揃えておく必要がある (ブラウザは name+domain+path で同一性を判定する)。
+ */
+export function DELETE() {
+	const response = NextResponse.json(
+		{ ok: true },
+		{
+			status: 200,
+			headers: {
+				"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+			},
+		},
+	);
+	response.cookies.set("invitation_token", "", {
+		path: "/",
+		httpOnly: true,
+		sameSite: "lax",
+		secure: process.env.NODE_ENV === "production",
+		maxAge: 0,
+	});
+	return response;
+}

--- a/src/app/api/auth/cookies/invitation-token/route.ts
+++ b/src/app/api/auth/cookies/invitation-token/route.ts
@@ -1,0 +1,70 @@
+/**
+ * 招待トークン Cookie 設定エンドポイント。
+ *
+ * 認証フロー（特に OAuth リダイレクト）の前にトークン値を Cookie に格納する
+ * 必要があるが、`document.cookie` での書き込みでは `HttpOnly` を付けられず
+ * XSS から保護できない。サーバー側で書き込むことで `HttpOnly; Secure;
+ * SameSite=Lax` を強制する。
+ *
+ * SameSite=Lax の理由:
+ *   Google → Supabase → /auth/callback の最終リダイレクトは cross-site の
+ *   top-level GET になる。SameSite=Strict だとこのとき Cookie が落ちるため、
+ *   Strict ではフローが破綻する。XSS 緩和の本命は HttpOnly。
+ *
+ * CSRF: middleware の `requiresCSRFProtection` でカバーされており、本ルート
+ *   は除外リストに入っていないため、クライアントは `X-CSRF-Token` ヘッダー
+ *   と `csrf-token` Cookie の両方を持参する必要がある。
+ */
+
+import logger from "@/lib/logger";
+import { NextResponse } from "next/server";
+
+const INVITATION_TOKEN_MAX_LENGTH = 256;
+// 招待トークンの値域。現状は UUID 想定だが将来 base64url 系に拡張しても
+// 通すよう緩めにしてある。コロン・スラッシュ・改行など Cookie 注入に
+// 使われうる文字を確実に排除するのが目的。
+const INVITATION_TOKEN_PATTERN = /^[A-Za-z0-9._~-]+$/;
+
+interface RequestBody {
+	token?: unknown;
+}
+
+export async function POST(request: Request) {
+	let body: RequestBody;
+	try {
+		body = (await request.json()) as RequestBody;
+	} catch {
+		return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+	}
+
+	const token = body.token;
+	if (typeof token !== "string" || token.length === 0) {
+		return NextResponse.json({ error: "token is required" }, { status: 400 });
+	}
+	if (token.length > INVITATION_TOKEN_MAX_LENGTH) {
+		return NextResponse.json({ error: "token is too long" }, { status: 400 });
+	}
+	if (!INVITATION_TOKEN_PATTERN.test(token)) {
+		logger.warn(
+			{ tokenLength: token.length },
+			"Rejected invitation_token cookie write (bad chars)",
+		);
+		return NextResponse.json({ error: "token contains invalid characters" }, { status: 400 });
+	}
+
+	const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
+	const response = NextResponse.json(
+		{ ok: true },
+		{
+			status: 200,
+			headers: {
+				"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+			},
+		},
+	);
+	response.headers.set(
+		"Set-Cookie",
+		`invitation_token=${token}; Path=/; HttpOnly; SameSite=Lax;${secureFlag} Max-Age=3600`,
+	);
+	return response;
+}

--- a/src/app/api/auth/cookies/post-auth-redirect/route.ts
+++ b/src/app/api/auth/cookies/post-auth-redirect/route.ts
@@ -41,7 +41,6 @@ export async function POST(request: Request) {
 	// 文字列利用なので、ここでも生のパスをそのまま入れる。Cookie 値として禁止
 	// される文字 (`;`, 空白, 制御文字) は sanitizeRedirectPath 通過後の相対パス
 	// では現実的に出現しない（URL().pathname/search/hash は適切にエンコード済み）。
-	const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
 	const response = NextResponse.json(
 		{ ok: true },
 		{
@@ -51,9 +50,14 @@ export async function POST(request: Request) {
 			},
 		},
 	);
-	response.headers.set(
-		"Set-Cookie",
-		`post_auth_redirect=${safePath}; Path=/; HttpOnly; SameSite=Lax;${secureFlag}`,
-	);
+	// Max-Age は invitation_token と揃えて 1 時間。明示的な有効期限を付けることで
+	// ブラウザを閉じずに放置されたタブから古い redirect 先が再使用されるのを防ぐ。
+	response.cookies.set("post_auth_redirect", safePath, {
+		path: "/",
+		httpOnly: true,
+		sameSite: "lax",
+		secure: process.env.NODE_ENV === "production",
+		maxAge: 3600,
+	});
 	return response;
 }

--- a/src/app/api/auth/cookies/post-auth-redirect/route.ts
+++ b/src/app/api/auth/cookies/post-auth-redirect/route.ts
@@ -1,0 +1,59 @@
+/**
+ * 認証完了後リダイレクト先 Cookie 設定エンドポイント。
+ *
+ * OAuth / OTP の前にユーザーがどこに戻りたかったかを Cookie に保存し、
+ * `/auth/callback` で読み出して redirect する。`document.cookie` だと
+ * HttpOnly を付けられないため、サーバー側で書き込む。
+ *
+ * SameSite=Lax の理由は `/api/auth/cookies/invitation-token` と同じ。
+ *
+ * 値検証は {@link sanitizeRedirectPath} に委ねる。書き込み側と読み出し側
+ * (`/auth/callback`) で同一ロジックを共有することで、ローカルに緩い Cookie
+ * を仕込んで callback の信頼を悪用する経路を塞ぐ。
+ */
+
+import { sanitizeRedirectPath } from "@/lib/security/redirect";
+import { NextResponse } from "next/server";
+
+interface RequestBody {
+	redirectTo?: unknown;
+}
+
+export async function POST(request: Request) {
+	let body: RequestBody;
+	try {
+		body = (await request.json()) as RequestBody;
+	} catch {
+		return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+	}
+
+	const redirectTo = body.redirectTo;
+	if (typeof redirectTo !== "string") {
+		return NextResponse.json({ error: "redirectTo is required" }, { status: 400 });
+	}
+
+	const safePath = sanitizeRedirectPath(redirectTo);
+	if (!safePath) {
+		return NextResponse.json({ error: "redirectTo is not a safe relative path" }, { status: 400 });
+	}
+
+	// Cookie 読み出し側 (/auth/callback) で `decodeURIComponent` していない素朴な
+	// 文字列利用なので、ここでも生のパスをそのまま入れる。Cookie 値として禁止
+	// される文字 (`;`, 空白, 制御文字) は sanitizeRedirectPath 通過後の相対パス
+	// では現実的に出現しない（URL().pathname/search/hash は適切にエンコード済み）。
+	const secureFlag = process.env.NODE_ENV === "production" ? " Secure;" : "";
+	const response = NextResponse.json(
+		{ ok: true },
+		{
+			status: 200,
+			headers: {
+				"Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+			},
+		},
+	);
+	response.headers.set(
+		"Set-Cookie",
+		`post_auth_redirect=${safePath}; Path=/; HttpOnly; SameSite=Lax;${secureFlag}`,
+	);
+	return response;
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,35 +1,7 @@
 import { acceptInvitation } from "@/app/_actions/invitations";
+import { sanitizeRedirectPath } from "@/lib/security/redirect";
 import { createClient } from "@/lib/supabase/server";
 import { cookies } from "next/headers";
-
-/**
- * オープンリダイレクト対策。リダイレクト先として安全な相対パスのみを許可する。
- *
- * 受理する値:
- *   - "/" で始まる相対パス（"/koudens/123" など）
- * 拒否する値:
- *   - スキーム付き絶対URL（"https://evil.com" など）
- *   - プロトコル相対URL（"//evil.com"）
- *   - バックスラッシュで始まるパス（"\\evil.com" — ブラウザで "//evil.com" と解釈されうる）
- *   - 空文字 / 不正な文字列
- *
- * 戻り値: そのまま `Response.redirect(new URL(value, origin))` に渡せる安全な相対パス、または `null`。
- */
-function sanitizeRedirectPath(value: string | null | undefined): string | null {
-	if (!value) return null;
-	if (value.startsWith("//") || value.startsWith("\\")) return null;
-	if (!value.startsWith("/")) return null;
-	try {
-		// base URL を使えば相対パスでも URL としてパースできる。
-		// origin が変わった (= 絶対URLが指定されていた) ら拒否する。
-		const base = "https://internal.invalid";
-		const parsed = new URL(value, base);
-		if (parsed.origin !== base) return null;
-		return parsed.pathname + parsed.search + parsed.hash;
-	} catch {
-		return null;
-	}
-}
 
 export async function GET(request: Request) {
 	const requestUrl = new URL(request.url);

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -84,6 +84,23 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 		}
 	};
 
+	/**
+	 * `signInWith*` 失敗時に、setupAuthCookies で書いた invitation_token Cookie を
+	 * 破棄する。失敗放置だと Cookie が Max-Age=3600 残存し、次回ログイン時に古い
+	 * 招待が auto-apply されてしまう。
+	 *
+	 * 失敗はベストエフォートで握りつぶす（ロールバックの失敗を更にユーザーに
+	 * 出してもどうしようもない）。
+	 */
+	const clearInvitationCookie = async () => {
+		if (!invitationToken) return;
+		try {
+			await fetchWithCSRF("/api/auth/cookies/invitation-token", { method: "DELETE" });
+		} catch (error) {
+			console.error("[ERROR] Failed to clear invitation token cookie:", error);
+		}
+	};
+
 	const handleSendOtp = async () => {
 		if (!email) {
 			setMessage("メールアドレスを入力してください");
@@ -118,6 +135,7 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 			} else {
 				setMessage("認証コードの送信に失敗しました。再度お試しください。");
 			}
+			await clearInvitationCookie();
 		} finally {
 			setIsLoading(false);
 		}
@@ -200,6 +218,7 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 			} else {
 				setMessage("Googleログインに失敗しました。再度お試しください。");
 			}
+			await clearInvitationCookie();
 			setIsLoading(false);
 		}
 	};

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -190,6 +190,13 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 		setCurrentStep("email");
 		setOtpCode("");
 		setMessage(null);
+		// ユーザーが OTP フローを明示的に放棄した時点で Cookie をクリアする。
+		// 同じメールで再送信した場合 setupAuthCookies が再書き込みするので、
+		// 別メールに切り替える正規ケースで stale Cookie を残さないようにする。
+		// 注: handleVerifyOtp の失敗 catch では消さない。OTP 一回ミスごとに Cookie を
+		// 飛ばすと、正しいコードでのリトライが invitation_token 無しで callback に
+		// 到達して招待フローが壊れるため。
+		clearInvitationCookie();
 	};
 
 	const handleGoogleLogin = async () => {

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -41,33 +41,47 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 	/**
 	 * 認証フローに必要な Cookie をサーバー側で HttpOnly 付きで設定する。
 	 * 失敗時は false を返し、呼び出し側で OAuth/OTP 起動を中止する。
+	 *
+	 * 2 つの Cookie 書き込みは独立しているので並列で投げ、ログインボタン押下から
+	 * OAuth 起動までの待ち時間を短縮する。
 	 */
 	const setupAuthCookies = async (): Promise<boolean> => {
+		const tasks: Promise<Response>[] = [];
 		if (invitationToken) {
-			const res = await fetchWithCSRF("/api/auth/cookies/invitation-token", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ token: invitationToken }),
-			});
-			if (!res.ok) {
-				console.error("[ERROR] Failed to store invitation token cookie:", await res.text());
-				setMessage("招待情報の保存に失敗しました。再度お試しください。");
-				return false;
-			}
+			tasks.push(
+				fetchWithCSRF("/api/auth/cookies/invitation-token", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ token: invitationToken }),
+				}),
+			);
 		}
 		if (propRedirectTo) {
-			const res = await fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ redirectTo: propRedirectTo }),
-			});
-			if (!res.ok) {
-				console.error("[ERROR] Failed to store post-auth redirect cookie:", await res.text());
-				setMessage("リダイレクト情報の保存に失敗しました。再度お試しください。");
-				return false;
-			}
+			tasks.push(
+				fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ redirectTo: propRedirectTo }),
+				}),
+			);
 		}
-		return true;
+		if (tasks.length === 0) return true;
+
+		try {
+			const responses = await Promise.all(tasks);
+			for (const res of responses) {
+				if (!res.ok) {
+					console.error("[ERROR] Failed to store auth cookie:", await res.text());
+					setMessage("認証情報の保存に失敗しました。再度お試しください。");
+					return false;
+				}
+			}
+			return true;
+		} catch (error) {
+			console.error("[ERROR] Network error during cookie setup:", error);
+			setMessage("通信エラーが発生しました。再度お試しください。");
+			return false;
+		}
 	};
 
 	const handleSendOtp = async () => {

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { GoogleIcon } from "@/components/custom/icons/google";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
+import { useCSRFToken } from "@/hooks/use-csrf-token";
 import { createClient } from "@/lib/supabase/client";
-import { GoogleIcon } from "@/components/custom/icons/google";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 interface AuthFormProps {
 	invitationToken?: string;
@@ -24,18 +25,9 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 	const [isLoading, setIsLoading] = useState(false);
 	const [currentStep, setCurrentStep] = useState<AuthStep>("email");
 	const supabase = createClient();
+	const { fetchWithCSRF } = useCSRFToken();
 
 	useEffect(() => {
-		// Store invitation token in cookie before authentication
-		if (invitationToken) {
-			try {
-				document.cookie = `invitation_token=${invitationToken}; path=/; max-age=3600; SameSite=Lax; Secure`;
-			} catch (error) {
-				console.error("[ERROR] Failed to store invitation token in cookie:", error);
-				setMessage("招待情報の保存に失敗しました。再度お試しください。");
-			}
-		}
-
 		// Build callback URL for Supabase OAuth (include invitation token if present)
 		const base = `${window.location.origin}/auth/callback`;
 		const params = new URLSearchParams();
@@ -45,6 +37,38 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 		const callbackUrl = params.toString() ? `${base}?${params.toString()}` : base;
 		setRedirectUrl(callbackUrl);
 	}, [invitationToken]);
+
+	/**
+	 * 認証フローに必要な Cookie をサーバー側で HttpOnly 付きで設定する。
+	 * 失敗時は false を返し、呼び出し側で OAuth/OTP 起動を中止する。
+	 */
+	const setupAuthCookies = async (): Promise<boolean> => {
+		if (invitationToken) {
+			const res = await fetchWithCSRF("/api/auth/cookies/invitation-token", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ token: invitationToken }),
+			});
+			if (!res.ok) {
+				console.error("[ERROR] Failed to store invitation token cookie:", await res.text());
+				setMessage("招待情報の保存に失敗しました。再度お試しください。");
+				return false;
+			}
+		}
+		if (propRedirectTo) {
+			const res = await fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ redirectTo: propRedirectTo }),
+			});
+			if (!res.ok) {
+				console.error("[ERROR] Failed to store post-auth redirect cookie:", await res.text());
+				setMessage("リダイレクト情報の保存に失敗しました。再度お試しください。");
+				return false;
+			}
+		}
+		return true;
+	};
 
 	const handleSendOtp = async () => {
 		if (!email) {
@@ -56,9 +80,10 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 			setIsLoading(true);
 			setMessage(null);
 
-			// Store post-login redirect in cookie if provided
-			if (propRedirectTo) {
-				document.cookie = `post_auth_redirect=${encodeURIComponent(propRedirectTo)}; path=/; SameSite=Lax; Secure`;
+			const cookiesOk = await setupAuthCookies();
+			if (!cookiesOk) {
+				setIsLoading(false);
+				return;
 			}
 
 			const { error } = await supabase.auth.signInWithOtp({
@@ -140,9 +165,10 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 			setIsLoading(true);
 			setMessage(null);
 
-			// Store post-login redirect in cookie if provided
-			if (propRedirectTo) {
-				document.cookie = `post_auth_redirect=${encodeURIComponent(propRedirectTo)}; path=/; SameSite=Lax; Secure`;
+			const cookiesOk = await setupAuthCookies();
+			if (!cookiesOk) {
+				setIsLoading(false);
+				return;
 			}
 
 			const { error } = await supabase.auth.signInWithOAuth({

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -42,36 +42,36 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 	 * 認証フローに必要な Cookie をサーバー側で HttpOnly 付きで設定する。
 	 * 失敗時は false を返し、呼び出し側で OAuth/OTP 起動を中止する。
 	 *
-	 * 2 つの Cookie 書き込みは独立しているので並列で投げ、ログインボタン押下から
-	 * OAuth 起動までの待ち時間を短縮する。
+	 * 順序が重要: 必ず post_auth_redirect → invitation_token の順で書く。
+	 *   invitation_token は次回認証時に /auth/callback で `acceptInvitation`
+	 *   を自動発火させる semantics を持つため、部分失敗で取り残されると
+	 *   ユーザーが意図しない香典帳に参加させられる可能性がある。
+	 *   post_auth_redirect は読み出し時に毎回上書き / 削除される素朴な
+	 *   リダイレクト先なので、取り残されても害は無い。よって「悪い側」を
+	 *   後に書き、前段が失敗した時点で abort することで orphan を回避する。
 	 */
 	const setupAuthCookies = async (): Promise<boolean> => {
-		const tasks: Promise<Response>[] = [];
-		if (invitationToken) {
-			tasks.push(
-				fetchWithCSRF("/api/auth/cookies/invitation-token", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ token: invitationToken }),
-				}),
-			);
-		}
-		if (propRedirectTo) {
-			tasks.push(
-				fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
+		try {
+			if (propRedirectTo) {
+				const res = await fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ redirectTo: propRedirectTo }),
-				}),
-			);
-		}
-		if (tasks.length === 0) return true;
-
-		try {
-			const responses = await Promise.all(tasks);
-			for (const res of responses) {
+				});
 				if (!res.ok) {
-					console.error("[ERROR] Failed to store auth cookie:", await res.text());
+					console.error("[ERROR] Failed to store post-auth redirect cookie:", await res.text());
+					setMessage("認証情報の保存に失敗しました。再度お試しください。");
+					return false;
+				}
+			}
+			if (invitationToken) {
+				const res = await fetchWithCSRF("/api/auth/cookies/invitation-token", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ token: invitationToken }),
+				});
+				if (!res.ok) {
+					console.error("[ERROR] Failed to store invitation token cookie:", await res.text());
 					setMessage("認証情報の保存に失敗しました。再度お試しください。");
 					return false;
 				}

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -51,27 +51,52 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 	 *   後に書き、前段が失敗した時点で abort することで orphan を回避する。
 	 */
 	const setupAuthCookies = async (): Promise<boolean> => {
+		// 4xx は「入力(redirectTo / invitation_token) がサーバ検証で弾かれた」状態であり、
+		// 認証フロー自体は破綻していない。ログインを止めると、URL に古い / 不正な
+		// クエリパラメータが残っているだけでユーザーがログインできなくなるので、
+		// 該当 Cookie を諦めて先へ進める（callback 側にはデフォルト /koudens と
+		// URL ?token= フォールバックがある）。
+		// 5xx / ネットワーク失敗はサーバ／回線側の故障なので、UI にエラーを出して
+		// abort する。
+		const writeCookie = async (
+			url: string,
+			body: object,
+			label: string,
+		): Promise<"ok" | "skipped" | "fail"> => {
+			const res = await fetchWithCSRF(url, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			if (res.ok) return "ok";
+			const detail = await res.text().catch(() => "");
+			if (res.status >= 400 && res.status < 500) {
+				console.warn(`[WARN] ${label} skipped (${res.status}):`, detail);
+				return "skipped";
+			}
+			console.error(`[ERROR] Failed to store ${label} cookie (${res.status}):`, detail);
+			return "fail";
+		};
+
 		try {
 			if (propRedirectTo) {
-				const res = await fetchWithCSRF("/api/auth/cookies/post-auth-redirect", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ redirectTo: propRedirectTo }),
-				});
-				if (!res.ok) {
-					console.error("[ERROR] Failed to store post-auth redirect cookie:", await res.text());
+				const r = await writeCookie(
+					"/api/auth/cookies/post-auth-redirect",
+					{ redirectTo: propRedirectTo },
+					"post_auth_redirect",
+				);
+				if (r === "fail") {
 					setMessage("認証情報の保存に失敗しました。再度お試しください。");
 					return false;
 				}
 			}
 			if (invitationToken) {
-				const res = await fetchWithCSRF("/api/auth/cookies/invitation-token", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ token: invitationToken }),
-				});
-				if (!res.ok) {
-					console.error("[ERROR] Failed to store invitation token cookie:", await res.text());
+				const r = await writeCookie(
+					"/api/auth/cookies/invitation-token",
+					{ token: invitationToken },
+					"invitation_token",
+				);
+				if (r === "fail") {
 					setMessage("認証情報の保存に失敗しました。再度お試しください。");
 					return false;
 				}

--- a/src/components/custom/auth-form.tsx
+++ b/src/components/custom/auth-form.tsx
@@ -51,13 +51,14 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 	 *   後に書き、前段が失敗した時点で abort することで orphan を回避する。
 	 */
 	const setupAuthCookies = async (): Promise<boolean> => {
-		// 4xx は「入力(redirectTo / invitation_token) がサーバ検証で弾かれた」状態であり、
-		// 認証フロー自体は破綻していない。ログインを止めると、URL に古い / 不正な
-		// クエリパラメータが残っているだけでユーザーがログインできなくなるので、
-		// 該当 Cookie を諦めて先へ進める（callback 側にはデフォルト /koudens と
-		// URL ?token= フォールバックがある）。
-		// 5xx / ネットワーク失敗はサーバ／回線側の故障なので、UI にエラーを出して
-		// abort する。
+		// 400 のみ「入力(redirectTo / invitation_token) がサーバ検証で弾かれた」状態として
+		// 扱い、該当 Cookie を諦めて先へ進める。URL に古い / 不正なクエリパラメータが残って
+		// いるだけでログインを止めると、ユーザーが詰まるため。callback 側にはデフォルト
+		// /koudens と URL ?token= フォールバックがある。
+		// 403 (CSRF トークン失効) / 429 (rate limit) / その他の 4xx は認証フロー自体の
+		// 問題であり、サイレントに進めると本来書くべき Cookie が落ちて UX が壊れる
+		// （意図したリダイレクト先を失う、招待が適用されない、など）。明示的に失敗
+		// させて、ユーザーがリトライ（= 新鮮な CSRF トークン）できる状態に戻す。
 		const writeCookie = async (
 			url: string,
 			body: object,
@@ -70,8 +71,8 @@ export function AuthForm({ invitationToken, redirectTo: propRedirectTo }: AuthFo
 			});
 			if (res.ok) return "ok";
 			const detail = await res.text().catch(() => "");
-			if (res.status >= 400 && res.status < 500) {
-				console.warn(`[WARN] ${label} skipped (${res.status}):`, detail);
+			if (res.status === 400) {
+				console.warn(`[WARN] ${label} skipped (400):`, detail);
 				return "skipped";
 			}
 			console.error(`[ERROR] Failed to store ${label} cookie (${res.status}):`, detail);

--- a/src/components/custom/login-button.tsx
+++ b/src/components/custom/login-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useCSRFToken } from "@/hooks/use-csrf-token";
 import { createClient } from "@/lib/supabase/client";
 import { useState } from "react";
 import { GoogleIcon } from "./icons/google";
@@ -12,14 +13,25 @@ interface LoginButtonProps {
 export function LoginButton({ invitationToken }: LoginButtonProps) {
 	const [loading, setLoading] = useState(false);
 	const supabase = createClient();
+	const { fetchWithCSRF } = useCSRFToken();
 
 	const handleLogin = async () => {
 		try {
 			setLoading(true);
 
-			// 認証前にinvitation_tokenをクッキーに保存
+			// 認証前に invitation_token を HttpOnly Cookie として保存する。
+			// 書き込みは /api/auth/cookies/invitation-token 経由で行い、document.cookie
+			// では付与できない HttpOnly を強制する。失敗時は OAuth を起動しない。
 			if (invitationToken) {
-				document.cookie = `invitation_token=${invitationToken}; path=/; max-age=3600; SameSite=Lax`;
+				const res = await fetchWithCSRF("/api/auth/cookies/invitation-token", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ token: invitationToken }),
+				});
+				if (!res.ok) {
+					console.error("[DEBUG] Failed to store invitation token cookie:", await res.text());
+					return;
+				}
 			}
 
 			const { error } = await supabase.auth.signInWithOAuth({

--- a/src/components/custom/login-button.tsx
+++ b/src/components/custom/login-button.tsx
@@ -16,6 +16,20 @@ export function LoginButton({ invitationToken }: LoginButtonProps) {
 	const supabase = createClient();
 	const { fetchWithCSRF } = useCSRFToken();
 
+	/**
+	 * `signInWithOAuth` 失敗時に保存済みの invitation_token を破棄する。
+	 * Cookie が Max-Age=3600 残存すると、次回ログインで /auth/callback が
+	 * 古い招待を auto-apply してしまうため。ロールバック自体の失敗は飲み込む。
+	 */
+	const clearInvitationCookie = async () => {
+		if (!invitationToken) return;
+		try {
+			await fetchWithCSRF("/api/auth/cookies/invitation-token", { method: "DELETE" });
+		} catch (err) {
+			console.error("[DEBUG] Failed to clear invitation token cookie:", err);
+		}
+	};
+
 	const handleLogin = async () => {
 		try {
 			setLoading(true);
@@ -51,6 +65,7 @@ export function LoginButton({ invitationToken }: LoginButtonProps) {
 		} catch (err) {
 			console.error("[DEBUG] Login error:", err);
 			setError("ログインに失敗しました。再度お試しください。");
+			await clearInvitationCookie();
 		} finally {
 			setLoading(false);
 		}

--- a/src/components/custom/login-button.tsx
+++ b/src/components/custom/login-button.tsx
@@ -12,12 +12,14 @@ interface LoginButtonProps {
 
 export function LoginButton({ invitationToken }: LoginButtonProps) {
 	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 	const supabase = createClient();
 	const { fetchWithCSRF } = useCSRFToken();
 
 	const handleLogin = async () => {
 		try {
 			setLoading(true);
+			setError(null);
 
 			// 認証前に invitation_token を HttpOnly Cookie として保存する。
 			// 書き込みは /api/auth/cookies/invitation-token 経由で行い、document.cookie
@@ -30,32 +32,37 @@ export function LoginButton({ invitationToken }: LoginButtonProps) {
 				});
 				if (!res.ok) {
 					console.error("[DEBUG] Failed to store invitation token cookie:", await res.text());
+					setError("ログインの準備に失敗しました。再度お試しください。");
 					return;
 				}
 			}
 
-			const { error } = await supabase.auth.signInWithOAuth({
+			const { error: oauthError } = await supabase.auth.signInWithOAuth({
 				provider: "google",
 				options: {
 					redirectTo: `${window.location.origin}/auth/callback`,
 				},
 			});
 
-			if (error) {
-				console.error("[DEBUG] OAuth error:", error);
-				throw error;
+			if (oauthError) {
+				console.error("[DEBUG] OAuth error:", oauthError);
+				throw oauthError;
 			}
-		} catch (error) {
-			console.error("[DEBUG] Login error:", error);
+		} catch (err) {
+			console.error("[DEBUG] Login error:", err);
+			setError("ログインに失敗しました。再度お試しください。");
 		} finally {
 			setLoading(false);
 		}
 	};
 
 	return (
-		<Button onClick={handleLogin} disabled={loading} className="w-full" variant="outline">
-			<GoogleIcon />
-			{loading ? "ログイン中..." : "Googleでログイン"}
-		</Button>
+		<div className="w-full space-y-2">
+			{error && <p className="text-sm text-destructive text-center">{error}</p>}
+			<Button onClick={handleLogin} disabled={loading} className="w-full" variant="outline">
+				<GoogleIcon />
+				{loading ? "ログイン中..." : "Googleでログイン"}
+			</Button>
+		</div>
 	);
 }

--- a/src/hooks/use-csrf-token.ts
+++ b/src/hooks/use-csrf-token.ts
@@ -70,11 +70,15 @@ export function useCSRFToken() {
 			if (!currentToken) {
 				currentToken = await fetchToken();
 			}
+			if (!currentToken) {
+				// トークン取得自体が失敗している場合、本リクエストを送ると CSRF ヘッダー
+				// 抜きで 403 を食らうだけで、呼び出し側には原因が「トークン取得失敗」だと
+				// 伝わらない。明示的に throw して上位で扱えるようにする。
+				throw new Error("Failed to obtain CSRF token");
+			}
 
 			const headers = new Headers(options.headers);
-			if (currentToken) {
-				headers.set("X-CSRF-Token", currentToken);
-			}
+			headers.set("X-CSRF-Token", currentToken);
 
 			return fetch(url, {
 				...options,

--- a/src/hooks/use-csrf-token.ts
+++ b/src/hooks/use-csrf-token.ts
@@ -3,7 +3,7 @@
  * トークンの取得・更新・送信を自動化
  */
 
-import { useEffect, useState, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface CSRFTokenResponse {
 	csrfToken: string;
@@ -16,9 +16,16 @@ export function useCSRFToken() {
 	const [error, setError] = useState<string | null>(null);
 
 	/**
-	 * CSRFトークンを取得
+	 * CSRFトークンを取得して state を更新し、取得したトークン値そのものも返す。
+	 *
+	 * 返り値を返しているのは、`fetchWithCSRF` 等の同一クロージャ内で
+	 * `await fetchToken()` 直後に最新トークンを使いたいケースのため。
+	 * React の state 更新はバッチされて非同期に反映されるので、
+	 * `await fetchToken()` 直後の `token` クロージャ変数は依然として古い値
+	 * （初回 fetchWithCSRF 呼び出し時は `null`）を指している。そのまま読むと
+	 * `X-CSRF-Token` 未付与で 403 になるため、戻り値経由で受け渡す。
 	 */
-	const fetchToken = useCallback(async () => {
+	const fetchToken = useCallback(async (): Promise<string | null> => {
 		setIsLoading(true);
 		setError(null);
 
@@ -34,10 +41,12 @@ export function useCSRFToken() {
 
 			const data: CSRFTokenResponse = await response.json();
 			setToken(data.csrfToken);
+			return data.csrfToken;
 		} catch (err) {
 			const errorMessage = err instanceof Error ? err.message : "Failed to fetch CSRF token";
 			setError(errorMessage);
 			console.error("CSRF token fetch error:", err);
+			return null;
 		} finally {
 			setIsLoading(false);
 		}
@@ -55,14 +64,16 @@ export function useCSRFToken() {
 	 */
 	const fetchWithCSRF = useCallback(
 		async (url: string, options: RequestInit = {}) => {
-			// トークンがない場合は取得
-			if (!token) {
-				await fetchToken();
+			// 初回呼び出し時は token state がまだ null なので fetchToken の戻り値を
+			// 使う（state 経由だと同一同期パス内では古い値しか読めない）。
+			let currentToken = token;
+			if (!currentToken) {
+				currentToken = await fetchToken();
 			}
 
 			const headers = new Headers(options.headers);
-			if (token) {
-				headers.set("X-CSRF-Token", token);
+			if (currentToken) {
+				headers.set("X-CSRF-Token", currentToken);
 			}
 
 			return fetch(url, {

--- a/src/lib/security/__tests__/ip-restrictions.test.ts
+++ b/src/lib/security/__tests__/ip-restrictions.test.ts
@@ -158,6 +158,17 @@ describe("verifyBasicAuth", () => {
 		).toBe(false);
 	});
 
+	it("Basic の後に base64 部分が無い場合は false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		// 空 base64: コロンが見つからず indexOf === -1 で弾かれる
+		expect(verifyBasicAuth(buildRequest({ authorization: "Basic " }))).toBe(false);
+		// "Basic" のみ (末尾スペース無し): "Basic " で始まらないので即 false
+		expect(verifyBasicAuth(buildRequest({ authorization: "Basic" }))).toBe(false);
+	});
+
 	it("パスワードにコロンが含まれていても正しく検証できる", async () => {
 		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
 		vi.stubEnv("ADMIN_BASIC_PASSWORD", "pa:ss:wo:rd");

--- a/src/lib/security/__tests__/ip-restrictions.test.ts
+++ b/src/lib/security/__tests__/ip-restrictions.test.ts
@@ -25,12 +25,22 @@ async function freshIsAllowedAdminIP() {
 	return mod.isAllowedAdminIP;
 }
 
+/**
+ * `vi.stubEnv` で更新した環境変数を反映した状態で `verifyBasicAuth` を
+ * 再評価するため、モジュールキャッシュを破棄して再 import する。
+ * 各テストはこのヘルパー経由で取得した関数を使うことで、前のテストの
+ * env が漏れないクリーンなモジュールインスタンスで検証できる。
+ */
 async function freshVerifyBasicAuth() {
 	vi.resetModules();
 	const mod = await import("../ip-restrictions");
 	return mod.verifyBasicAuth;
 }
 
+/**
+ * 指定した資格情報から Basic 認証の `Authorization` ヘッダー値を生成する。
+ * `user:pass` を UTF-8 で base64 エンコードし、"Basic <base64>" 形式で返す。
+ */
 function basicAuthHeader(user: string, pass: string): string {
 	return `Basic ${Buffer.from(`${user}:${pass}`, "utf-8").toString("base64")}`;
 }

--- a/src/lib/security/__tests__/ip-restrictions.test.ts
+++ b/src/lib/security/__tests__/ip-restrictions.test.ts
@@ -25,6 +25,16 @@ async function freshIsAllowedAdminIP() {
 	return mod.isAllowedAdminIP;
 }
 
+async function freshVerifyBasicAuth() {
+	vi.resetModules();
+	const mod = await import("../ip-restrictions");
+	return mod.verifyBasicAuth;
+}
+
+function basicAuthHeader(user: string, pass: string): string {
+	return `Basic ${Buffer.from(`${user}:${pass}`, "utf-8").toString("base64")}`;
+}
+
 describe("isAllowedAdminIP", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();
@@ -65,5 +75,89 @@ describe("isAllowedAdminIP", () => {
 
 		const isAllowedAdminIP = await freshIsAllowedAdminIP();
 		expect(isAllowedAdminIP(buildRequest({}))).toBe(false);
+	});
+});
+
+describe("verifyBasicAuth", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("Authorization ヘッダーが無い場合は false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(verifyBasicAuth(buildRequest({}))).toBe(false);
+	});
+
+	it("Basic 以外のスキームは false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(verifyBasicAuth(buildRequest({ authorization: "Bearer abc" }))).toBe(false);
+	});
+
+	it("デコード後にコロンが無い場合は false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const noColon = `Basic ${Buffer.from("adminonly", "utf-8").toString("base64")}`;
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(verifyBasicAuth(buildRequest({ authorization: noColon }))).toBe(false);
+	});
+
+	it("環境変数が未設定なら false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(
+			verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("admin", "secret") })),
+		).toBe(false);
+	});
+
+	it("正しい資格情報なら true", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(
+			verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("admin", "secret") })),
+		).toBe(true);
+	});
+
+	it("ユーザー名が違うと false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(
+			verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("guest", "secret") })),
+		).toBe(false);
+	});
+
+	it("パスワードが違うと false", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "secret");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(
+			verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("admin", "wrong") })),
+		).toBe(false);
+	});
+
+	it("パスワードにコロンが含まれていても正しく検証できる", async () => {
+		vi.stubEnv("ADMIN_BASIC_USERNAME", "admin");
+		vi.stubEnv("ADMIN_BASIC_PASSWORD", "pa:ss:wo:rd");
+
+		const verifyBasicAuth = await freshVerifyBasicAuth();
+		expect(
+			verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("admin", "pa:ss:wo:rd") })),
+		).toBe(true);
+		expect(verifyBasicAuth(buildRequest({ authorization: basicAuthHeader("admin", "pa") }))).toBe(
+			false,
+		);
 	});
 });

--- a/src/lib/security/__tests__/redirect.test.ts
+++ b/src/lib/security/__tests__/redirect.test.ts
@@ -1,0 +1,47 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { sanitizeRedirectPath } from "../redirect";
+
+describe("sanitizeRedirectPath", () => {
+	it("正常な相対パスはそのまま返す", () => {
+		expect(sanitizeRedirectPath("/")).toBe("/");
+		expect(sanitizeRedirectPath("/koudens")).toBe("/koudens");
+		expect(sanitizeRedirectPath("/koudens/123")).toBe("/koudens/123");
+	});
+
+	it("クエリ・ハッシュも保持する", () => {
+		expect(sanitizeRedirectPath("/koudens/123?tab=members")).toBe("/koudens/123?tab=members");
+		expect(sanitizeRedirectPath("/koudens/123#section")).toBe("/koudens/123#section");
+		expect(sanitizeRedirectPath("/koudens/123?x=y#z")).toBe("/koudens/123?x=y#z");
+	});
+
+	it("null / undefined / 空文字は null", () => {
+		expect(sanitizeRedirectPath(null)).toBeNull();
+		expect(sanitizeRedirectPath(undefined)).toBeNull();
+		expect(sanitizeRedirectPath("")).toBeNull();
+	});
+
+	it("プロトコル相対URLは拒否（オープンリダイレクト対策）", () => {
+		expect(sanitizeRedirectPath("//evil.com")).toBeNull();
+		expect(sanitizeRedirectPath("//evil.com/path")).toBeNull();
+	});
+
+	it("バックスラッシュ始まりは拒否（ブラウザが //evil.com と解釈しうる）", () => {
+		expect(sanitizeRedirectPath("\\evil.com")).toBeNull();
+		expect(sanitizeRedirectPath("\\\\evil.com")).toBeNull();
+	});
+
+	it("スキーム付き絶対URLは拒否", () => {
+		expect(sanitizeRedirectPath("https://evil.com")).toBeNull();
+		expect(sanitizeRedirectPath("http://evil.com/path")).toBeNull();
+		expect(sanitizeRedirectPath("javascript:alert(1)")).toBeNull();
+		expect(sanitizeRedirectPath("mailto:x@example.com")).toBeNull();
+		expect(sanitizeRedirectPath("data:text/html,abc")).toBeNull();
+	});
+
+	it("スラッシュで始まらないパスは拒否", () => {
+		expect(sanitizeRedirectPath("koudens")).toBeNull();
+		expect(sanitizeRedirectPath("./koudens")).toBeNull();
+		expect(sanitizeRedirectPath("../koudens")).toBeNull();
+	});
+});

--- a/src/lib/security/__tests__/timing-safe.test.ts
+++ b/src/lib/security/__tests__/timing-safe.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { timingSafeEqual } from "../timing-safe";
+
+describe("timingSafeEqual", () => {
+	it("等しい文字列は true", () => {
+		expect(timingSafeEqual("abc", "abc")).toBe(true);
+	});
+
+	it("空文字列同士は true", () => {
+		expect(timingSafeEqual("", "")).toBe(true);
+	});
+
+	it("長さが違う文字列は false（部分一致でも false）", () => {
+		expect(timingSafeEqual("abc", "abcd")).toBe(false);
+		expect(timingSafeEqual("abcd", "abc")).toBe(false);
+		expect(timingSafeEqual("", "a")).toBe(false);
+	});
+
+	it("同じ長さで内容が違う場合は false", () => {
+		expect(timingSafeEqual("abc", "abd")).toBe(false);
+		expect(timingSafeEqual("abc", "xbc")).toBe(false);
+	});
+
+	it("先頭・末尾の不一致いずれも false（短絡評価していないことを担保）", () => {
+		expect(timingSafeEqual("Xbcdef", "abcdef")).toBe(false);
+		expect(timingSafeEqual("abcdeX", "abcdef")).toBe(false);
+	});
+
+	it("Unicode を含む文字列でも一致を検出できる", () => {
+		expect(timingSafeEqual("香典帳", "香典帳")).toBe(true);
+		expect(timingSafeEqual("香典帳", "香典簿")).toBe(false);
+	});
+});

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -16,6 +16,7 @@
  *   - CookieはHttpOnlyで発行され、JavaScriptから読めない
  */
 
+import { timingSafeEqual } from "@/lib/security/timing-safe";
 import type { NextRequest } from "next/server";
 
 /**
@@ -103,25 +104,6 @@ export async function generateCSRFToken(): Promise<string> {
 	const signature = await createSha256Hash(`${token}:${timestamp}:${CSRF_SECRET}`);
 
 	return `${token}:${timestamp}:${signature}`;
-}
-
-/**
- * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
- * 短絡評価せず全文字をXORして集約することで、最初の不一致位置を漏らさない。
- *
- * @param a 比較対象A
- * @param b 比較対象B
- * @returns 完全一致なら true
- */
-function timingSafeEqual(a: string, b: string): boolean {
-	if (a.length !== b.length) {
-		return false;
-	}
-	let diff = 0;
-	for (let i = 0; i < a.length; i++) {
-		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-	}
-	return diff === 0;
 }
 
 /**

--- a/src/lib/security/ip-restrictions.ts
+++ b/src/lib/security/ip-restrictions.ts
@@ -5,6 +5,7 @@
 
 import logger from "@/lib/logger";
 import { getClientIP } from "@/lib/security/client-ip";
+import { timingSafeEqual } from "@/lib/security/timing-safe";
 import type { NextRequest } from "next/server";
 
 // 許可されたIPアドレスのリスト（環境変数から取得）
@@ -53,7 +54,18 @@ export function isAllowedAdminIP(request: NextRequest): boolean {
 }
 
 /**
- * ベーシック認証の実装
+ * ベーシック認証の実装。
+ *
+ * タイミング攻撃対策:
+ *   - ユーザー名/パスワードはどちらも {@link timingSafeEqual} で定数時間比較する。
+ *   - 両方の比較を必ず実行した上で AND を取り、どちらが不一致だったかを timing から
+ *     推測できないようにする（先に `userOk` を見て短絡しない）。
+ *   - 仕分けの前段（ヘッダー有無・コロン有無・env 未設定）は資格情報の値ではなく
+ *     リクエストの形・サーバ設定の問題なので、早期 return でよい。
+ *
+ * その他:
+ *   - 資格情報の分割は `split(":")` ではなく `indexOf(":")` で行い、パスワードに
+ *     コロンが含まれていても切り捨てない。
  */
 export function verifyBasicAuth(request: NextRequest): boolean {
 	const authHeader = request.headers.get("authorization");
@@ -64,7 +76,12 @@ export function verifyBasicAuth(request: NextRequest): boolean {
 
 	const credentials = authHeader.slice(6);
 	const decoded = Buffer.from(credentials, "base64").toString("utf-8");
-	const [username, password] = decoded.split(":");
+	const colonIdx = decoded.indexOf(":");
+	if (colonIdx === -1) {
+		return false;
+	}
+	const username = decoded.slice(0, colonIdx);
+	const password = decoded.slice(colonIdx + 1);
 
 	const adminUsername = process.env.ADMIN_BASIC_USERNAME;
 	const adminPassword = process.env.ADMIN_BASIC_PASSWORD;
@@ -74,5 +91,7 @@ export function verifyBasicAuth(request: NextRequest): boolean {
 		return false;
 	}
 
-	return username === adminUsername && password === adminPassword;
+	const userOk = timingSafeEqual(username, adminUsername);
+	const passOk = timingSafeEqual(password, adminPassword);
+	return userOk && passOk;
 }

--- a/src/lib/security/redirect.ts
+++ b/src/lib/security/redirect.ts
@@ -1,0 +1,34 @@
+/**
+ * 認証フロー等で「次にリダイレクトする先」をユーザー入力から受け取るときの
+ * オープンリダイレクト対策ヘルパー。
+ *
+ * 受理する値:
+ *   - "/" で始まる相対パス（"/koudens/123" など）
+ * 拒否する値:
+ *   - スキーム付き絶対URL（"https://evil.com" など）
+ *   - プロトコル相対URL（"//evil.com"）
+ *   - バックスラッシュで始まるパス（"\\evil.com" — ブラウザで "//evil.com" と解釈されうる）
+ *   - 空文字 / 不正な文字列 / null / undefined
+ *
+ * 戻り値: そのまま `Response.redirect(new URL(value, origin))` に渡せる安全な相対パス、または `null`。
+ *
+ * 検証ロジックは Cookie を書き込む側（API ルート）と読み出して redirect する側
+ * （/auth/callback）の両方で完全に一致している必要がある。書き込み側が緩いと
+ * 攻撃者がローカル Cookie を仕込んで読み出し側の信頼を悪用できるため、本関数を
+ * 単一のソースとして使うこと。
+ */
+export function sanitizeRedirectPath(value: string | null | undefined): string | null {
+	if (!value) return null;
+	if (value.startsWith("//") || value.startsWith("\\")) return null;
+	if (!value.startsWith("/")) return null;
+	try {
+		// base URL を使えば相対パスでも URL としてパースできる。
+		// origin が変わった (= 絶対URLが指定されていた) ら拒否する。
+		const base = "https://internal.invalid";
+		const parsed = new URL(value, base);
+		if (parsed.origin !== base) return null;
+		return parsed.pathname + parsed.search + parsed.hash;
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/security/timing-safe.ts
+++ b/src/lib/security/timing-safe.ts
@@ -1,0 +1,24 @@
+/**
+ * 2つの文字列を定数時間で比較する（タイミング攻撃対策）。
+ * 短絡評価せず全文字をXORして集約することで、最初の不一致位置を漏らさない。
+ *
+ * 注意:
+ *   入力長が一致しない場合は早期に false を返す。これは入力長が一致する正規系での
+ *   タイミング差を消すことを目的とした実装であり、Node.js の `crypto.timingSafeEqual`
+ *   と同じ前提に立つ。長さそのものは比較対象から漏れうるため、機密値とのペアでは
+ *   呼び出し側であらかじめハッシュ化して長さを揃えることが望ましい。
+ *
+ * @param a 比較対象A
+ * @param b 比較対象B
+ * @returns 完全一致なら true
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) {
+		diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return diff === 0;
+}


### PR DESCRIPTION
## Summary
This PR enhances authentication security by implementing server-side HttpOnly cookie management for sensitive auth data and adding timing-safe string comparison to prevent timing attacks on credential verification.

## Key Changes

### Security Infrastructure
- **New `timingSafeEqual()` utility** (`src/lib/security/timing-safe.ts`): Constant-time string comparison to prevent timing attacks on password/username verification
- **New `sanitizeRedirectPath()` utility** (`src/lib/security/redirect.ts`): Centralized open redirect protection for post-auth redirects, extracted from callback route for reuse
- **Refactored CSRF protection** to use the new `timingSafeEqual()` function

### Authentication Cookie Management
- **New API endpoint** `/api/auth/cookies/invitation-token`: Server-side endpoint to set `invitation_token` cookie with `HttpOnly; Secure; SameSite=Lax` flags
- **New API endpoint** `/api/auth/cookies/post-auth-redirect`: Server-side endpoint to set `post_auth_redirect` cookie with `HttpOnly; Secure; SameSite=Lax` flags
- Both endpoints validate input and reject malicious values before setting cookies

### Client-Side Updates
- **AuthForm component**: Replaced `document.cookie` writes with `fetchWithCSRF()` calls to the new API endpoints, ensuring cookies are set server-side with HttpOnly protection
- **LoginButton component**: Updated to use server-side cookie endpoint instead of direct `document.cookie` manipulation

### Basic Auth Hardening
- **Improved credential parsing** in `verifyBasicAuth()`: Changed from `split(":")` to `indexOf()` to correctly handle passwords containing colons
- **Timing-safe comparison**: Both username and password now use `timingSafeEqual()` for constant-time comparison, with both comparisons always executed to prevent timing-based attacks

### Testing
- Added comprehensive test suite for `verifyBasicAuth()` covering edge cases (missing headers, invalid schemes, malformed credentials, colon-containing passwords)
- Added test suite for `sanitizeRedirectPath()` covering open redirect attack vectors
- Added test suite for `timingSafeEqual()` covering length mismatches and Unicode strings

## Notable Implementation Details
- `SameSite=Lax` is used (not `Strict`) because OAuth redirects from external providers are cross-site top-level GETs that would fail with `Strict`
- `Secure` flag is only added in production (`NODE_ENV === "production"`)
- Redirect path validation is performed identically on both write (API) and read (callback) sides to prevent attackers from injecting malicious cookies locally
- CSRF protection is enforced on the new cookie-setting endpoints via middleware

https://claude.ai/code/session_015ebkxKA3NhGzLEpjrv71Fz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 認証前にサーバー側で HttpOnly/SameSite の認証用 Cookie を設定・削除する公開 API を追加し、OAuth/OTP 開始前に確実に適用します。
  * 認証失敗時の Cookie ロールバック（削除）を自動化。

* **セキュリティ**
  * リダイレクト先検証を集中化して安全性を強化。
  * 比較処理をタイミング攻撃耐性のある方式に変更。
  * CSRF トークン取得・送信の堅牢化。

* **テスト**
  * セキュリティ関連のユニットテストを追加・拡充。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->