### PR TITLE
refactor(supabase): migrate to publishable/secret API key names (#59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ NEXT_PUBLIC_APP_URL=https://kouden-app.com
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
+SUPABASE_SECRET_KEY=
 
 # Google
 GOOGLE_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ cp .env.example .env.local
 ```
 以下の環境変数を`.env.local`に設定してください：
 - `NEXT_PUBLIC_SUPABASE_URL`: SupabaseのプロジェクトURL
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: SupabaseのAnonymous Key
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`: SupabaseのPublishable Key
+
+> Supabaseダッシュボードの `Project Settings → API Keys` または Connect ダイアログから新しいAPIキー (`sb_publishable_*` / `sb_secret_*`) を取得できます。詳細は [Supabase API Keys ドキュメント](https://supabase.com/docs/guides/api/api-keys) を参照してください。
 
 4. 開発サーバーの起動
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cp .env.example .env.local
 以下の環境変数を`.env.local`に設定してください：
 - `NEXT_PUBLIC_SUPABASE_URL`: SupabaseのプロジェクトURL
 - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`: SupabaseのPublishable Key
+- `SUPABASE_SECRET_KEY`: SupabaseのSecret Key（サーバー側のみで使用、ブラウザに露出させないこと）
 
 > Supabaseダッシュボードの `Project Settings → API Keys` または Connect ダイアログから新しいAPIキー (`sb_publishable_*` / `sb_secret_*`) を取得できます。詳細は [Supabase API Keys ドキュメント](https://supabase.com/docs/guides/api/api-keys) を参照してください。
 

--- a/docs/developments/paid-implementation-plan.md
+++ b/docs/developments/paid-implementation-plan.md
@@ -315,7 +315,7 @@ CREATE INDEX IF NOT EXISTS idx_koudens_plan ON koudens(plan_id);
 - RESEND_API_KEY       （Resend API キー）
 - STRIPE_SECRET_KEY    （Stripe シークレットキー）
 - STRIPE_WEBHOOK_SECRET（Stripe Webhook シグニチャ検証用シークレット）
-- SUPABASE_URL        
+- NEXT_PUBLIC_SUPABASE_URL （SupabaseプロジェクトURL）
 - SUPABASE_SECRET_KEY （Supabase Secret Key）
 - STRIPE_PUBLISHABLE_KEY （Stripe公開可能キー）
 

--- a/docs/developments/paid-implementation-plan.md
+++ b/docs/developments/paid-implementation-plan.md
@@ -316,7 +316,7 @@ CREATE INDEX IF NOT EXISTS idx_koudens_plan ON koudens(plan_id);
 - STRIPE_SECRET_KEY    （Stripe シークレットキー）
 - STRIPE_WEBHOOK_SECRET（Stripe Webhook シグニチャ検証用シークレット）
 - SUPABASE_URL        
-- SUPABASE_SERVICE_ROLE_KEY （Supabase サービスロールキー）
+- SUPABASE_SECRET_KEY （Supabase Secret Key）
 - STRIPE_PUBLISHABLE_KEY （Stripe公開可能キー）
 
 ### 11.5 冪等性・エラーハンドリング

--- a/docs/developments/reminder-implementation.md
+++ b/docs/developments/reminder-implementation.md
@@ -106,6 +106,7 @@ export async function GET() {
 
 ## 3. 環境変数
 - `RESEND_API_KEY`（Resend APIキー）
+- `NEXT_PUBLIC_SUPABASE_URL`（SupabaseプロジェクトURL）
 - `SUPABASE_SECRET_KEY`（Supabase Secret Key）
 
 ## 4. 作業手順

--- a/docs/developments/reminder-implementation.md
+++ b/docs/developments/reminder-implementation.md
@@ -106,7 +106,7 @@ export async function GET() {
 
 ## 3. 環境変数
 - `RESEND_API_KEY`（Resend APIキー）
-- `SUPABASE_SERVICE_ROLE_KEY`（Supabase サービスロールキー）
+- `SUPABASE_SECRET_KEY`（Supabase Secret Key）
 
 ## 4. 作業手順
 1. `src/app/api/cron/send-reminders/route.ts` を作成し、上記コードを実装する

--- a/scripts/oss-sync/prepare-oss-package.js
+++ b/scripts/oss-sync/prepare-oss-package.js
@@ -105,7 +105,7 @@ function prepareEnvExample() {
 
 	const envExample = `# Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
 
 # App Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -2,19 +2,19 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/supabase";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabaseSecretKey = process.env.SUPABASE_SECRET_KEY;
 
 /**
- * Service Role キーでSupabaseクライアントを生成し、RLSをバイパスします
+ * Secret キーでSupabaseクライアントを生成し、RLSをバイパスします
  */
 export function createAdminClient() {
 	const url = supabaseUrl;
-	const key = supabaseServiceRoleKey;
+	const key = supabaseSecretKey;
 	if (!url) {
 		throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL");
 	}
 	if (!key) {
-		throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY");
+		throw new Error("Missing SUPABASE_SECRET_KEY");
 	}
 	return createClient<Database>(url, key);
 }

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -3,15 +3,15 @@ import type { Database } from "@/types/supabase";
 
 export function createClient() {
 	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+	const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
 	if (!supabaseUrl) {
 		throw new Error("Missing Supabase environment variables");
 	}
 
-	if (!supabaseAnonKey) {
+	if (!supabasePublishableKey) {
 		throw new Error("Missing Supabase environment variables");
 	}
 
-	return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+	return createBrowserClient<Database>(supabaseUrl, supabasePublishableKey);
 }

--- a/src/lib/supabase/config.ts
+++ b/src/lib/supabase/config.ts
@@ -1,8 +1,8 @@
 export function getSupabaseConfig() {
 	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+	const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-	if (!url || !anonKey) {
+	if (!url || !publishableKey) {
 		throw new Error(
 			"Missing Supabase environment variables. Please check your .env file.",
 		);
@@ -10,6 +10,6 @@ export function getSupabaseConfig() {
 
 	return {
 		url,
-		anonKey,
+		publishableKey,
 	};
 }

--- a/src/lib/supabase/db.ts
+++ b/src/lib/supabase/db.ts
@@ -2,10 +2,10 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/supabase";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!supabaseUrl || !supabasePublishableKey) {
 	throw new Error("Missing Supabase environment variables");
 }
 
-export const db = createClient<Database>(supabaseUrl, supabaseAnonKey);
+export const db = createClient<Database>(supabaseUrl, supabasePublishableKey);

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -2,9 +2,9 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-const hasValidEnv = supabaseUrl && supabaseAnonKey;
+const hasValidEnv = supabaseUrl && supabasePublishableKey;
 if (!hasValidEnv) {
 	throw new Error("Missing Supabase environment variables");
 }
@@ -14,7 +14,7 @@ export async function updateSession(request: NextRequest) {
 		request,
 	});
 
-	const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+	const supabase = createServerClient(supabaseUrl, supabasePublishableKey, {
 		cookies: {
 			getAll() {
 				return request.cookies.getAll();

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -6,12 +6,12 @@ import logger from "@/lib/logger";
 export async function createClient() {
 	const cookieStore = await cookies();
 	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+	const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
 	if (!supabaseUrl) throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL");
-	if (!supabaseAnonKey) throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY");
+	if (!supabasePublishableKey) throw new Error("Missing NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
 
-	return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+	return createServerClient<Database>(supabaseUrl, supabasePublishableKey, {
 		cookies: {
 			getAll() {
 				return Array.from(cookieStore.getAll()).map(({ name, value }) => ({

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -7,8 +7,8 @@ declare namespace NodeJS {
 
 		// Supabase
 		NEXT_PUBLIC_SUPABASE_URL: string;
-		NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
-		SUPABASE_SERVICE_ROLE_KEY: string;
+		NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: string;
+		SUPABASE_SECRET_KEY: string;
 
 		// Google OAuth / API
 		GOOGLE_CLIENT_ID: string;


### PR DESCRIPTION
Rename environment variables to match Supabase's new API key format
(sb_publishable_* / sb_secret_*), making them independently rotatable
from session JWTs. Legacy anon/service_role JWTs are being phased out.

- NEXT_PUBLIC_SUPABASE_ANON_KEY -> NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
- SUPABASE_SERVICE_ROLE_KEY -> SUPABASE_SECRET_KEY

Note: deploy environments (Vercel etc.) must update their env values to
the new names before this branch is merged. Supabase accepts both key
formats concurrently, so the rename is safe to land with a coordinated
env update.

https://claude.ai/code/session_01TmizdbLC2DBhZwcj28zJ2V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Supabase 環境変数名を更新しました（NEXT_PUBLIC_SUPABASE_ANON_KEY → NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY、SUPABASE_SERVICE_ROLE_KEY → SUPABASE_SECRET_KEY）。設定テンプレートやコード内参照を統一。

* **Documentation**
  * README と開発ドキュメントの環境変数説明を更新し、API キーの取得元と参照手順を追記。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->