### PR TITLE
Add comprehensive tests for contact attachment upload

### DIFF
--- a/src/app/_actions/__tests__/contact-attachment.test.ts
+++ b/src/app/_actions/__tests__/contact-attachment.test.ts
@@ -74,6 +74,27 @@ describe("uploadContactAttachment", () => {
 		vi.mocked(validateFileUpload).mockResolvedValue({ isValid: true });
 	});
 
+	it("ファイル検証失敗時は VALIDATION_ERROR を返し upload/insert/remove を呼ばない", async () => {
+		vi.mocked(validateFileUpload).mockResolvedValue({
+			isValid: false,
+			error: "不正なファイルです",
+		});
+		const { supabase, uploadMock, insertMock, removeMock } = buildSupabaseMock();
+		// biome-ignore lint/suspicious/noExplicitAny: supabase mock shape
+		vi.mocked(createClient).mockResolvedValue(supabase as any);
+
+		const result = await uploadContactAttachment(REQUEST_ID, file);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe(ErrorCodes.VALIDATION_ERROR);
+		}
+		// 検証で弾かれるため Storage / DB 操作は一切行わない
+		expect(uploadMock).not.toHaveBeenCalled();
+		expect(insertMock).not.toHaveBeenCalled();
+		expect(removeMock).not.toHaveBeenCalled();
+	});
+
 	it("INSERT 失敗時にアップロード済みファイルを削除して孤児ファイルを残さない", async () => {
 		const { supabase, removeMock } = buildSupabaseMock({
 			insertError: { message: "insert boom", code: "23505" },

--- a/src/app/_actions/__tests__/contact-attachment.test.ts
+++ b/src/app/_actions/__tests__/contact-attachment.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest" />
+import { ErrorCodes } from "@/lib/errors";
 import { validateFileUpload } from "@/lib/security/file-upload-validation";
 import { createClient } from "@/lib/supabase/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -22,11 +23,13 @@ const REQUEST_ID = "request-1";
  * - from("contact_request_attachments"): INSERT (insert().select()) 用
  * - storage.from("contact-attachments"): upload / remove 用
  */
-function buildSupabaseMock(options: {
-	uploadError?: unknown;
-	insertError?: unknown;
-	removeError?: unknown;
-}) {
+function buildSupabaseMock(
+	options: {
+		uploadError?: unknown;
+		insertError?: unknown;
+		removeError?: unknown;
+	} = {},
+) {
 	const removeMock = vi.fn().mockResolvedValue({ error: options.removeError ?? null });
 	const uploadMock = vi.fn().mockResolvedValue({ error: options.uploadError ?? null });
 	const selectInsertMock = vi
@@ -68,16 +71,15 @@ describe("uploadContactAttachment", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(validateFileUpload as any).mockResolvedValue({ isValid: true });
+		vi.mocked(validateFileUpload).mockResolvedValue({ isValid: true });
 	});
 
 	it("INSERT 失敗時にアップロード済みファイルを削除して孤児ファイルを残さない", async () => {
 		const { supabase, removeMock } = buildSupabaseMock({
 			insertError: { message: "insert boom", code: "23505" },
 		});
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createClient as any).mockResolvedValue(supabase);
+		// biome-ignore lint/suspicious/noExplicitAny: supabase mock shape
+		vi.mocked(createClient).mockResolvedValue(supabase as any);
 
 		const result = await uploadContactAttachment(REQUEST_ID, file);
 
@@ -90,9 +92,9 @@ describe("uploadContactAttachment", () => {
 	});
 
 	it("INSERT 成功時はファイル削除を行わない", async () => {
-		const { supabase, removeMock } = buildSupabaseMock({});
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createClient as any).mockResolvedValue(supabase);
+		const { supabase, removeMock } = buildSupabaseMock();
+		// biome-ignore lint/suspicious/noExplicitAny: supabase mock shape
+		vi.mocked(createClient).mockResolvedValue(supabase as any);
 
 		const result = await uploadContactAttachment(REQUEST_ID, file);
 
@@ -104,8 +106,8 @@ describe("uploadContactAttachment", () => {
 		const { supabase, insertMock, removeMock } = buildSupabaseMock({
 			uploadError: { message: "upload boom" },
 		});
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createClient as any).mockResolvedValue(supabase);
+		// biome-ignore lint/suspicious/noExplicitAny: supabase mock shape
+		vi.mocked(createClient).mockResolvedValue(supabase as any);
 
 		const result = await uploadContactAttachment(REQUEST_ID, file);
 
@@ -119,12 +121,17 @@ describe("uploadContactAttachment", () => {
 			insertError: { message: "insert boom", code: "23505" },
 			removeError: { message: "remove boom" },
 		});
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createClient as any).mockResolvedValue(supabase);
+		// biome-ignore lint/suspicious/noExplicitAny: supabase mock shape
+		vi.mocked(createClient).mockResolvedValue(supabase as any);
 
 		const result = await uploadContactAttachment(REQUEST_ID, file);
 
 		expect(result.ok).toBe(false);
 		expect(removeMock).toHaveBeenCalledTimes(1);
+		// remove のエラー (code なし) ではなく、元の INSERT エラー (23505 → ALREADY_EXISTS)
+		// が返ることを検証してエラーの優先順位を保証する
+		if (!result.ok) {
+			expect(result.error.code).toBe(ErrorCodes.ALREADY_EXISTS);
+		}
 	});
 });

--- a/src/app/_actions/__tests__/contact-attachment.test.ts
+++ b/src/app/_actions/__tests__/contact-attachment.test.ts
@@ -23,13 +23,13 @@ const REQUEST_ID = "request-1";
  * - from("contact_request_attachments"): INSERT (insert().select()) 用
  * - storage.from("contact-attachments"): upload / remove 用
  */
-function buildSupabaseMock(
-	options: {
-		uploadError?: unknown;
-		insertError?: unknown;
-		removeError?: unknown;
-	} = {},
-) {
+interface SupabaseMockOptions {
+	uploadError?: unknown;
+	insertError?: unknown;
+	removeError?: unknown;
+}
+
+function buildSupabaseMock(options: SupabaseMockOptions = {}) {
 	const removeMock = vi.fn().mockResolvedValue({ error: options.removeError ?? null });
 	const uploadMock = vi.fn().mockResolvedValue({ error: options.uploadError ?? null });
 	const selectInsertMock = vi

--- a/src/app/_actions/__tests__/contact-attachment.test.ts
+++ b/src/app/_actions/__tests__/contact-attachment.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="vitest" />
+import { validateFileUpload } from "@/lib/security/file-upload-validation";
+import { createClient } from "@/lib/supabase/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadContactAttachment } from "../contact";
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/security/file-upload-validation", () => ({
+	validateFileUpload: vi.fn(),
+}));
+
+const USER_ID = "user-1";
+const REQUEST_ID = "request-1";
+
+/**
+ * uploadContactAttachment が依存する Supabase クライアントのモックを生成する。
+ * - auth.getUser: 認証済みユーザーを返す
+ * - from("contact_requests"): 所有者チェック (single) 用
+ * - from("contact_request_attachments"): INSERT (insert().select()) 用
+ * - storage.from("contact-attachments"): upload / remove 用
+ */
+function buildSupabaseMock(options: {
+	uploadError?: unknown;
+	insertError?: unknown;
+	removeError?: unknown;
+}) {
+	const removeMock = vi.fn().mockResolvedValue({ error: options.removeError ?? null });
+	const uploadMock = vi.fn().mockResolvedValue({ error: options.uploadError ?? null });
+	const selectInsertMock = vi
+		.fn()
+		.mockResolvedValue(
+			options.insertError
+				? { data: null, error: options.insertError }
+				: { data: [{ id: "att-1" }], error: null },
+		);
+	const insertMock = vi.fn().mockReturnValue({ select: selectInsertMock });
+
+	const ownerSingleMock = vi.fn().mockResolvedValue({ data: { user_id: USER_ID }, error: null });
+
+	const supabase = {
+		auth: {
+			getUser: vi.fn().mockResolvedValue({ data: { user: { id: USER_ID } } }),
+		},
+		from: vi.fn((table: string) => {
+			if (table === "contact_requests") {
+				return {
+					select: vi.fn().mockReturnValue({
+						eq: vi.fn().mockReturnValue({ single: ownerSingleMock }),
+					}),
+				};
+			}
+			// contact_request_attachments
+			return { insert: insertMock };
+		}),
+		storage: {
+			from: vi.fn(() => ({ upload: uploadMock, remove: removeMock })),
+		},
+	};
+
+	return { supabase, uploadMock, insertMock, selectInsertMock, removeMock };
+}
+
+describe("uploadContactAttachment", () => {
+	const file = new File(["hello"], "report.pdf", { type: "application/pdf" });
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(validateFileUpload as any).mockResolvedValue({ isValid: true });
+	});
+
+	it("INSERT 失敗時にアップロード済みファイルを削除して孤児ファイルを残さない", async () => {
+		const { supabase, removeMock } = buildSupabaseMock({
+			insertError: { message: "insert boom", code: "23505" },
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createClient as any).mockResolvedValue(supabase);
+
+		const result = await uploadContactAttachment(REQUEST_ID, file);
+
+		expect(result.ok).toBe(false);
+		// best-effort cleanup でアップロード済みファイルを削除している
+		expect(removeMock).toHaveBeenCalledTimes(1);
+		const removedPaths = removeMock.mock.calls[0]?.[0];
+		expect(Array.isArray(removedPaths)).toBe(true);
+		expect(removedPaths[0]).toContain(`requests/${REQUEST_ID}/`);
+	});
+
+	it("INSERT 成功時はファイル削除を行わない", async () => {
+		const { supabase, removeMock } = buildSupabaseMock({});
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createClient as any).mockResolvedValue(supabase);
+
+		const result = await uploadContactAttachment(REQUEST_ID, file);
+
+		expect(result.ok).toBe(true);
+		expect(removeMock).not.toHaveBeenCalled();
+	});
+
+	it("アップロード失敗時は INSERT も削除も行わない", async () => {
+		const { supabase, insertMock, removeMock } = buildSupabaseMock({
+			uploadError: { message: "upload boom" },
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createClient as any).mockResolvedValue(supabase);
+
+		const result = await uploadContactAttachment(REQUEST_ID, file);
+
+		expect(result.ok).toBe(false);
+		expect(insertMock).not.toHaveBeenCalled();
+		expect(removeMock).not.toHaveBeenCalled();
+	});
+
+	it("cleanup の remove が失敗しても元の INSERT エラーを返す", async () => {
+		const { supabase, removeMock } = buildSupabaseMock({
+			insertError: { message: "insert boom", code: "23505" },
+			removeError: { message: "remove boom" },
+		});
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createClient as any).mockResolvedValue(supabase);
+
+		const result = await uploadContactAttachment(REQUEST_ID, file);
+
+		expect(result.ok).toBe(false);
+		expect(removeMock).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
Added a comprehensive test suite for the `uploadContactAttachment` function to ensure proper error handling and cleanup behavior during file uploads.

## Key Changes
- **New test file**: `src/app/_actions/__tests__/contact-attachment.test.ts`
  - Tests the `uploadContactAttachment` function with various failure scenarios
  - Validates that orphaned files are properly cleaned up when database operations fail
  - Ensures cleanup failures don't mask the original error

## Notable Implementation Details
- **Orphan file prevention**: Verifies that when INSERT fails after a successful file upload, the uploaded file is deleted via best-effort cleanup
- **Error precedence**: Confirms that cleanup failures don't override the original INSERT error in the result
- **Upload failure handling**: Ensures that when file upload fails, no database INSERT or cleanup operations are attempted
- **Mock structure**: Comprehensive Supabase client mocking that covers auth, database operations (contact_requests and contact_request_attachments tables), and storage operations
- **File validation**: Tests include mocking of the `validateFileUpload` security function

The tests ensure data integrity by preventing orphaned files in storage when database transactions fail.

https://claude.ai/code/session_018Xpf7irc9265ajPzXQN7Xz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * コンタクト添付ファイルのアップロード処理に対する包括的なユニットテストを追加。
    - ファイル検証失敗時は処理を中断し外部操作を行わないことを確認。
    - データベース挿入失敗時は既にアップロードされたファイルを削除することを確認。
    - 挿入成功時は削除しないこと、アップロード失敗時は挿入/削除を行わないことを確認。
    - 削除失敗でも元の挿入エラーが優先して返ることを確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->