### PR TITLE
fix(security): admin/announcements.ts の mutation に admin 権限チェックを追加 (#112)

### DIFF
--- a/src/app/_actions/admin/announcements.ts
+++ b/src/app/_actions/admin/announcements.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
-import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { type ActionResult, withActionResult } from "@/lib/errors";
 import { revalidatePath } from "next/cache";
 
 export type Announcement = {
@@ -20,7 +20,7 @@ export type Announcement = {
 
 export async function getAnnouncements(): Promise<ActionResult<Announcement[]>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
+		const { supabase } = await checkAdminPermission();
 		const { data, error } = await supabase
 			.from("system_announcements")
 			.select("*")
@@ -62,11 +62,7 @@ export async function createAnnouncement({
 	expiresAt?: string;
 }): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
-		const {
-			data: { user },
-		} = await supabase.auth.getUser();
-		if (!user) throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
+		const { supabase, user } = await checkAdminPermission();
 
 		const requestData = {
 			title,
@@ -113,7 +109,7 @@ export async function updateAnnouncement(
 	},
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
+		const { supabase } = await checkAdminPermission();
 		const { error } = await supabase
 			.from("system_announcements")
 			.update({
@@ -135,7 +131,7 @@ export async function updateAnnouncement(
 
 export async function deleteAnnouncement(id: string): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
+		const { supabase } = await checkAdminPermission();
 		const { error } = await supabase.from("system_announcements").delete().eq("id", id);
 
 		if (error) throw error;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import { unstable_rethrow } from "next/navigation";
 import logger from "./logger";
 
 /**
@@ -358,6 +359,9 @@ export const withErrorHandling = async <T>(
 	try {
 		return await action();
 	} catch (error) {
+		// Next.js のフレームワークエラー（redirect / notFound）は握りつぶさず再スローする。
+		// これらを KoudenError に変換するとリダイレクトが機能しなくなる。
+		unstable_rethrow(error);
 		const koudenError = KoudenError.fromSupabase(error, errorContext);
 		logKoudenError(koudenError, errorContext);
 		throw koudenError;
@@ -378,6 +382,9 @@ export const withActionResult = async <T>(
 		const data = await action();
 		return { ok: true, data };
 	} catch (error) {
+		// Next.js のフレームワークエラー（redirect / notFound）は握りつぶさず再スローする。
+		// ActionResult に変換するとリダイレクトが機能しなくなる。
+		unstable_rethrow(error);
 		const koudenError = KoudenError.fromSupabase(error, errorContext);
 		logKoudenError(koudenError, errorContext);
 		return toActionError<T>(koudenError, errorContext);


### PR DESCRIPTION
src/app/_actions/admin/announcements.ts は管理画面 (admin/announcements)
が実際に利用しているお知らせ操作 (system_announcements テーブル) だが、
admin 権限チェックが欠落していた。

- createAnnouncement は supabase.auth.getUser() でログイン確認のみ
- updateAnnouncement / deleteAnnouncement は認証チェックすら無い
- getAnnouncements も認証チェック無し

これらは Server Action として直接呼び出せるため、認証済みの任意の
ユーザー (非管理者) がお知らせの一覧取得/作成/更新/削除を行えてしまう。

入り口で checkAdminPermission() を呼び出し、admin/super_admin のみが
mutation/取得を実行できるようガードする。これは同 issue で先に修正された
_actions/announcements.ts (announcements テーブル) と同じパターン。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 管理者権限確認を統一・改善し、お知らせ機能周りの権限処理が一貫化されました。

* **Bug Fixes**
  * フレームワーク由来の例外を適切に再スローするように変更され、意図しない例外抑制が解消されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->