### PR TITLE
Fix admin list pagination by adding count: exact (issue #118)

### DIFF
--- a/src/app/_actions/admin/campaign-applications.ts
+++ b/src/app/_actions/admin/campaign-applications.ts
@@ -53,7 +53,7 @@ export async function getCampaignApplications(params?: {
 
 		let query = supabase
 			.from("campaign_hearing_applications")
-			.select("*")
+			.select("*", { count: "exact" })
 			.order("created_at", { ascending: false });
 
 		// フィルタリング

--- a/src/app/_actions/admin/contact-requests.ts
+++ b/src/app/_actions/admin/contact-requests.ts
@@ -54,7 +54,7 @@ export async function getContactRequests(params?: {
 
 		let query = supabase
 			.from("contact_requests")
-			.select("*")
+			.select("*", { count: "exact" })
 			.order("created_at", { ascending: false });
 
 		// フィルタリング


### PR DESCRIPTION
contact_requests と campaign_hearing_applications の一覧取得 Server Action
で `select("*")` の第二引数 `{ count: "exact" }` が抜けており、
クエリ結果の `count` が null になり、上位の `totalPages` が常に 0 になる
結果、管理画面のページネーション UI が機能していなかった。

両クエリに `{ count: "exact" }` を追加し、件数取得を有効化する。

https://claude.ai/code/session_01LBnqrayRgKawimF9np7rEE