### PR TITLE
Atomize kouden creation with RPC and fix security issues

### DIFF
--- a/src/app/(protected)/koudens/loading.tsx
+++ b/src/app/(protected)/koudens/loading.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function KoudensLoading() {
 	return (
@@ -12,8 +12,9 @@ export default function KoudensLoading() {
 
 			{/* リストのスケルトン */}
 			<div className="koudens-list grid gap-2 md:grid-cols-2 lg:grid-cols-3 md:gap-6">
-				{Array.from({ length: 6 }, () => (
-					<Card key={crypto.randomUUID()} className="kouden-card flex flex-col">
+				{Array.from({ length: 6 }, (_, index) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: 静的な長さ6のスケルトンで並び替えは発生しないため index を key に使う
+					<Card key={`skeleton-${index}`} className="kouden-card flex flex-col">
 						<div className="flex-1">
 							<CardHeader className="space-y-2">
 								<Skeleton className="h-6 w-[200px]" />

--- a/src/app/(public)/_components/pain-points-section.tsx
+++ b/src/app/(public)/_components/pain-points-section.tsx
@@ -1,8 +1,8 @@
 import { zenOldMincho } from "@/app/fonts";
 import { Card } from "@/components/ui/card";
-import { FileSpreadsheet, Users2, Calculator, History } from "lucide-react";
-import { SectionTitle } from "@/components/ui/section-title";
 import { Section } from "@/components/ui/section";
+import { SectionTitle } from "@/components/ui/section-title";
+import { Calculator, FileSpreadsheet, History, Users2 } from "lucide-react";
 
 type Story = {
 	text: string;
@@ -99,12 +99,9 @@ const StoryText = ({ text, emphasizedWords }: Story) => {
 	const parts = text.split(new RegExp(`(${emphasizedWords.join("|")})`, "g"));
 	return (
 		<li className="text-lg font-medium">
-			{parts.map((part) =>
+			{parts.map((part, index) =>
 				emphasizedWords.includes(part) ? (
-					<span
-						key={crypto.randomUUID()}
-						className="text-gray-900 dark:text-gray-100 font-semibold"
-					>
+					<span key={`${index}-${part}`} className="text-gray-900 dark:text-gray-100 font-semibold">
 						{part}
 					</span>
 				) : (

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -46,30 +46,20 @@ export async function createKouden({
 		const supabase = await createClient();
 		const adminSupabase = createAdminClient();
 
-		// freeプランIDを取得 (plans テーブルは authenticated でも SELECT 可能だが、
-		// 表示用ではなく内部ロジックのため admin client で取得する)
-		const { data: freePlan, error: freePlanError } = await adminSupabase
-			.from("plans")
-			.select("id")
-			.eq("code", "free")
-			.single();
-		if (freePlanError || !freePlan) {
-			throw new Error("プランの取得に失敗しました");
-		}
-
 		// 香典帳作成: RPC で koudens INSERT を実行し、トリガで kouden_roles と
 		// kouden_members が同一トランザクション内に作成されるのを待つ。
+		// `plan_id` は RPC 内部で `code = 'free'` から解決される (クライアントから
+		// 渡すと有料プラン ID を指定して悪用される脆弱性となるため受け取らない)。
 		const { data: newKoudenId, error: rpcError } = await supabase.rpc("create_kouden_with_owner", {
 			p_title: title,
 			p_description: description ?? "",
-			p_plan_id: freePlan.id,
 		});
 
 		if (rpcError || !newKoudenId) {
 			throw rpcError ?? new Error("香典帳の作成に失敗しました");
 		}
 
-		// 作成した香典帳とオーナープロフィールを取得
+		// 作成した香典帳を取得
 		const { data: kouden, error: koudenError } = await adminSupabase
 			.from("koudens")
 			.select("*")
@@ -79,16 +69,26 @@ export async function createKouden({
 			throw koudenError ?? new Error("香典帳の取得に失敗しました");
 		}
 
+		// オーナーのプロフィール取得は best-effort: ここで失敗しても香典帳は既に
+		// 作成済みなのでエラー返却はしない (ユーザー再試行による重複作成を防ぐ)。
 		const { data: owner, error: ownerError } = await adminSupabase
 			.from("profiles")
 			.select("id, display_name")
 			.eq("id", userId)
 			.single();
 		if (ownerError) {
-			throw ownerError;
+			logger.warn(
+				{ userId, koudenId: newKoudenId, error: ownerError.message },
+				"Owner profile fetch failed after kouden creation; continuing with fallback",
+			);
 		}
 
-		return { kouden: { ...kouden, owner } as unknown as Kouden };
+		return {
+			kouden: {
+				...kouden,
+				owner: owner ?? { id: userId, display_name: null },
+			} as unknown as Kouden,
+		};
 	} catch (error) {
 		logger.error(
 			{

--- a/src/app/_actions/koudens/create.ts
+++ b/src/app/_actions/koudens/create.ts
@@ -4,7 +4,6 @@ import logger from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import type { CreateKoudenParams, Kouden } from "@/types/kouden";
-import { KOUDEN_ROLES } from "@/types/role";
 
 export interface CreateKoudenWithPlanParams extends Omit<CreateKoudenParams, "userId"> {
 	planCode: string;
@@ -27,8 +26,12 @@ async function getAuthenticatedUserId(): Promise<string | null> {
 /**
  * 香典帳の作成
  *
+ * `koudens` INSERT は RPC `create_kouden_with_owner` を経由する。
+ * `kouden_roles` / `kouden_members` は INSERT トリガが同一トランザクション内で
+ * 作成するため、呼び出し元での待機 (旧 1秒 setTimeout) は不要。
+ *
  * 注意: `userId` パラメータが渡された場合でも信用せず、必ずセッションから
- * 取得した auth.uid() を使用する。
+ * 取得した auth.uid() を使用する (RPC 内でも `auth.uid()` を使用)。
  */
 export async function createKouden({
 	title,
@@ -40,10 +43,12 @@ export async function createKouden({
 	}
 
 	try {
-		const supabase = createAdminClient();
+		const supabase = await createClient();
+		const adminSupabase = createAdminClient();
 
-		// freeプランIDを取得
-		const { data: freePlan, error: freePlanError } = await supabase
+		// freeプランIDを取得 (plans テーブルは authenticated でも SELECT 可能だが、
+		// 表示用ではなく内部ロジックのため admin client で取得する)
+		const { data: freePlan, error: freePlanError } = await adminSupabase
 			.from("plans")
 			.select("id")
 			.eq("code", "free")
@@ -52,50 +57,35 @@ export async function createKouden({
 			throw new Error("プランの取得に失敗しました");
 		}
 
-		// 香典帳を作成
-		const { data: kouden, error: koudenError } = await supabase
-			.from("koudens")
-			.insert({ title, description, owner_id: userId, created_by: userId, plan_id: freePlan.id })
-			.select("*")
-			.single();
+		// 香典帳作成: RPC で koudens INSERT を実行し、トリガで kouden_roles と
+		// kouden_members が同一トランザクション内に作成されるのを待つ。
+		const { data: newKoudenId, error: rpcError } = await supabase.rpc("create_kouden_with_owner", {
+			p_title: title,
+			p_description: description ?? "",
+			p_plan_id: freePlan.id,
+		});
 
-		if (koudenError) {
-			throw koudenError;
+		if (rpcError || !newKoudenId) {
+			throw rpcError ?? new Error("香典帳の作成に失敗しました");
 		}
 
-		// オーナー情報を取得
-		const { data: owner, error: ownerError } = await supabase
+		// 作成した香典帳とオーナープロフィールを取得
+		const { data: kouden, error: koudenError } = await adminSupabase
+			.from("koudens")
+			.select("*")
+			.eq("id", newKoudenId)
+			.single();
+		if (koudenError || !kouden) {
+			throw koudenError ?? new Error("香典帳の取得に失敗しました");
+		}
+
+		const { data: owner, error: ownerError } = await adminSupabase
 			.from("profiles")
 			.select("id, display_name")
 			.eq("id", userId)
 			.single();
-
 		if (ownerError) {
 			throw ownerError;
-		}
-
-		// 初期関係性を待機
-		await new Promise((resolve) => setTimeout(resolve, 1000));
-
-		// 編集者ロールを取得
-		const { data: ownerRole, error: roleError } = await supabase
-			.from("kouden_roles")
-			.select("id")
-			.eq("kouden_id", kouden.id)
-			.eq("name", KOUDEN_ROLES.EDITOR)
-			.single();
-
-		if (!ownerRole || roleError) {
-			throw new Error("編集者ロールの取得に失敗しました");
-		}
-
-		// メンバーとして登録
-		const { error: memberError } = await supabase
-			.from("kouden_members")
-			.insert({ kouden_id: kouden.id, user_id: userId, role_id: ownerRole.id, added_by: userId });
-
-		if (memberError) {
-			throw memberError;
 		}
 
 		return { kouden: { ...kouden, owner } as unknown as Kouden };

--- a/src/components/structured-data.tsx
+++ b/src/components/structured-data.tsx
@@ -12,13 +12,17 @@ export function StructuredData({ type, data }: StructuredDataProps) {
 		...data,
 	};
 
+	// `<` を `<` にエスケープし、JSON 値に `</script>` 等が混入しても
+	// script タグから抜け出せないようにする (latent XSS 対策)。
+	const safeJson = JSON.stringify(structuredData).replace(/</g, "\\u003c");
+
 	return (
 		<Script
 			id={`structured-data-${type.toLowerCase()}`}
 			type="application/ld+json"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD は HTML 文字列として埋め込む必要があるため。`<` は上で事前エスケープ済み。
 			dangerouslySetInnerHTML={{
-				__html: JSON.stringify(structuredData),
+				__html: safeJson,
 			}}
 		/>
 	);

--- a/src/lib/security/login-attempts.ts
+++ b/src/lib/security/login-attempts.ts
@@ -51,12 +51,16 @@ export async function recordLoginAttempt(
 	}
 
 	// 失敗時は試行回数を増加
-	const { data: existingAttempt } = await supabase
+	// `user_id` は uuid 型のため、空文字を `eq` に渡すと型変換エラーになる。
+	// 未認証ユーザーの試行は `user_id IS NULL` で一致させる。
+	const existingAttemptQuery = supabase
 		.from("login_attempts")
 		.select("*")
-		.eq("ip_address", ipAddress)
-		.eq("user_id", userId || "")
-		.single();
+		.eq("ip_address", ipAddress);
+	const { data: existingAttempt } = await (userId
+		? existingAttemptQuery.eq("user_id", userId)
+		: existingAttemptQuery.is("user_id", null)
+	).single();
 
 	if (existingAttempt) {
 		const newAttemptCount = existingAttempt.attempt_count + 1;
@@ -97,12 +101,11 @@ export async function isAccountLocked(
 		return { locked: false };
 	}
 
-	const { data: attempt } = await supabase
-		.from("login_attempts")
-		.select("*")
-		.eq("ip_address", ipAddress)
-		.eq("user_id", userId || "")
-		.single();
+	const attemptQuery = supabase.from("login_attempts").select("*").eq("ip_address", ipAddress);
+	const { data: attempt } = await (userId
+		? attemptQuery.eq("user_id", userId)
+		: attemptQuery.is("user_id", null)
+	).single();
 
 	if (!attempt?.locked_until) {
 		return { locked: false };
@@ -127,11 +130,8 @@ export async function isAccountLocked(
 async function clearLoginAttempts(ipAddress: string, userId?: string): Promise<void> {
 	const supabase = createAdminClient();
 
-	await supabase
-		.from("login_attempts")
-		.delete()
-		.eq("ip_address", ipAddress)
-		.eq("user_id", userId || "");
+	const deleteQuery = supabase.from("login_attempts").delete().eq("ip_address", ipAddress);
+	await (userId ? deleteQuery.eq("user_id", userId) : deleteQuery.is("user_id", null));
 }
 
 /**

--- a/src/lib/security/login-attempts.ts
+++ b/src/lib/security/login-attempts.ts
@@ -53,6 +53,10 @@ export async function recordLoginAttempt(
 	// 失敗時は試行回数を増加
 	// `user_id` は uuid 型のため、空文字を `eq` に渡すと型変換エラーになる。
 	// 未認証ユーザーの試行は `user_id IS NULL` で一致させる。
+	// PostgreSQL の UNIQUE 制約は NULL 同士を別物として扱うため、未認証ユーザーの
+	// (ip_address, user_id=NULL) に対し複数行が累積する可能性がある。複数行で
+	// `.single()` を使うと例外で lockout が壊れるので、最新行を 1 件だけ取る
+	// 形 (`order + limit + maybeSingle`) で堅牢化する。
 	const existingAttemptQuery = supabase
 		.from("login_attempts")
 		.select("*")
@@ -60,7 +64,10 @@ export async function recordLoginAttempt(
 	const { data: existingAttempt } = await (userId
 		? existingAttemptQuery.eq("user_id", userId)
 		: existingAttemptQuery.is("user_id", null)
-	).single();
+	)
+		.order("last_attempt_at", { ascending: false })
+		.limit(1)
+		.maybeSingle();
 
 	if (existingAttempt) {
 		const newAttemptCount = existingAttempt.attempt_count + 1;
@@ -101,11 +108,15 @@ export async function isAccountLocked(
 		return { locked: false };
 	}
 
+	// 未認証ユーザーの NULL 行が複数並ぶ可能性に備え、最新行を 1 件だけ取得する。
 	const attemptQuery = supabase.from("login_attempts").select("*").eq("ip_address", ipAddress);
 	const { data: attempt } = await (userId
 		? attemptQuery.eq("user_id", userId)
 		: attemptQuery.is("user_id", null)
-	).single();
+	)
+		.order("last_attempt_at", { ascending: false })
+		.limit(1)
+		.maybeSingle();
 
 	if (!attempt?.locked_until) {
 		return { locked: false };

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -3346,6 +3346,14 @@ export type Database = {
         }
         Returns: string
       }
+      create_kouden_with_owner: {
+        Args: {
+          p_title: string
+          p_description: string
+          p_plan_id: string
+        }
+        Returns: string
+      }
       detect_suspicious_activity: {
         Args: { p_user_id: string; p_ip_address: unknown; p_event_type: string }
         Returns: boolean

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -3350,7 +3350,6 @@ export type Database = {
         Args: {
           p_title: string
           p_description: string
-          p_plan_id: string
         }
         Returns: string
       }

--- a/supabase/migrations/20260517000000_add_create_kouden_with_owner_rpc.sql
+++ b/supabase/migrations/20260517000000_add_create_kouden_with_owner_rpc.sql
@@ -24,11 +24,27 @@
 --     `koudens` への INSERT 1 文と、戻り値用 SELECT のみで完結する
 --   - 認証ユーザー (`auth.uid()`) でのみ実行可能。`owner_id` / `created_by` は
 --     クライアントから受け取らず、必ず `auth.uid()` を使う
+--
+-- セキュリティ設計:
+--   - **`plan_id` はクライアントから受け取らない**。`authenticated` ロールに
+--     EXECUTE を許可するため、引数で `plan_id` を受け取ると悪意あるユーザーが
+--     直接 RPC を呼び出して有料プラン ID を指定し、無料で香典帳を作成できて
+--     しまう脆弱性につながる。この RPC は **無料プラン専用** とし、`plans` から
+--     `code = 'free'` の ID を内部で解決する。有料プラン経由の香典帳作成は
+--     決済済みを Stripe Webhook 経由で検証する
+--     `process_stripe_checkout_completed` RPC のみで行われる。
+--   - `SECURITY INVOKER` を採用。RLS 上、`authenticated` ロールは
+--       * `koudens` INSERT: `unified_kouden_insert` (`owner_id = auth.uid()`) で許可
+--       * `kouden_roles` INSERT (トリガ内): `kouden_roles_insert`
+--         (`koudens.owner_id = auth.uid()` の EXISTS) で許可
+--     のいずれもパスする。`kouden_members` INSERT (トリガ `add_kouden_owner` 内)
+--     は当該トリガ自体が `SECURITY DEFINER` のため RLS を介さない。
+--     よって `SECURITY DEFINER` で関数全体を権限昇格する必要は無く、最小権限の
+--     `SECURITY INVOKER` で十分。
 
 CREATE OR REPLACE FUNCTION public.create_kouden_with_owner(
     p_title text,
-    p_description text,
-    p_plan_id uuid
+    p_description text
 )
 RETURNS uuid
 LANGUAGE plpgsql
@@ -37,6 +53,7 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
     v_user_id uuid := auth.uid();
+    v_plan_id uuid;
     v_kouden_id uuid;
 BEGIN
     IF v_user_id IS NULL THEN
@@ -44,12 +61,23 @@ BEGIN
             USING ERRCODE = '42501'; -- insufficient_privilege
     END IF;
 
+    -- 無料プランの ID を関数内部で解決する (クライアントからは受け取らない)。
+    SELECT id INTO v_plan_id
+    FROM public.plans
+    WHERE code = 'free'
+    LIMIT 1;
+
+    IF v_plan_id IS NULL THEN
+        RAISE EXCEPTION 'free_plan_not_found'
+            USING ERRCODE = 'P0002'; -- no_data_found
+    END IF;
+
     -- koudens への INSERT。AFTER INSERT トリガが同一トランザクション内で
     --   - create_default_kouden_roles_trigger → kouden_roles (editor/viewer)
     --   - trigger_add_kouden_owner          → kouden_members (owner = editor)
     -- を埋めるため、関数戻り時点では関連レコードが揃っている。
     INSERT INTO public.koudens (title, description, owner_id, created_by, plan_id)
-    VALUES (p_title, p_description, v_user_id, v_user_id, p_plan_id)
+    VALUES (p_title, p_description, v_user_id, v_user_id, v_plan_id)
     RETURNING id INTO v_kouden_id;
 
     RETURN v_kouden_id;
@@ -57,6 +85,6 @@ END;
 $$;
 
 -- 認証済みユーザーのみが実行可能 (RLS は通常通り `koudens` 側のポリシーで担保)
-REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text, uuid) FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text, uuid) FROM anon;
-GRANT EXECUTE ON FUNCTION public.create_kouden_with_owner(text, text, uuid) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.create_kouden_with_owner(text, text) TO authenticated, service_role;

--- a/supabase/migrations/20260517000000_add_create_kouden_with_owner_rpc.sql
+++ b/supabase/migrations/20260517000000_add_create_kouden_with_owner_rpc.sql
@@ -1,0 +1,62 @@
+-- 2026-05-17: 香典帳作成のアトミック化用 RPC 関数
+-- Issue: https://github.com/otomatty/kouden/issues/81 (umbrella: #97)
+--
+-- 背景:
+--   `createKouden` Server Action (src/app/_actions/koudens/create.ts) では
+--   `koudens` INSERT 後にトリガで作成される `kouden_roles` を待つために
+--   1秒スリープしていた:
+--     await new Promise((resolve) => setTimeout(resolve, 1000));
+--
+--   - 競合状態に対するスリープによる対処はフレーキー (高負荷時に間に合わない)
+--   - 香典帳作成の体感速度を 1 秒悪化
+--
+--   実際には `koudens` への INSERT と関連する AFTER INSERT トリガ
+--   (`create_default_kouden_roles_trigger` / `trigger_add_kouden_owner`) は
+--   同一トランザクション内で同期的に実行されるため、本来スリープは不要。
+--   しかし呼び出し元から複数 INSERT/SELECT を続けて発行する構造自体が脆く、
+--   全体を 1 つの Postgres 関数 (= 1 トランザクション) にまとめることで
+--   失敗時のロールバックと挙動の明確化を担保する。
+--
+-- 本マイグレーションでは:
+--   - `koudens` INSERT を含む一連の処理を単一 RPC `create_kouden_with_owner`
+--     にカプセル化する
+--   - 既存トリガが `kouden_roles` / `kouden_members` を埋めるため、RPC 自体は
+--     `koudens` への INSERT 1 文と、戻り値用 SELECT のみで完結する
+--   - 認証ユーザー (`auth.uid()`) でのみ実行可能。`owner_id` / `created_by` は
+--     クライアントから受け取らず、必ず `auth.uid()` を使う
+
+CREATE OR REPLACE FUNCTION public.create_kouden_with_owner(
+    p_title text,
+    p_description text,
+    p_plan_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_user_id uuid := auth.uid();
+    v_kouden_id uuid;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'authentication_required'
+            USING ERRCODE = '42501'; -- insufficient_privilege
+    END IF;
+
+    -- koudens への INSERT。AFTER INSERT トリガが同一トランザクション内で
+    --   - create_default_kouden_roles_trigger → kouden_roles (editor/viewer)
+    --   - trigger_add_kouden_owner          → kouden_members (owner = editor)
+    -- を埋めるため、関数戻り時点では関連レコードが揃っている。
+    INSERT INTO public.koudens (title, description, owner_id, created_by, plan_id)
+    VALUES (p_title, p_description, v_user_id, v_user_id, p_plan_id)
+    RETURNING id INTO v_kouden_id;
+
+    RETURN v_kouden_id;
+END;
+$$;
+
+-- 認証済みユーザーのみが実行可能 (RLS は通常通り `koudens` 側のポリシーで担保)
+REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_kouden_with_owner(text, text, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.create_kouden_with_owner(text, text, uuid) TO authenticated, service_role;


### PR DESCRIPTION
## Summary
This PR refactors the kouden (香典帳) creation flow to use a PostgreSQL RPC function for atomicity, eliminating a fragile 1-second sleep workaround. It also fixes several security and code quality issues across the codebase.

## Key Changes

### Kouden Creation Atomicity
- **New RPC function** `create_kouden_with_owner`: Encapsulates the `koudens` INSERT in a single database transaction, allowing existing AFTER INSERT triggers to synchronously create `kouden_roles` and `kouden_members` within the same transaction
- **Removed 1-second sleep**: Eliminates the `setTimeout(resolve, 1000)` workaround that was masking a race condition and degrading UX
- **Simplified server action**: `createKouden` now calls the RPC instead of manually managing multiple INSERT/SELECT operations, reducing complexity and improving reliability
- **Added migration**: `20260517000000_add_create_kouden_with_owner_rpc.sql` defines the RPC with proper authentication checks and RLS enforcement

### Security & Code Quality Fixes
- **Login attempts query fix** (`login-attempts.ts`): Fixed type mismatch when querying `user_id` (uuid type) with empty string. Now properly uses `.is("user_id", null)` for unauthenticated users instead of `.eq("user_id", "")`, preventing type conversion errors
- **XSS prevention** (`structured-data.tsx`): Added escaping of `<` characters in JSON-LD structured data to prevent latent XSS if malicious content is embedded in data values
- **Key generation fixes**: Replaced `crypto.randomUUID()` with deterministic keys in list renders (`pain-points-section.tsx`, `koudens/loading.tsx`) to avoid React warnings and improve performance

### Code Organization
- Standardized import ordering across multiple files
- Improved code comments with detailed explanations of security considerations and implementation rationale
- Updated TypeScript types to include the new RPC function signature

## Implementation Details
- The RPC function uses `SECURITY INVOKER` to respect RLS policies and `auth.uid()` to ensure the authenticated user is always the owner
- Proper permission grants restrict execution to `authenticated` and `service_role` users only
- All related database operations now complete atomically within a single transaction, eliminating the need for client-side synchronization

https://claude.ai/code/session_01WbxeMkaxpP4UJ42nKjFS5m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ログイン試行記録の照合条件を改善し、未認証時の型エラーや誤動作を修正しました
  * リストや強調テキストのキー生成を決定的に変更し、表示の安定性を向上しました

* **Security**
  * 埋め込みJSON-LDを事前エスケープして、潜在的なスクリプト脱出リスクを低減しました

* **Refactor / Chores**
  * 香典帳作成をRPCに集約して処理フローを簡素化し、型定義とDBマイグレーションを追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->