### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -935,3 +935,31 @@ src/
 - **開発プロセスの可視化**: Issue/Research/Plan/Logにより、開発プロセス全体が可視化され、後から振り返りや引き継ぎが容易
 
 このガイドラインに従うことで、AIと人間双方にとって可読性が高く、変更に強いソフトウェア構造を実現できます。
+
+---
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Kouden (香典帳) is a Next.js 15 web application for managing funeral condolence registries. It uses Bun as runtime/package manager, Supabase for backend, and Biome for linting.
+
+### Commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `bun install` |
+| Dev server | `bun dev` (port 8788) |
+| Build | `bun run build` |
+| Lint | `bun run lint` (Biome) |
+| Unit tests | `bun run test -- --run` |
+| Storybook | `bun run storybook` (port 6006) |
+
+### Environment setup caveats
+
+- Bun must be on `$PATH`. The update script installs it to `~/.bun/bin/bun`. Source `~/.bashrc` or export `PATH="$HOME/.bun/bin:$PATH"` in your shell before running commands.
+- A `.env.local` file is required to start the dev server or run the build. Copy from `.env.example` and at minimum set `CSRF_SECRET` (generate with `openssl rand -hex 32`) and `STRIPE_SECRET_KEY` (even a placeholder like `sk_test_placeholder` suffices for local builds). The build will also fail if `GOOGLE_SERVICE_ACCOUNT_EMAIL` is unset.
+- The existing lint output has ~441 pre-existing errors (mostly `noConsoleLog` warnings in scripts and naming conventions). This is expected; do not attempt to fix them unless specifically asked.
+- Unit tests run via Vitest (`bun run test -- --run`). All 366 tests pass. The test for `survey-modal` is skipped by design.
+- The app connects to a remote Supabase instance. Most features (auth, data) require valid Supabase credentials. Without them, the landing page still renders but authenticated routes will fail.
+- Rate limiting falls back to in-memory `Map` when `UPSTASH_REDIS_REST_URL` is not set, which is fine for local dev.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -961,5 +961,5 @@ src/
 - `.env.local` ファイルが必要です。`.env.example` からコピーし、最低限 `CSRF_SECRET`（`openssl rand -hex 32` で生成）、`STRIPE_SECRET_KEY`（プレースホルダー `sk_test_placeholder` でもビルド可能）、`GOOGLE_SERVICE_ACCOUNT_EMAIL` を設定してください。また、README.md に記載の Supabase 認証情報（`NEXT_PUBLIC_SUPABASE_URL`、`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`、`SUPABASE_SECRET_KEY`）も設定が必要です。
 - `bun run lint` はプロジェクト既存のリント違反（約441件）により終了コード 1 で終了します。内訳は `noConsoleLog` や命名規則に関する警告・エラーです。これらは既知の技術的負債であり、明示的に依頼されない限り修正不要です。終了コード 1 は想定通りの動作です。
 - ユニットテストは Vitest で実行します（`bun run test -- --run`）。全366テストがパスします。`survey-modal` テストは設計上スキップされています。
-- アプリはリモートの Supabase インスタンスに接続します。認証やデータ機能には有効な Supabase 認証情報が必要です。未設定でもランディングページは表示されますが、認証が必要なルートは動作しません。
-- `UPSTASH_REDIS_REST_URL` が未設定の場合、レート制限はインメモリ `Map` にフォールバックします。ローカル開発では問題ありません。
+- Supabase 環境変数は必須です。`NEXT_PUBLIC_SUPABASE_URL` と `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` が未設定の場合、`src/lib/supabase/middleware.ts` がモジュールロード時に throw するため、アプリが正しく起動・動作しません。プレースホルダー値でもビルドと起動は可能ですが、認証やデータ機能には有効な認証情報が必要です。
+- `UPSTASH_REDIS_REST_URL` または `UPSTASH_REDIS_REST_TOKEN` が未設定の場合、もしくは Upstash への通信が失敗した場合、レート制限はインメモリ `Map` にフォールバックします。ローカル開発では問題ありません。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -940,26 +940,26 @@ src/
 
 ## Cursor Cloud specific instructions
 
-### Overview
+### 概要
 
-Kouden (香典帳) is a Next.js 15 web application for managing funeral condolence registries. It uses Bun as runtime/package manager, Supabase for backend, and Biome for linting.
+香典帳（Kouden）は葬儀・法要における香典管理のための Next.js 15 Webアプリケーションです。ランタイム/パッケージマネージャーに Bun、バックエンドに Supabase、リンターに Biome を使用しています。
 
-### Commands
+### コマンド一覧
 
-| Task | Command |
-|------|---------|
-| Install deps | `bun install` |
-| Dev server | `bun dev` (port 8788) |
-| Build | `bun run build` |
-| Lint | `bun run lint` (Biome) |
-| Unit tests | `bun run test -- --run` |
-| Storybook | `bun run storybook` (port 6006) |
+| タスク | コマンド |
+|--------|---------|
+| 依存関係インストール | `bun install` |
+| 開発サーバー起動 | `bun dev`（ポート 8788） |
+| ビルド | `bun run build` |
+| リント | `bun run lint`（Biome） |
+| ユニットテスト | `bun run test -- --run` |
+| Storybook | `bun run storybook`（ポート 6006） |
 
-### Environment setup caveats
+### 環境セットアップの注意点
 
-- Bun must be on `$PATH`. The update script installs it to `~/.bun/bin/bun`. Source `~/.bashrc` or export `PATH="$HOME/.bun/bin:$PATH"` in your shell before running commands.
-- A `.env.local` file is required to start the dev server or run the build. Copy from `.env.example` and at minimum set `CSRF_SECRET` (generate with `openssl rand -hex 32`) and `STRIPE_SECRET_KEY` (even a placeholder like `sk_test_placeholder` suffices for local builds). The build will also fail if `GOOGLE_SERVICE_ACCOUNT_EMAIL` is unset.
-- The existing lint output has ~441 pre-existing errors (mostly `noConsoleLog` warnings in scripts and naming conventions). This is expected; do not attempt to fix them unless specifically asked.
-- Unit tests run via Vitest (`bun run test -- --run`). All 366 tests pass. The test for `survey-modal` is skipped by design.
-- The app connects to a remote Supabase instance. Most features (auth, data) require valid Supabase credentials. Without them, the landing page still renders but authenticated routes will fail.
-- Rate limiting falls back to in-memory `Map` when `UPSTASH_REDIS_REST_URL` is not set, which is fine for local dev.
+- Bun が `$PATH` に含まれている必要があります。アップデートスクリプトにより `~/.bun/bin/bun` にインストールされます。コマンド実行前に `export PATH="$HOME/.bun/bin:$PATH"` を実行してください。
+- `.env.local` ファイルが必要です。`.env.example` からコピーし、最低限 `CSRF_SECRET`（`openssl rand -hex 32` で生成）、`STRIPE_SECRET_KEY`（プレースホルダー `sk_test_placeholder` でもビルド可能）、`GOOGLE_SERVICE_ACCOUNT_EMAIL` を設定してください。また、README.md に記載の Supabase 認証情報（`NEXT_PUBLIC_SUPABASE_URL`、`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`、`SUPABASE_SECRET_KEY`）も設定が必要です。
+- `bun run lint` はプロジェクト既存のリント違反（約441件）により終了コード 1 で終了します。内訳は `noConsoleLog` や命名規則に関する警告・エラーです。これらは既知の技術的負債であり、明示的に依頼されない限り修正不要です。終了コード 1 は想定通りの動作です。
+- ユニットテストは Vitest で実行します（`bun run test -- --run`）。全366テストがパスします。`survey-modal` テストは設計上スキップされています。
+- アプリはリモートの Supabase インスタンスに接続します。認証やデータ機能には有効な Supabase 認証情報が必要です。未設定でもランディングページは表示されますが、認証が必要なルートは動作しません。
+- `UPSTASH_REDIS_REST_URL` が未設定の場合、レート制限はインメモリ `Map` にフォールバックします。ローカル開発では問題ありません。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment caveats and command references for future Cloud Agent sessions.

### Changes
- Added command table (dev, build, lint, test, storybook) in Japanese for consistency with the rest of AGENTS.md
- Documented Bun PATH requirement (using direct `export` for reliability)
- Documented `.env.local` setup requirements: `CSRF_SECRET`, `STRIPE_SECRET_KEY`, `GOOGLE_SERVICE_ACCOUNT_EMAIL` for build, plus Supabase credentials for app functionality
- Clarified that Supabase env vars are mandatory (middleware throws at module load time if missing)
- Noted pre-existing lint violations (~441) and that `bun run lint` exits with code 1 by design
- Noted Vitest test suite status (366 pass, 1 skipped)
- Documented Upstash Redis fallback conditions (URL/token missing or API failure)

### Evidence of working environment

[Kouden app landing page running on localhost:8788](https://cursor.com/agents/bc-faa389b4-dbbd-40c6-91b6-a39fd0b9dbe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkouden_landing_page.webp)

Dev server running on port 8788 with full landing page rendering.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-faa389b4-dbbd-40c6-91b6-a39fd0b9dbe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-faa389b4-dbbd-40c6-91b6-a39fd0b9dbe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Cursor Cloud向け導入セクションを追加しました。Koudenの概要（Next.js 15 / Bun / Supabase / Biome前提）、実行コマンド一覧、環境変数の必須設定と注意点（BunのPATHや .env.local の扱い、Supabase認証未設定による起動時エラーや、Redis関連設定未定義時のレート制限フォールバックなど）を整理しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/otomatty/kouden/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->