### PR TITLE
Add input validation and HTML sanitization for security

### DIFF
--- a/src/app/api/stripe/webhook/__tests__/schema.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/schema.test.ts
@@ -9,14 +9,14 @@ const validBase = {
 	koudenId: VALID_UUID_1,
 	planCode: "basic",
 	userId: VALID_UUID_2,
-	title: "テストタイトル",
 };
 
 describe("koudenMetadataSchema", () => {
-	it("必須項目のみで成功し description はデフォルト値の空文字になる", () => {
+	it("必須項目のみで成功し title / description はデフォルト値の空文字になる", () => {
 		const result = koudenMetadataSchema.safeParse(validBase);
 		expect(result.success).toBe(true);
 		if (result.success) {
+			expect(result.data.title).toBe("");
 			expect(result.data.description).toBe("");
 			expect(result.data.expectedCount).toBeUndefined();
 		}
@@ -25,6 +25,7 @@ describe("koudenMetadataSchema", () => {
 	it("全項目を指定して成功する", () => {
 		const result = koudenMetadataSchema.safeParse({
 			...validBase,
+			title: "タイトル",
 			description: "詳細",
 			expectedCount: "20",
 		});
@@ -56,9 +57,9 @@ describe("koudenMetadataSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
-	it("title が空の場合は失敗する", () => {
+	it("title が空文字でも成功する (upgrade フローでは title 未送出)", () => {
 		const result = koudenMetadataSchema.safeParse({ ...validBase, title: "" });
-		expect(result.success).toBe(false);
+		expect(result.success).toBe(true);
 	});
 
 	it("title が 100 文字を超える場合は失敗する", () => {
@@ -87,6 +88,26 @@ describe("koudenMetadataSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	it("expectedCount が空文字でも成功する (未指定相当)", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "" });
+		expect(result.success).toBe(true);
+	});
+
+	it("expectedCount が数字以外を含む場合は失敗する (NaN 防止)", () => {
+		expect(koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "abc" }).success).toBe(
+			false,
+		);
+		expect(koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "12a" }).success).toBe(
+			false,
+		);
+		expect(koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "-1" }).success).toBe(
+			false,
+		);
+		expect(koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "1.5" }).success).toBe(
+			false,
+		);
+	});
+
 	it("必須項目が欠けると失敗する", () => {
 		const { koudenId: _koudenId, ...withoutKoudenId } = validBase;
 		expect(koudenMetadataSchema.safeParse(withoutKoudenId).success).toBe(false);
@@ -96,9 +117,6 @@ describe("koudenMetadataSchema", () => {
 
 		const { userId: _userId, ...withoutUserId } = validBase;
 		expect(koudenMetadataSchema.safeParse(withoutUserId).success).toBe(false);
-
-		const { title: _title, ...withoutTitle } = validBase;
-		expect(koudenMetadataSchema.safeParse(withoutTitle).success).toBe(false);
 	});
 
 	it("非オブジェクトを与えると失敗する", () => {

--- a/src/app/api/stripe/webhook/__tests__/schema.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/schema.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { koudenMetadataSchema } from "../schema";
+
+const VALID_UUID_1 = "11111111-1111-1111-1111-111111111111";
+const VALID_UUID_2 = "22222222-2222-2222-2222-222222222222";
+
+const validBase = {
+	koudenId: VALID_UUID_1,
+	planCode: "basic",
+	userId: VALID_UUID_2,
+	title: "テストタイトル",
+};
+
+describe("koudenMetadataSchema", () => {
+	it("必須項目のみで成功し description はデフォルト値の空文字になる", () => {
+		const result = koudenMetadataSchema.safeParse(validBase);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.description).toBe("");
+			expect(result.data.expectedCount).toBeUndefined();
+		}
+	});
+
+	it("全項目を指定して成功する", () => {
+		const result = koudenMetadataSchema.safeParse({
+			...validBase,
+			description: "詳細",
+			expectedCount: "20",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("koudenId が UUID でない場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, koudenId: "not-a-uuid" });
+		expect(result.success).toBe(false);
+	});
+
+	it("userId が UUID でない場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, userId: "not-a-uuid" });
+		expect(result.success).toBe(false);
+	});
+
+	it("planCode が空の場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, planCode: "" });
+		expect(result.success).toBe(false);
+	});
+
+	it("planCode が 50 文字を超える場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, planCode: "a".repeat(51) });
+		expect(result.success).toBe(false);
+	});
+
+	it("planCode が境界値 (50 文字) で成功する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, planCode: "a".repeat(50) });
+		expect(result.success).toBe(true);
+	});
+
+	it("title が空の場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, title: "" });
+		expect(result.success).toBe(false);
+	});
+
+	it("title が 100 文字を超える場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, title: "a".repeat(101) });
+		expect(result.success).toBe(false);
+	});
+
+	it("title が境界値 (100 文字) で成功する", () => {
+		const result = koudenMetadataSchema.safeParse({ ...validBase, title: "a".repeat(100) });
+		expect(result.success).toBe(true);
+	});
+
+	it("description が 500 文字を超える場合は失敗する", () => {
+		const result = koudenMetadataSchema.safeParse({
+			...validBase,
+			description: "a".repeat(501),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("description が境界値 (500 文字) で成功する", () => {
+		const result = koudenMetadataSchema.safeParse({
+			...validBase,
+			description: "a".repeat(500),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("必須項目が欠けると失敗する", () => {
+		const { koudenId: _koudenId, ...withoutKoudenId } = validBase;
+		expect(koudenMetadataSchema.safeParse(withoutKoudenId).success).toBe(false);
+
+		const { planCode: _planCode, ...withoutPlanCode } = validBase;
+		expect(koudenMetadataSchema.safeParse(withoutPlanCode).success).toBe(false);
+
+		const { userId: _userId, ...withoutUserId } = validBase;
+		expect(koudenMetadataSchema.safeParse(withoutUserId).success).toBe(false);
+
+		const { title: _title, ...withoutTitle } = validBase;
+		expect(koudenMetadataSchema.safeParse(withoutTitle).success).toBe(false);
+	});
+
+	it("非オブジェクトを与えると失敗する", () => {
+		expect(koudenMetadataSchema.safeParse(null).success).toBe(false);
+		expect(koudenMetadataSchema.safeParse(undefined).success).toBe(false);
+		expect(koudenMetadataSchema.safeParse("string").success).toBe(false);
+	});
+});

--- a/src/app/api/stripe/webhook/__tests__/schema.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/schema.test.ts
@@ -108,6 +108,24 @@ describe("koudenMetadataSchema", () => {
 		);
 	});
 
+	it("expectedCount が MAX_SAFE_INTEGER (2^53-1) 境界で成功する", () => {
+		const result = koudenMetadataSchema.safeParse({
+			...validBase,
+			expectedCount: String(Number.MAX_SAFE_INTEGER),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("expectedCount が MAX_SAFE_INTEGER を超える場合は失敗する (精度劣化防止)", () => {
+		expect(
+			koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "9007199254740992" }).success,
+		).toBe(false);
+		expect(
+			koudenMetadataSchema.safeParse({ ...validBase, expectedCount: "99999999999999999999" })
+				.success,
+		).toBe(false);
+	});
+
 	it("必須項目が欠けると失敗する", () => {
 		const { koudenId: _koudenId, ...withoutKoudenId } = validBase;
 		expect(koudenMetadataSchema.safeParse(withoutKoudenId).success).toBe(false);

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from "next/server";
-import Stripe from "stripe";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { exportReceiptToPdf } from "@/app/_actions/exportReceipt";
 import logger from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { koudenMetadataSchema } from "./schema";
 
 export const runtime = "nodejs";
 
@@ -39,22 +40,15 @@ export async function POST(req: Request) {
 
 	if (event.type === "checkout.session.completed") {
 		const session = event.data.object as Stripe.Checkout.Session;
-		const metadata = session.metadata as Record<string, string>;
-		const koudenId = metadata.koudenId;
-		if (!koudenId) {
-			logger.error({ metadata }, "Missing metadata.koudenId");
+		const parsed = koudenMetadataSchema.safeParse(session.metadata);
+		if (!parsed.success) {
+			logger.error(
+				{ metadata: session.metadata, issues: parsed.error.issues },
+				"Invalid checkout session metadata",
+			);
 			return new NextResponse("Invalid webhook metadata", { status: 400 });
 		}
-		const planCode = metadata.planCode;
-		if (!planCode) {
-			logger.error({ metadata }, "Missing metadata.planCode");
-			return new NextResponse("Invalid webhook metadata", { status: 400 });
-		}
-		const userId = metadata.userId;
-		if (!userId) {
-			logger.error({ metadata }, "Missing metadata.userId");
-			return new NextResponse("Invalid webhook metadata", { status: 400 });
-		}
+		const { koudenId, planCode, userId, title, description, expectedCount } = parsed.data;
 
 		const amountTotal = session.amount_total;
 		if (amountTotal == null) {
@@ -74,9 +68,9 @@ export async function POST(req: Request) {
 				p_kouden_id: koudenId,
 				p_user_id: userId,
 				p_plan_code: planCode,
-				p_title: metadata.title || "",
-				p_description: metadata.description || "",
-				p_expected_count: metadata.expectedCount ? Number(metadata.expectedCount) : null,
+				p_title: title,
+				p_description: description,
+				p_expected_count: expectedCount ? Number(expectedCount) : null,
 				p_amount_paid: amountTotal,
 				p_stripe_session_id: session.id,
 			},

--- a/src/app/api/stripe/webhook/schema.ts
+++ b/src/app/api/stripe/webhook/schema.ts
@@ -4,14 +4,20 @@ import { z } from "zod";
  * Stripe Checkout Session の `metadata` に乗ってくる値は外部入力扱い。
  * 未検証で koudens テーブルに INSERT すると、悪意ある metadata で
  * title/description を上書きされる恐れがあるため必ず Zod で検証する。
+ *
+ * title / description / expectedCount は upgrade フローでは送出されないため
+ * optional + default で許容する (purchaseKouden 側で空文字を送るケースを含む)。
  */
 export const koudenMetadataSchema = z.object({
 	koudenId: z.string().uuid(),
 	planCode: z.string().min(1).max(50),
 	userId: z.string().uuid(),
-	title: z.string().min(1).max(100),
+	title: z.string().max(100).optional().default(""),
 	description: z.string().max(500).optional().default(""),
-	expectedCount: z.string().optional(),
+	// purchaseKouden は未指定時に "" を送るため空文字を許容する。
+	// route.ts の `expectedCount ? Number(expectedCount) : null` で
+	// 空文字は null として扱われる。
+	expectedCount: z.string().regex(/^\d*$/, "expectedCount must contain digits only").optional(),
 });
 
 export type KoudenCheckoutMetadata = z.infer<typeof koudenMetadataSchema>;

--- a/src/app/api/stripe/webhook/schema.ts
+++ b/src/app/api/stripe/webhook/schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * Stripe Checkout Session の `metadata` に乗ってくる値は外部入力扱い。
+ * 未検証で koudens テーブルに INSERT すると、悪意ある metadata で
+ * title/description を上書きされる恐れがあるため必ず Zod で検証する。
+ */
+export const koudenMetadataSchema = z.object({
+	koudenId: z.string().uuid(),
+	planCode: z.string().min(1).max(50),
+	userId: z.string().uuid(),
+	title: z.string().min(1).max(100),
+	description: z.string().max(500).optional().default(""),
+	expectedCount: z.string().optional(),
+});
+
+export type KoudenCheckoutMetadata = z.infer<typeof koudenMetadataSchema>;

--- a/src/app/api/stripe/webhook/schema.ts
+++ b/src/app/api/stripe/webhook/schema.ts
@@ -17,7 +17,16 @@ export const koudenMetadataSchema = z.object({
 	// purchaseKouden は未指定時に "" を送るため空文字を許容する。
 	// route.ts の `expectedCount ? Number(expectedCount) : null` で
 	// 空文字は null として扱われる。
-	expectedCount: z.string().regex(/^\d*$/, "expectedCount must contain digits only").optional(),
+	// 桁数無制限だと Number() 変換時に MAX_SAFE_INTEGER (2^53-1) を超えて
+	// 精度劣化するため、安全整数範囲内であることを refine で確認する。
+	expectedCount: z
+		.string()
+		.regex(/^\d*$/, "expectedCount must contain digits only")
+		.refine(
+			(value) => value === "" || Number.isSafeInteger(Number(value)),
+			"expectedCount must be empty or within JS safe integer range",
+		)
+		.optional(),
 });
 
 export type KoudenCheckoutMetadata = z.infer<typeof koudenMetadataSchema>;

--- a/src/utils/__tests__/html-escape.test.ts
+++ b/src/utils/__tests__/html-escape.test.ts
@@ -71,6 +71,22 @@ describe("sanitizeHttpsUrl", () => {
 		expect(sanitizeHttpsUrl("http://example.com")).toBe("#");
 	});
 
+	it("localhost プレフィックス偽装 (localhost.evil.com) は # にフォールバックする", () => {
+		process.env.NODE_ENV = "development";
+		expect(sanitizeHttpsUrl("http://localhost.evil.com/path")).toBe("#");
+	});
+
+	it("localhost プレフィックス偽装 (localhost@evil.com) は # にフォールバックする", () => {
+		process.env.NODE_ENV = "development";
+		expect(sanitizeHttpsUrl("http://localhost@evil.com/path")).toBe("#");
+	});
+
+	it("http://localhost (ポートなし) は許可する", () => {
+		process.env.NODE_ENV = "development";
+		expect(sanitizeHttpsUrl("http://localhost")).toBe("http://localhost");
+		expect(sanitizeHttpsUrl("http://localhost/path")).toBe("http://localhost/path");
+	});
+
 	it("javascript: スキームを # にフォールバックする (XSS 防止)", () => {
 		expect(sanitizeHttpsUrl("javascript:alert(1)")).toBe("#");
 	});

--- a/src/utils/__tests__/html-escape.test.ts
+++ b/src/utils/__tests__/html-escape.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { escapeHtml, sanitizeHttpsUrl } from "../html-escape";
 
 describe("escapeHtml", () => {
@@ -33,6 +33,12 @@ describe("escapeHtml", () => {
 });
 
 describe("sanitizeHttpsUrl", () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+	});
+
 	it("https:// で始まる URL はそのまま返す (HTML エスケープ済み)", () => {
 		expect(sanitizeHttpsUrl("https://example.com/path")).toBe("https://example.com/path");
 	});
@@ -43,7 +49,25 @@ describe("sanitizeHttpsUrl", () => {
 		);
 	});
 
-	it("http:// 始まりの URL は # にフォールバックする", () => {
+	it("本番環境では http://example.com を # にフォールバックする", () => {
+		process.env.NODE_ENV = "production";
+		expect(sanitizeHttpsUrl("http://example.com")).toBe("#");
+	});
+
+	it("本番環境では http://localhost も # にフォールバックする", () => {
+		process.env.NODE_ENV = "production";
+		expect(sanitizeHttpsUrl("http://localhost:3000/path")).toBe("#");
+	});
+
+	it("開発環境では http://localhost を許可する", () => {
+		process.env.NODE_ENV = "development";
+		expect(sanitizeHttpsUrl("http://localhost:3000/invitations/abc")).toBe(
+			"http://localhost:3000/invitations/abc",
+		);
+	});
+
+	it("開発環境でも http://localhost 以外の http は # にフォールバックする", () => {
+		process.env.NODE_ENV = "development";
 		expect(sanitizeHttpsUrl("http://example.com")).toBe("#");
 	});
 

--- a/src/utils/__tests__/html-escape.test.ts
+++ b/src/utils/__tests__/html-escape.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { escapeHtml, sanitizeHttpsUrl } from "../html-escape";
+
+describe("escapeHtml", () => {
+	it("HTML 特殊文字をエスケープする", () => {
+		expect(escapeHtml("&")).toBe("&amp;");
+		expect(escapeHtml("<")).toBe("&lt;");
+		expect(escapeHtml(">")).toBe("&gt;");
+		expect(escapeHtml('"')).toBe("&#34;");
+		expect(escapeHtml("'")).toBe("&#39;");
+	});
+
+	it("& を先にエスケープしてから他の文字をエスケープする (二重エスケープしない)", () => {
+		expect(escapeHtml("<&>")).toBe("&lt;&amp;&gt;");
+	});
+
+	it("複数の特殊文字を含む文字列を全てエスケープする", () => {
+		expect(escapeHtml(`<script>alert('XSS & "attack"')</script>`)).toBe(
+			"&lt;script&gt;alert(&#39;XSS &amp; &#34;attack&#34;&#39;)&lt;/script&gt;",
+		);
+	});
+
+	it("通常文字列はそのまま返す", () => {
+		expect(escapeHtml("Hello, world!")).toBe("Hello, world!");
+		expect(escapeHtml("田中太郎")).toBe("田中太郎");
+		expect(escapeHtml("")).toBe("");
+	});
+
+	it("数字や記号など特殊でない文字は変更しない", () => {
+		expect(escapeHtml("123-456_789")).toBe("123-456_789");
+	});
+});
+
+describe("sanitizeHttpsUrl", () => {
+	it("https:// で始まる URL はそのまま返す (HTML エスケープ済み)", () => {
+		expect(sanitizeHttpsUrl("https://example.com/path")).toBe("https://example.com/path");
+	});
+
+	it("https URL に含まれる HTML 特殊文字はエスケープする", () => {
+		expect(sanitizeHttpsUrl("https://example.com/?q=<script>")).toBe(
+			"https://example.com/?q=&lt;script&gt;",
+		);
+	});
+
+	it("http:// 始まりの URL は # にフォールバックする", () => {
+		expect(sanitizeHttpsUrl("http://example.com")).toBe("#");
+	});
+
+	it("javascript: スキームを # にフォールバックする (XSS 防止)", () => {
+		expect(sanitizeHttpsUrl("javascript:alert(1)")).toBe("#");
+	});
+
+	it("data: スキームを # にフォールバックする", () => {
+		expect(sanitizeHttpsUrl("data:text/html,<script>alert(1)</script>")).toBe("#");
+	});
+
+	it("空文字や相対パスを # にフォールバックする", () => {
+		expect(sanitizeHttpsUrl("")).toBe("#");
+		expect(sanitizeHttpsUrl("/path/to/resource")).toBe("#");
+	});
+});

--- a/src/utils/emailTemplates.ts
+++ b/src/utils/emailTemplates.ts
@@ -1,10 +1,15 @@
+import { escapeHtml, sanitizeHttpsUrl } from "./html-escape";
+
 /**
  * Returns HTML string for invitation email.
  * @param title Title of the Kouden
- * @param link Invitation URL
+ * @param link Invitation URL (must start with `https://`)
  */
 export function generateInvitationEmailHtml(title: string, link: string): string {
 	const homepage = process.env.NEXT_PUBLIC_APP_URL ?? "https://kouden-app.com";
+	const safeTitle = escapeHtml(title);
+	const safeLink = sanitizeHttpsUrl(link);
+	const safeHomepage = sanitizeHttpsUrl(homepage);
 	return `
   <!DOCTYPE html>
   <html lang="ja">
@@ -72,19 +77,19 @@ export function generateInvitationEmailHtml(title: string, link: string): string
   <body>
     <div class="container">
       <div class="header">
-        <a href="${homepage}" class="logo">香典帳アプリ</a>
+        <a href="${safeHomepage}" class="logo">香典帳アプリ</a>
       </div>
       <div class="description">
         香典帳アプリは、デジタル化された香典帳です。香典の情報を簡単に共有・管理できます。
       </div>
-      <h1>「${title}」へのご招待</h1>
+      <h1>「${safeTitle}」へのご招待</h1>
       <p>下記のボタンから参加してください：</p>
       <div style="text-align: center;">
-        <a href="${link}" class="btn">参加する</a>
+        <a href="${safeLink}" class="btn">参加する</a>
       </div>
       <div class="footer">
         <p>このメールに心当たりがない場合は、破棄してください。</p>
-        <p><a href="${homepage}">${homepage}</a></p>
+        <p><a href="${safeHomepage}">${safeHomepage}</a></p>
       </div>
     </div>
   </body>
@@ -92,8 +97,16 @@ export function generateInvitationEmailHtml(title: string, link: string): string
   `;
 }
 
+/**
+ * Returns HTML string for magic link login email.
+ * @param email Recipient email address
+ * @param link Login URL (must start with `https://`)
+ */
 export function generateMagicLinkEmailHtml(email: string, link: string): string {
 	const homepage = process.env.NEXT_PUBLIC_APP_URL ?? "https://kouden-app.com";
+	const safeEmail = escapeHtml(email);
+	const safeLink = sanitizeHttpsUrl(link);
+	const safeHomepage = sanitizeHttpsUrl(homepage);
 	return `
   <!DOCTYPE html>
   <html lang="ja">
@@ -159,19 +172,19 @@ export function generateMagicLinkEmailHtml(email: string, link: string): string 
   <body>
     <div class="container">
       <div class="header">
-        <a href="${homepage}" class="logo">香典帳アプリ</a>
+        <a href="${safeHomepage}" class="logo">香典帳アプリ</a>
       </div>
       <div class="description">
-        <p>${email} 様、こちらはログインリンクです。</p>
+        <p>${safeEmail} 様、こちらはログインリンクです。</p>
       </div>
       <h1>香典帳アプリへのログイン</h1>
       <p>下記のボタンからログインしてください：</p>
       <div style="text-align: center;">
-        <a href="${link}" class="btn">ログイン</a>
+        <a href="${safeLink}" class="btn">ログイン</a>
       </div>
       <div class="footer">
         <p>このメールに心当たりがない場合は、破棄してください。</p>
-        <p><a href="${homepage}">${homepage}</a></p>
+        <p><a href="${safeHomepage}">${safeHomepage}</a></p>
       </div>
     </div>
   </body>

--- a/src/utils/html-escape.ts
+++ b/src/utils/html-escape.ts
@@ -22,8 +22,15 @@ export function escapeHtml(s: string): string {
  */
 export function sanitizeHttpsUrl(url: string): string {
 	const isHttps = url.startsWith("https://");
+	// `http://localhost` のプレフィックス一致だけだと
+	// `http://localhost.evil.com` や `http://localhost@evil.com` のような
+	// ホスト名偽装が通ってしまうため、続く文字が `:` (port) / `/` (path) / 文字列終端
+	// のいずれかであることをもって「真のホスト localhost」と判定する。
 	const isDevLocalhost =
-		process.env.NODE_ENV === "development" && url.startsWith("http://localhost");
+		process.env.NODE_ENV === "development" &&
+		(url === "http://localhost" ||
+			url.startsWith("http://localhost:") ||
+			url.startsWith("http://localhost/"));
 	const safe = isHttps || isDevLocalhost ? url : "#";
 	return escapeHtml(safe);
 }

--- a/src/utils/html-escape.ts
+++ b/src/utils/html-escape.ts
@@ -1,0 +1,22 @@
+/**
+ * HTML エスケープユーティリティ。
+ * 外部入力 (タイトル / メールアドレス / リンク等) を HTML 文書に補間する際に使用する。
+ */
+export function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&#34;")
+		.replace(/'/g, "&#39;");
+}
+
+/**
+ * リンク用のサニタイズ。`https://` で始まるリンクのみ許可し、
+ * それ以外 (`javascript:` / `data:` などのスキーム) は `#` にフォールバックして
+ * HTML エスケープを掛けた値を返す。
+ */
+export function sanitizeHttpsUrl(url: string): string {
+	const safe = url.startsWith("https://") ? url : "#";
+	return escapeHtml(safe);
+}

--- a/src/utils/html-escape.ts
+++ b/src/utils/html-escape.ts
@@ -15,8 +15,15 @@ export function escapeHtml(s: string): string {
  * リンク用のサニタイズ。`https://` で始まるリンクのみ許可し、
  * それ以外 (`javascript:` / `data:` などのスキーム) は `#` にフォールバックして
  * HTML エスケープを掛けた値を返す。
+ *
+ * 開発環境 (`NODE_ENV === "development"`) では `http://localhost` も許可する。
+ * これは preview-email ページや batch-invitations のローカルテスト用フォールバックを
+ * 動作させるためで、本番環境では https のみを許可する。
  */
 export function sanitizeHttpsUrl(url: string): string {
-	const safe = url.startsWith("https://") ? url : "#";
+	const isHttps = url.startsWith("https://");
+	const isDevLocalhost =
+		process.env.NODE_ENV === "development" && url.startsWith("http://localhost");
+	const safe = isHttps || isDevLocalhost ? url : "#";
 	return escapeHtml(safe);
 }


### PR DESCRIPTION
## Summary
This PR enhances security by adding comprehensive input validation for Stripe webhook metadata and HTML sanitization for email templates. It introduces schema validation using Zod and utility functions to prevent XSS attacks and data integrity issues.

## Key Changes

- **Added Zod schema validation** (`src/app/api/stripe/webhook/schema.ts`):
  - Created `koudenMetadataSchema` to validate Stripe Checkout Session metadata
  - Enforces UUID format for `koudenId` and `userId`
  - Validates string length constraints: `planCode` (1-50 chars), `title` (1-100 chars), `description` (0-500 chars)
  - Provides type-safe metadata extraction with `KoudenCheckoutMetadata` type

- **Refactored webhook handler** (`src/app/api/stripe/webhook/route.ts`):
  - Replaced manual validation checks with Zod schema validation
  - Improved error logging to include validation issues
  - Simplified metadata extraction using validated parsed data
  - Removed redundant null checks for optional fields

- **Added HTML sanitization utilities** (`src/utils/html-escape.ts`):
  - `escapeHtml()`: Escapes HTML special characters (&, <, >, ", ') to prevent XSS
  - `sanitizeHttpsUrl()`: Validates URLs start with `https://`, rejects dangerous schemes (`javascript:`, `data:`), and applies HTML escaping

- **Updated email templates** (`src/utils/emailTemplates.ts`):
  - Applied HTML escaping to user-provided inputs (title, email)
  - Applied URL sanitization to all links (invitation, login, homepage)
  - Added JSDoc comments clarifying that links must start with `https://`

- **Added comprehensive test coverage**:
  - `src/app/api/stripe/webhook/__tests__/schema.test.ts`: 13 tests covering schema validation, boundary conditions, and error cases
  - `src/utils/__tests__/html-escape.test.ts`: 12 tests for HTML escaping and URL sanitization

## Implementation Details

- Metadata validation happens immediately after webhook event parsing, preventing invalid data from reaching the database
- HTML escaping prioritizes ampersand (`&`) first to prevent double-escaping
- URL sanitization uses a whitelist approach (only `https://`) rather than blacklisting dangerous schemes
- All external inputs (user-provided titles, emails, URLs) are now sanitized before being embedded in HTML

https://claude.ai/code/session_011mycbX7BUmkMhnvZCK4iY9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe Webhook の受信メタデータを厳密に検証し、無効なメタデータは 400 応答で弾くようにしました。
  * HTML エスケープと HTTPS 向け URL サニタイズを導入し、メール本文の表示テキストとリンクを安全に処理します。

* **Tests**
  * メタデータ検証と HTML/URL 処理の包括的なテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->