### PR TITLE
Add Content-Security-Policy reporting and security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,13 @@ import withPWA from "next-pwa";
 const supabaseOrigin =
 	process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://tcqnsslsaizqwjuyvoyu.supabase.co";
 
-const isProduction = process.env.NODE_ENV === "production";
+// Vercel preview deploy も `NODE_ENV=production` でビルドされるため、
+// HSTS のような「長期にブラウザへ焼き込まれる」ヘッダーは
+// 本番デプロイ (`VERCEL_ENV=production`) でのみ送りたい。
+// Vercel 以外 (ローカル / Cloudflare 等) では NODE_ENV にフォールバックする。
+const isProductionDeploy = process.env.VERCEL_ENV
+	? process.env.VERCEL_ENV === "production"
+	: process.env.NODE_ENV === "production";
 
 // Reporting API のグループ名。CSP の `report-to` ディレクティブと
 // レスポンスヘッダー `Reporting-Endpoints` の双方で参照する。
@@ -68,9 +74,9 @@ const securityHeaders: { key: string; value: string }[] = [
 	{ key: "Content-Security-Policy-Report-Only", value: contentSecurityPolicy },
 ];
 
-// HSTS は HTTPS が保証される本番ビルドでのみ送信する。
-// Vercel preview など他環境で誤って長期 HSTS を焼き付けないため。
-if (isProduction) {
+// HSTS は HTTPS が保証される本番デプロイでのみ送信する。
+// preview / staging のドメインにブラウザを長期間ピン留めしないように。
+if (isProductionDeploy) {
 	securityHeaders.splice(securityHeaders.length - 1, 0, {
 		key: "Strict-Transport-Security",
 		value: "max-age=63072000; includeSubDomains; preload",

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,12 @@ import withPWA from "next-pwa";
 const supabaseOrigin =
 	process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://tcqnsslsaizqwjuyvoyu.supabase.co";
 
+const isProduction = process.env.NODE_ENV === "production";
+
+// Reporting API のグループ名。CSP の `report-to` ディレクティブと
+// レスポンスヘッダー `Reporting-Endpoints` の双方で参照する。
+const REPORTING_GROUP = "csp-endpoint";
+
 // Content-Security-Policy のディレクティブ定義。
 // まずは Report-Only で配信し、`/api/csp-report` でレポートを収集する。
 const cspDirectives: Record<string, string[]> = {
@@ -23,17 +29,53 @@ const cspDirectives: Record<string, string[]> = {
 	],
 	"font-src": ["'self'", "data:"],
 	"connect-src": ["'self'", supabaseOrigin, "https://api.stripe.com"],
-	"frame-src": ["https://js.stripe.com", "https://hooks.stripe.com"],
+	// js.stripe.com / hooks.stripe.com は Stripe 決済、
+	// www.youtube.com / youtube-nocookie.com は機能紹介ページの動画埋め込み。
+	"frame-src": [
+		"https://js.stripe.com",
+		"https://hooks.stripe.com",
+		"https://www.youtube.com",
+		"https://www.youtube-nocookie.com",
+	],
 	"frame-ancestors": ["'none'"],
 	"form-action": ["'self'"],
 	"base-uri": ["'self'"],
 	"object-src": ["'none'"],
+	// レガシー: `application/csp-report` 形式のレポート送信先
 	"report-uri": ["/api/csp-report"],
+	// 新方式: 下記 `Reporting-Endpoints` ヘッダーで定義したグループへ送る
+	"report-to": [REPORTING_GROUP],
 };
 
 const contentSecurityPolicy = Object.entries(cspDirectives)
 	.map(([directive, values]) => `${directive} ${values.join(" ")}`)
 	.join("; ");
+
+const securityHeaders: { key: string; value: string }[] = [
+	{ key: "X-DNS-Prefetch-Control", value: "on" },
+	{ key: "X-XSS-Protection", value: "1; mode=block" },
+	// CSP `frame-ancestors 'none'` と整合させて DENY に統一。
+	// 同一オリジンでの iframe 利用想定はないため SAMEORIGIN から変更。
+	{ key: "X-Frame-Options", value: "DENY" },
+	{ key: "X-Content-Type-Options", value: "nosniff" },
+	{ key: "X-Permitted-Cross-Domain-Policies", value: "none" },
+	{ key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+	{ key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+	{
+		key: "Reporting-Endpoints",
+		value: `${REPORTING_GROUP}="/api/csp-report"`,
+	},
+	{ key: "Content-Security-Policy-Report-Only", value: contentSecurityPolicy },
+];
+
+// HSTS は HTTPS が保証される本番ビルドでのみ送信する。
+// Vercel preview など他環境で誤って長期 HSTS を焼き付けないため。
+if (isProduction) {
+	securityHeaders.splice(securityHeaders.length - 1, 0, {
+		key: "Strict-Transport-Security",
+		value: "max-age=63072000; includeSubDomains; preload",
+	});
+}
 
 const config: NextConfig = withPWA({
 	dest: "public",
@@ -83,44 +125,7 @@ const config: NextConfig = withPWA({
 		return [
 			{
 				source: "/:path*",
-				headers: [
-					{
-						key: "X-DNS-Prefetch-Control",
-						value: "on",
-					},
-					{
-						key: "X-XSS-Protection",
-						value: "1; mode=block",
-					},
-					{
-						key: "X-Frame-Options",
-						value: "SAMEORIGIN",
-					},
-					{
-						key: "X-Content-Type-Options",
-						value: "nosniff",
-					},
-					{
-						key: "X-Permitted-Cross-Domain-Policies",
-						value: "none",
-					},
-					{
-						key: "Strict-Transport-Security",
-						value: "max-age=63072000; includeSubDomains; preload",
-					},
-					{
-						key: "Referrer-Policy",
-						value: "strict-origin-when-cross-origin",
-					},
-					{
-						key: "Permissions-Policy",
-						value: "camera=(), microphone=(), geolocation=()",
-					},
-					{
-						key: "Content-Security-Policy-Report-Only",
-						value: contentSecurityPolicy,
-					},
-				],
+				headers: securityHeaders,
 			},
 		];
 	},

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,39 @@
-import withPWA from "next-pwa";
 import type { NextConfig } from "next";
+import withPWA from "next-pwa";
+
+// CSP の対象となる Supabase オリジン。
+// `NEXT_PUBLIC_SUPABASE_URL` が未設定のビルド時 (例: Storybook の型生成) でも
+// 値が消えないよう、本番で利用しているプロジェクトURLをフォールバックに置く。
+const supabaseOrigin =
+	process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://tcqnsslsaizqwjuyvoyu.supabase.co";
+
+// Content-Security-Policy のディレクティブ定義。
+// まずは Report-Only で配信し、`/api/csp-report` でレポートを収集する。
+const cspDirectives: Record<string, string[]> = {
+	"default-src": ["'self'"],
+	"script-src": ["'self'", "'unsafe-inline'", "https://js.stripe.com"],
+	"style-src": ["'self'", "'unsafe-inline'"],
+	"img-src": [
+		"'self'",
+		"data:",
+		"blob:",
+		supabaseOrigin,
+		"https://*.gyazo.com",
+		"https://*.imgur.com",
+	],
+	"font-src": ["'self'", "data:"],
+	"connect-src": ["'self'", supabaseOrigin, "https://api.stripe.com"],
+	"frame-src": ["https://js.stripe.com", "https://hooks.stripe.com"],
+	"frame-ancestors": ["'none'"],
+	"form-action": ["'self'"],
+	"base-uri": ["'self'"],
+	"object-src": ["'none'"],
+	"report-uri": ["/api/csp-report"],
+};
+
+const contentSecurityPolicy = Object.entries(cspDirectives)
+	.map(([directive, values]) => `${directive} ${values.join(" ")}`)
+	.join("; ");
 
 const config: NextConfig = withPWA({
 	dest: "public",
@@ -42,8 +76,7 @@ const config: NextConfig = withPWA({
 	// 本番環境での最適化設定
 	compress: true,
 	poweredByHeader: false,
-	reactStrictMode: false, // 一時的に無効化（デバッグ用）
-	// Next.js 15では不要な設定のため削除
+	reactStrictMode: true,
 
 	// セキュリティヘッダーの設定
 	async headers() {
@@ -68,12 +101,24 @@ const config: NextConfig = withPWA({
 						value: "nosniff",
 					},
 					{
+						key: "X-Permitted-Cross-Domain-Policies",
+						value: "none",
+					},
+					{
+						key: "Strict-Transport-Security",
+						value: "max-age=63072000; includeSubDomains; preload",
+					},
+					{
 						key: "Referrer-Policy",
 						value: "strict-origin-when-cross-origin",
 					},
 					{
 						key: "Permissions-Policy",
 						value: "camera=(), microphone=(), geolocation=()",
+					},
+					{
+						key: "Content-Security-Policy-Report-Only",
+						value: contentSecurityPolicy,
 					},
 				],
 			},

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,8 +4,17 @@ import withPWA from "next-pwa";
 // CSP の対象となる Supabase オリジン。
 // `NEXT_PUBLIC_SUPABASE_URL` が未設定のビルド時 (例: Storybook の型生成) でも
 // 値が消えないよう、本番で利用しているプロジェクトURLをフォールバックに置く。
-const supabaseOrigin =
-	process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://tcqnsslsaizqwjuyvoyu.supabase.co";
+// 末尾スラッシュやパスを含む env 値で CSP が壊れないよう `URL.origin` に正規化する。
+const SUPABASE_ORIGIN_FALLBACK = "https://tcqnsslsaizqwjuyvoyu.supabase.co";
+function toOrigin(value: string | undefined, fallback: string): string {
+	if (!value) return fallback;
+	try {
+		return new URL(value).origin;
+	} catch {
+		return fallback;
+	}
+}
+const supabaseOrigin = toOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL, SUPABASE_ORIGIN_FALLBACK);
 
 // Vercel preview deploy も `NODE_ENV=production` でビルドされるため、
 // HSTS のような「長期にブラウザへ焼き込まれる」ヘッダーは

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -58,7 +58,12 @@ function sanitizeUrl(value: unknown): string | undefined {
 	if (typeof value !== "string" || value.length === 0) return undefined;
 	try {
 		const url = new URL(value);
-		return `${url.origin}${url.pathname}`;
+		// http(s) 以外 (data:, blob:, javascript: 等) は本体にペイロードが
+		// 含まれうるためプロトコルだけに丸める。
+		if (url.protocol === "http:" || url.protocol === "https:") {
+			return `${url.origin}${url.pathname}`;
+		}
+		return url.protocol;
 	} catch {
 		// 相対 URL や `inline` / `eval` など非 URL 文字列は先頭だけ残す。
 		return value.slice(0, 200);
@@ -130,8 +135,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 		if (!raw) {
 			return new NextResponse(null, { status: 204 });
 		}
-		if (raw.length > MAX_CSP_REPORT_BYTES) {
-			logger.warn({ size: raw.length }, "CSP report payload too large");
+		// `raw.length` は UTF-16 単位の文字数なのでマルチバイト混在ペイロード
+		// では実バイト数とズレる。実バイト長 (UTF-8) で判定する。
+		const rawBytes = Buffer.byteLength(raw, "utf8");
+		if (rawBytes > MAX_CSP_REPORT_BYTES) {
+			logger.warn({ size: rawBytes }, "CSP report payload too large");
 			return new NextResponse(null, { status: 204 });
 		}
 

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -2,11 +2,13 @@
  * Content-Security-Policy 違反レポート受信エンドポイント。
  *
  * `next.config.ts` の `Content-Security-Policy-Report-Only` ヘッダーで
- * `report-uri /api/csp-report` を指定しているため、ブラウザは違反検知時に
- * このパスへ POST を送る。
+ * `report-uri /api/csp-report` および `report-to csp` を指定しているため、
+ * ブラウザは違反検知時にこのパスへ POST を送る。
  *
- * - レガシー `report-uri`: `application/csp-report` (単一の `csp-report` オブジェクト)
- * - 新方式 `report-to` / Reporting API: `application/reports+json` (配列)
+ * - レガシー `report-uri`: `application/csp-report`
+ *   (単一オブジェクト、ダッシュ区切りキー `document-uri` 等)
+ * - 新方式 Reporting API: `application/reports+json`
+ *   (配列、キャメルケースキー `documentURL` 等)
  *
  * どちらの形式でも受け取り、構造化ログとして記録する。Report-Only での
  * チューニング中に誤検知を洗い出し、enforce 化に備えるための窓口。
@@ -16,38 +18,95 @@ import logger from "@/lib/logger";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-interface CspReportPayload {
-	"document-uri"?: string;
-	"violated-directive"?: string;
-	"effective-directive"?: string;
-	"blocked-uri"?: string;
-	"original-policy"?: string;
-	"source-file"?: string;
-	"line-number"?: number;
-	"column-number"?: number;
+// 受け付けるリクエストボディの上限。CSP レポートは通常 1-2KB 程度で、
+// 余裕を見ても 64KB あれば十分。これを超えた POST は早期に弾く。
+const MAX_CSP_REPORT_BYTES = 64 * 1024;
+
+// 1 リクエスト内で処理するエントリ数の上限。Reporting API は配列形式で
+// 来る可能性があり、巨大配列によるログ増幅を防ぐ。
+const MAX_REPORT_ENTRIES = 10;
+
+const ALLOWED_CONTENT_TYPES = [
+	"application/csp-report",
+	"application/reports+json",
+	"application/json",
+];
+
+interface NormalizedReport {
+	documentUri?: string;
+	violatedDirective?: string;
+	blockedUri?: string;
+	sourceFile?: string;
+	lineNumber?: number;
+	columnNumber?: number;
 	disposition?: string;
 	referrer?: string;
-	[key: string]: unknown;
 }
 
 interface ReportToBody {
 	type?: string;
 	url?: string;
-	body?: CspReportPayload;
-	[key: string]: unknown;
+	body?: Record<string, unknown>;
 }
 
-function logViolation(report: CspReportPayload, request: NextRequest): void {
+/**
+ * URL らしき文字列から `origin + pathname` だけを残す。
+ * クエリ文字列やフラグメントに含まれるトークン / PII を
+ * ログへ落とさないためのサニタイズ。
+ */
+function sanitizeUrl(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	try {
+		const url = new URL(value);
+		return `${url.origin}${url.pathname}`;
+	} catch {
+		// 相対 URL や `inline` / `eval` など非 URL 文字列は先頭だけ残す。
+		return value.slice(0, 200);
+	}
+}
+
+function pickString(report: Record<string, unknown>, ...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const v = report[key];
+		if (typeof v === "string" && v.length > 0) return v;
+	}
+	return undefined;
+}
+
+function pickNumber(report: Record<string, unknown>, ...keys: string[]): number | undefined {
+	for (const key of keys) {
+		const v = report[key];
+		if (typeof v === "number") return v;
+	}
+	return undefined;
+}
+
+/**
+ * レガシー (dashed) / モダン (camelCase) 両形式のキーを吸収して
+ * 共通のログ形式に正規化する。
+ */
+function normalize(report: Record<string, unknown>): NormalizedReport {
+	return {
+		documentUri: sanitizeUrl(pickString(report, "document-uri", "documentURL")),
+		violatedDirective: pickString(
+			report,
+			"violated-directive",
+			"effective-directive",
+			"effectiveDirective",
+		),
+		blockedUri: sanitizeUrl(pickString(report, "blocked-uri", "blockedURL")),
+		sourceFile: sanitizeUrl(pickString(report, "source-file", "sourceFile")),
+		lineNumber: pickNumber(report, "line-number", "lineNumber"),
+		columnNumber: pickNumber(report, "column-number", "columnNumber"),
+		disposition: pickString(report, "disposition"),
+		referrer: sanitizeUrl(pickString(report, "referrer")),
+	};
+}
+
+function logViolation(report: Record<string, unknown>, request: NextRequest): void {
 	logger.warn(
 		{
-			documentUri: report["document-uri"],
-			violatedDirective: report["violated-directive"] ?? report["effective-directive"],
-			blockedUri: report["blocked-uri"],
-			sourceFile: report["source-file"],
-			lineNumber: report["line-number"],
-			columnNumber: report["column-number"],
-			disposition: report.disposition,
-			referrer: report.referrer,
+			...normalize(report),
 			userAgent: request.headers.get("user-agent"),
 		},
 		"CSP violation reported",
@@ -55,9 +114,24 @@ function logViolation(report: CspReportPayload, request: NextRequest): void {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+	const contentType = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+	if (contentType && !ALLOWED_CONTENT_TYPES.includes(contentType)) {
+		return new NextResponse(null, { status: 204 });
+	}
+
+	const declaredLength = Number(request.headers.get("content-length") ?? "0");
+	if (Number.isFinite(declaredLength) && declaredLength > MAX_CSP_REPORT_BYTES) {
+		logger.warn({ declaredLength }, "CSP report payload too large (Content-Length)");
+		return new NextResponse(null, { status: 204 });
+	}
+
 	try {
 		const raw = await request.text();
 		if (!raw) {
+			return new NextResponse(null, { status: 204 });
+		}
+		if (raw.length > MAX_CSP_REPORT_BYTES) {
+			logger.warn({ size: raw.length }, "CSP report payload too large");
 			return new NextResponse(null, { status: 204 });
 		}
 
@@ -65,13 +139,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
 		if (Array.isArray(parsed)) {
 			// 新方式 Reporting API: `application/reports+json` の配列形式
-			for (const entry of parsed as ReportToBody[]) {
+			const entries = (parsed as ReportToBody[]).slice(0, MAX_REPORT_ENTRIES);
+			for (const entry of entries) {
 				if (entry?.type === "csp-violation" && entry.body) {
 					logViolation(entry.body, request);
 				}
 			}
 		} else if (parsed && typeof parsed === "object") {
-			const obj = parsed as { "csp-report"?: CspReportPayload; body?: CspReportPayload };
+			const obj = parsed as {
+				"csp-report"?: Record<string, unknown>;
+				body?: Record<string, unknown>;
+			};
 			if (obj["csp-report"]) {
 				// レガシー `report-uri`: `application/csp-report`
 				logViolation(obj["csp-report"], request);

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,89 @@
+/**
+ * Content-Security-Policy 違反レポート受信エンドポイント。
+ *
+ * `next.config.ts` の `Content-Security-Policy-Report-Only` ヘッダーで
+ * `report-uri /api/csp-report` を指定しているため、ブラウザは違反検知時に
+ * このパスへ POST を送る。
+ *
+ * - レガシー `report-uri`: `application/csp-report` (単一の `csp-report` オブジェクト)
+ * - 新方式 `report-to` / Reporting API: `application/reports+json` (配列)
+ *
+ * どちらの形式でも受け取り、構造化ログとして記録する。Report-Only での
+ * チューニング中に誤検知を洗い出し、enforce 化に備えるための窓口。
+ */
+
+import logger from "@/lib/logger";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+interface CspReportPayload {
+	"document-uri"?: string;
+	"violated-directive"?: string;
+	"effective-directive"?: string;
+	"blocked-uri"?: string;
+	"original-policy"?: string;
+	"source-file"?: string;
+	"line-number"?: number;
+	"column-number"?: number;
+	disposition?: string;
+	referrer?: string;
+	[key: string]: unknown;
+}
+
+interface ReportToBody {
+	type?: string;
+	url?: string;
+	body?: CspReportPayload;
+	[key: string]: unknown;
+}
+
+function logViolation(report: CspReportPayload, request: NextRequest): void {
+	logger.warn(
+		{
+			documentUri: report["document-uri"],
+			violatedDirective: report["violated-directive"] ?? report["effective-directive"],
+			blockedUri: report["blocked-uri"],
+			sourceFile: report["source-file"],
+			lineNumber: report["line-number"],
+			columnNumber: report["column-number"],
+			disposition: report.disposition,
+			referrer: report.referrer,
+			userAgent: request.headers.get("user-agent"),
+		},
+		"CSP violation reported",
+	);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+	try {
+		const raw = await request.text();
+		if (!raw) {
+			return new NextResponse(null, { status: 204 });
+		}
+
+		const parsed: unknown = JSON.parse(raw);
+
+		if (Array.isArray(parsed)) {
+			// 新方式 Reporting API: `application/reports+json` の配列形式
+			for (const entry of parsed as ReportToBody[]) {
+				if (entry?.type === "csp-violation" && entry.body) {
+					logViolation(entry.body, request);
+				}
+			}
+		} else if (parsed && typeof parsed === "object") {
+			const obj = parsed as { "csp-report"?: CspReportPayload; body?: CspReportPayload };
+			if (obj["csp-report"]) {
+				// レガシー `report-uri`: `application/csp-report`
+				logViolation(obj["csp-report"], request);
+			} else if (obj.body) {
+				// 単発の Reporting API オブジェクト
+				logViolation(obj.body, request);
+			}
+		}
+	} catch (error) {
+		// 不正な JSON を送ってきたクライアントでも 5xx は返さない (ブラウザがリトライしないため)。
+		logger.warn({ err: error }, "Failed to parse CSP report payload");
+	}
+
+	return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -65,8 +65,10 @@ function sanitizeUrl(value: unknown): string | undefined {
 		}
 		return url.protocol;
 	} catch {
-		// 相対 URL や `inline` / `eval` など非 URL 文字列は先頭だけ残す。
-		return value.slice(0, 200);
+		// 相対 URL や `inline` / `eval` など非 URL 文字列はクエリ・フラグメントを
+		// 落としたうえで先頭だけ残す (相対パスにトークンが入る形を想定)。
+		const head = value.split(/[?#]/, 1)[0] ?? "";
+		return head.slice(0, 200);
 	}
 }
 
@@ -108,6 +110,31 @@ function normalize(report: Record<string, unknown>): NormalizedReport {
 	};
 }
 
+/**
+ * ボディをストリーミングで読み、累積バイト数が `limit` を超えた時点で
+ * 早期に中断する。Content-Length が信頼できない (chunked 等の) 場合でも
+ * 上限超過分をメモリへバッファしないための保護。
+ *
+ * @returns 読み切れた UTF-8 文字列、または上限超過時は `null`
+ */
+async function readBodyWithLimit(request: NextRequest, limit: number): Promise<string | null> {
+	const reader = request.body?.getReader();
+	if (!reader) return "";
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		total += value.byteLength;
+		if (total > limit) {
+			await reader.cancel();
+			return null;
+		}
+		chunks.push(value);
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
 function logViolation(report: Record<string, unknown>, request: NextRequest): void {
 	logger.warn(
 		{
@@ -131,15 +158,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 	}
 
 	try {
-		const raw = await request.text();
-		if (!raw) {
+		// Content-Length が無い chunked リクエストでも、ストリームを
+		// チャンク単位で読みながら上限超過で打ち切ることで
+		// 64KB 以上のメモリ確保を防ぐ。
+		const raw = await readBodyWithLimit(request, MAX_CSP_REPORT_BYTES);
+		if (raw === null) {
+			logger.warn({ limit: MAX_CSP_REPORT_BYTES }, "CSP report payload too large");
 			return new NextResponse(null, { status: 204 });
 		}
-		// `raw.length` は UTF-16 単位の文字数なのでマルチバイト混在ペイロード
-		// では実バイト数とズレる。実バイト長 (UTF-8) で判定する。
-		const rawBytes = Buffer.byteLength(raw, "utf8");
-		if (rawBytes > MAX_CSP_REPORT_BYTES) {
-			logger.warn({ size: rawBytes }, "CSP report payload too large");
+		if (!raw) {
 			return new NextResponse(null, { status: 204 });
 		}
 

--- a/src/lib/security/csrf-protection.ts
+++ b/src/lib/security/csrf-protection.ts
@@ -193,7 +193,7 @@ export async function checkCSRFToken(request: NextRequest): Promise<boolean> {
  * CSRF保護が必要なパスかどうかを判定する。
  *
  * - `/api/*` はデフォルトで保護対象（一部例外あり）
- * - 例外: `/api/stripe/webhook`, `/api/health`, `/api/csrf-token`
+ * - 例外: `/api/stripe/webhook`, `/api/health`, `/api/csrf-token`, `/api/csp-report`
  * - Server Actions は Next.js のビルトインCSRF保護に委ねるため対象外
  *
  * @param pathname リクエストパス
@@ -201,7 +201,12 @@ export async function checkCSRFToken(request: NextRequest): Promise<boolean> {
  */
 export function requiresCSRFProtection(pathname: string): boolean {
 	if (pathname.startsWith("/api/")) {
-		const exemptPaths = ["/api/stripe/webhook", "/api/health", "/api/csrf-token"];
+		const exemptPaths = [
+			"/api/stripe/webhook",
+			"/api/health",
+			"/api/csrf-token",
+			"/api/csp-report",
+		];
 		// 完全一致または明示的なサブルート（`path + "/"`）のみを除外対象とする。
 		// 単純な startsWith だと "/api/csrf-tokenize" のような prefix 一致パスまで
 		// 誤って除外されてしまうため。


### PR DESCRIPTION
## Summary
Implements Content-Security-Policy (CSP) monitoring and enhances security headers configuration. This adds a new CSP report collection endpoint and configures CSP directives in Report-Only mode to identify policy violations before enforcement.

## Key Changes

- **New CSP Report Endpoint** (`src/app/api/csp-report/route.ts`)
  - Receives and logs CSP violations from browsers
  - Supports both legacy `report-uri` format (`application/csp-report`) and modern Reporting API format (`application/reports+json`)
  - Structures violation data for analysis (document URI, violated directive, blocked URI, source location, user agent, etc.)
  - Returns 204 No Content to prevent browser retries on malformed requests

- **CSP Configuration** (`next.config.ts`)
  - Defines CSP directives covering script, style, image, font, and connection sources
  - Allows Stripe integration (`js.stripe.com`, `api.stripe.com`)
  - Allows Supabase and image hosting services (Gyazo, Imgur)
  - Configured in Report-Only mode via `Content-Security-Policy-Report-Only` header for safe tuning
  - Includes fallback Supabase URL for builds without environment variables

- **Additional Security Headers** (`next.config.ts`)
  - `X-Permitted-Cross-Domain-Policies: none` - Prevents cross-domain policy loading
  - `Strict-Transport-Security` - HSTS with 2-year max-age and preload flag
  - Maintains existing headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)

- **CSRF Protection Update** (`src/lib/security/csrf-protection.ts`)
  - Exempts `/api/csp-report` from CSRF token validation (webhook-like endpoint)

- **Configuration Cleanup** (`next.config.ts`)
  - Re-enabled `reactStrictMode: true` (was temporarily disabled)
  - Removed outdated comments about Next.js 15

## Implementation Details

The CSP report endpoint gracefully handles both legacy and modern browser formats, normalizing them into a consistent logging structure. The Report-Only mode allows safe collection of violations without blocking resources, enabling data-driven policy refinement before enforcement. The endpoint returns 204 status codes to prevent browser retry behavior on parsing errors.

https://claude.ai/code/session_01WC9FYeuvxoAf73eRYtDzGF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セキュリティ違反（CSP）レポート受信エンドポイントを追加し、受信した報告を検証・正規化して構造化ログに記録。

* **改善**
  * Content-Security-Policy（Report-Only）とレポーティング設定を導入し、報告送信先を一元化。
  * セキュリティヘッダーを整理・強化（X-Frame-Options: DENY、X-Permitted-Cross-Domain-Policies など、条件付きでHSTS適用）。
  * 受信レポートにサイズ上限・処理上限・機密情報サニタイズを適用。
  * アプリの厳格モードを有効化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->