### PR TITLE
fix(security): 未使用の return-method-types mutation アクションを削除 (#119)

### DIFF
--- a/src/app/_actions/return-records/return-method-types.ts
+++ b/src/app/_actions/return-records/return-method-types.ts
@@ -5,49 +5,9 @@
  * @module return-method-types
  */
 
-import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
+import { type ActionResult, withActionResult } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
-import type {
-	CreateReturnMethodTypeInput,
-	ReturnMethodType,
-	UpdateReturnMethodTypeInput,
-} from "@/types/return-records/return-method-types";
-import { revalidatePath } from "next/cache";
-
-/**
- * 返礼方法種別を作成する
- */
-export async function createReturnMethodType(
-	input: CreateReturnMethodTypeInput,
-): Promise<ActionResult<ReturnMethodType>> {
-	return withActionResult(async () => {
-		const supabase = await createClient();
-		const {
-			data: { user },
-		} = await supabase.auth.getUser();
-		if (!user) {
-			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
-		}
-
-		const { data, error } = await supabase
-			.from("return_method_types")
-			.insert({ ...input, created_by: user.id })
-			.select("*")
-			.single();
-
-		if (error) {
-			throw error;
-		}
-
-		if (!data) {
-			throw new KoudenError("返礼方法種別の作成に失敗しました", ErrorCodes.DB_INSERT_ERROR);
-		}
-
-		revalidatePath("/settings/return-method-types");
-
-		return data as ReturnMethodType;
-	}, "返礼方法種別の作成");
-}
+import type { ReturnMethodType } from "@/types/return-records/return-method-types";
 
 /**
  * 返礼方法種別一覧を取得する
@@ -88,51 +48,4 @@ export async function getReturnMethodType(
 
 		return data as ReturnMethodType | null;
 	}, "返礼方法種別の取得");
-}
-
-/**
- * 返礼方法種別を更新する
- */
-export async function updateReturnMethodType(
-	input: UpdateReturnMethodTypeInput,
-): Promise<ActionResult<ReturnMethodType>> {
-	return withActionResult(async () => {
-		const supabase = await createClient();
-		const { id, ...updateData } = input;
-		const { data, error } = await supabase
-			.from("return_method_types")
-			.update(updateData)
-			.eq("id", id)
-			.select("*")
-			.single();
-
-		if (error) {
-			throw error;
-		}
-
-		if (!data) {
-			throw new KoudenError("返礼方法種別の更新に失敗しました", ErrorCodes.DB_UPDATE_ERROR);
-		}
-
-		revalidatePath("/settings/return-method-types");
-
-		return data as ReturnMethodType;
-	}, "返礼方法種別の更新");
-}
-
-/**
- * 返礼方法種別を削除する
- */
-export async function deleteReturnMethodType(id: string): Promise<ActionResult<null>> {
-	return withActionResult(async () => {
-		const supabase = await createClient();
-		const { error } = await supabase.from("return_method_types").delete().eq("id", id);
-
-		if (error) {
-			throw error;
-		}
-
-		revalidatePath("/settings/return-method-types");
-		return null;
-	}, "返礼方法種別の削除");
 }

--- a/src/types/return-records/return-method-types.ts
+++ b/src/types/return-records/return-method-types.ts
@@ -30,23 +30,3 @@ export interface ReturnMethodType extends ReturnMethodTypeBase {
 	updated_at: string;
 }
 
-/**
- * 返礼方法種別作成時の入力型
- */
-export type CreateReturnMethodTypeInput = ReturnMethodTypeBase;
-
-/**
- * 返礼方法種別更新時の入力型
- */
-export interface UpdateReturnMethodTypeInput {
-	/** 返礼方法種別ID */
-	id: string;
-	/** 返礼方法名 */
-	name?: string;
-	/** 返礼方法の説明 */
-	description?: string | null;
-	/** 項目必須フラグ */
-	is_item_required?: boolean;
-	/** 表示順 */
-	sort_order?: number | null;
-}


### PR DESCRIPTION
return_method_types は kouden_id を持たないグローバルマスタテーブルで、
checkKoudenPermission を適用できない。さらに create/update/delete の
呼び出し元がコードベースに存在せず、未使用の Server Action が無防備な
mutation 攻撃面として残っていた。

- createReturnMethodType / updateReturnMethodType / deleteReturnMethodType
  を削除し、入口の無認可 mutation 経路を除去
- 併せて未使用になった CreateReturnMethodTypeInput /
  UpdateReturnMethodTypeInput 型を削除
- 読み取り系 (getReturnMethodTypes / getReturnMethodType) は維持

issue #119 の他ファイル (return-items / return-record-selected-methods /
return-record-items) は PR #128 で対応済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能削除**
  * 返礼方法種別の作成・更新・削除操作を削除しました。
  * 返礼方法種別の取得機能は引き続き利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->