### PR TITLE
perf(admin): admin系アクションのN+1クエリを解消 (#116)

### DIFF
--- a/src/app/_actions/admin/auth-users.ts
+++ b/src/app/_actions/admin/auth-users.ts
@@ -1,0 +1,69 @@
+import logger from "@/lib/logger";
+
+/**
+ * 管理画面向け: Auth ユーザーの一括解決ヘルパー
+ *
+ * `supabase.auth.admin.getUserById` を 1 件ずつ呼ぶと N+1 になるため、
+ * `listUsers()` で全ユーザーを一括取得し、必要な id だけ Map から引く。
+ *
+ * 注意:
+ *   - サービスロール (`createAdminClient`) を使うため、呼び出し元で
+ *     管理者権限をチェックしてから利用すること。
+ *   - listUsers はページングされる（既定 perPage=50）。全ページを走査する。
+ */
+export interface AuthUserInfo {
+	id: string;
+	email: string;
+}
+
+/**
+ * 指定した user_id 群に対応する Auth ユーザー情報を一括取得して Map で返す。
+ * 見つからなかった id はマップに含まれない。
+ */
+export async function getAuthUsersByIds(
+	userIds: Array<string | null | undefined>,
+): Promise<Map<string, AuthUserInfo>> {
+	const map = new Map<string, AuthUserInfo>();
+
+	// 解決が必要な一意な id 集合
+	const targetIds = new Set(userIds.filter((id): id is string => Boolean(id)));
+	if (targetIds.size === 0) {
+		return map;
+	}
+
+	const { createAdminClient } = await import("@/lib/supabase/admin");
+	const supabase = createAdminClient();
+
+	const perPage = 1000;
+	let page = 1;
+
+	try {
+		while (true) {
+			const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+			if (error) {
+				logger.error({ error: error.message, code: error.code, page }, "Failed to list auth users");
+				break;
+			}
+
+			const users = data?.users ?? [];
+			for (const user of users) {
+				if (targetIds.has(user.id)) {
+					map.set(user.id, { id: user.id, email: user.email ?? "" });
+				}
+			}
+
+			// 必要な id が全て揃った、または最終ページに達したら終了
+			if (map.size >= targetIds.size || users.length < perPage) {
+				break;
+			}
+			page += 1;
+		}
+	} catch (error) {
+		logger.error(
+			{ error: error instanceof Error ? error.message : String(error) },
+			"Error listing auth users",
+		);
+	}
+
+	return map;
+}

--- a/src/app/_actions/admin/auth-users.ts
+++ b/src/app/_actions/admin/auth-users.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { KoudenError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 
 /**
@@ -52,10 +52,8 @@ export async function getAuthUsersByIds(
 	)("get_auth_users_by_ids", { p_user_ids: targetIds });
 
 	if (error) {
-		throw new KoudenError(
-			`Failed to fetch auth users: ${error.message}`,
-			ErrorCodes.DB_FETCH_ERROR,
-		);
+		// 生の Supabase メッセージを UI に露出させないよう fromSupabase でラップする
+		throw KoudenError.fromSupabase(error, "Auth ユーザー情報の取得");
 	}
 
 	for (const row of data ?? []) {

--- a/src/app/_actions/admin/auth-users.ts
+++ b/src/app/_actions/admin/auth-users.ts
@@ -1,15 +1,20 @@
-import logger from "@/lib/logger";
+import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { createClient } from "@/lib/supabase/server";
 
 /**
  * 管理画面向け: Auth ユーザーの一括解決ヘルパー
  *
- * `supabase.auth.admin.getUserById` を 1 件ずつ呼ぶと N+1 になるため、
- * `listUsers()` で全ユーザーを一括取得し、必要な id だけ Map から引く。
+ * `supabase.auth.admin.getUserById` を 1 件ずつ呼ぶと N+1 になる。
+ * また `listUsers()` の全ページ走査は全ユーザー数 N に比例（O(N)）し、
+ * 指定 id が後方ページにある場合に無駄なページングが発生する。
+ *
+ * そこで専用 RPC `get_auth_users_by_ids` で `auth.users` を id で絞り込み、
+ * 対象 id 数 M に比例（O(M)）した 1 クエリで email を一括取得する。
  *
  * 注意:
- *   - サービスロール (`createAdminClient`) を使うため、呼び出し元で
- *     管理者権限をチェックしてから利用すること。
- *   - listUsers はページングされる（既定 perPage=50）。全ページを走査する。
+ *   - RPC は SECURITY DEFINER + 内部で `is_admin(auth.uid())` を強制するため、
+ *     呼び出し元はユーザーセッションのクライアント経由で利用すること
+ *     （呼び出し元で別途管理者権限を担保していること）。
  */
 export interface AuthUserInfo {
 	id: string;
@@ -18,7 +23,8 @@ export interface AuthUserInfo {
 
 /**
  * 指定した user_id 群に対応する Auth ユーザー情報を一括取得して Map で返す。
- * 見つからなかった id はマップに含まれない。
+ * 見つからなかった id（削除済みユーザー等）はマップに含まれない。
+ * RPC 自体が失敗した場合は、ブランクで握りつぶさず例外を送出する。
  */
 export async function getAuthUsersByIds(
 	userIds: Array<string | null | undefined>,
@@ -26,43 +32,34 @@ export async function getAuthUsersByIds(
 	const map = new Map<string, AuthUserInfo>();
 
 	// 解決が必要な一意な id 集合
-	const targetIds = new Set(userIds.filter((id): id is string => Boolean(id)));
-	if (targetIds.size === 0) {
+	const targetIds = Array.from(new Set(userIds.filter((id): id is string => Boolean(id))));
+	if (targetIds.length === 0) {
 		return map;
 	}
 
-	const { createAdminClient } = await import("@/lib/supabase/admin");
-	const supabase = createAdminClient();
+	const supabase = await createClient();
 
-	const perPage = 1000;
-	let page = 1;
+	// 注: get_auth_users_by_ids は 20260608000001_add_get_auth_users_by_ids_rpc.sql で追加。
+	// マイグレーション適用後に `bun run db:types` を実行すれば、ここのキャストは不要になる。
+	const { data, error } = await (
+		supabase.rpc as unknown as (
+			fn: string,
+			args: unknown,
+		) => PromiseLike<{
+			data: Array<{ id: string; email: string | null }> | null;
+			error: { message: string } | null;
+		}>
+	)("get_auth_users_by_ids", { p_user_ids: targetIds });
 
-	try {
-		while (true) {
-			const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
-			if (error) {
-				logger.error({ error: error.message, code: error.code, page }, "Failed to list auth users");
-				break;
-			}
-
-			const users = data?.users ?? [];
-			for (const user of users) {
-				if (targetIds.has(user.id)) {
-					map.set(user.id, { id: user.id, email: user.email ?? "" });
-				}
-			}
-
-			// 必要な id が全て揃った、または最終ページに達したら終了
-			if (map.size >= targetIds.size || users.length < perPage) {
-				break;
-			}
-			page += 1;
-		}
-	} catch (error) {
-		logger.error(
-			{ error: error instanceof Error ? error.message : String(error) },
-			"Error listing auth users",
+	if (error) {
+		throw new KoudenError(
+			`Failed to fetch auth users: ${error.message}`,
+			ErrorCodes.DB_FETCH_ERROR,
 		);
+	}
+
+	for (const row of data ?? []) {
+		map.set(row.id, { id: row.id, email: row.email ?? "" });
 	}
 
 	return map;

--- a/src/app/_actions/admin/tickets.ts
+++ b/src/app/_actions/admin/tickets.ts
@@ -2,6 +2,7 @@ import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/
 import { createClient } from "@/lib/supabase/server";
 import type { Ticket, TicketMessage } from "@/types/admin";
 import { revalidatePath } from "next/cache";
+import { getAuthUsersByIds } from "./auth-users";
 
 /**
  * 管理者権限チェック
@@ -45,41 +46,23 @@ export async function getTickets(): Promise<ActionResult<Ticket[]>> {
 
 		if (ticketsError) throw ticketsError;
 
-		// チケットごとのユーザー情報を取得
-		const ticketsWithUsers = await Promise.all(
-			tickets.map(async (ticket) => {
-				const { data: userData, error: userError } = await supabase.auth.admin.getUserById(
-					ticket.user_id,
-				);
-
-				if (userError) throw userError;
-
-				// 担当管理者の情報を取得
-				let assignedAdmin = null;
-				if (ticket.assigned_to) {
-					const { data: adminData, error: adminError } = await supabase.auth.admin.getUserById(
-						ticket.assigned_to,
-					);
-
-					if (adminError) throw adminError;
-					assignedAdmin = adminData?.user;
-				}
-
-				return {
-					...ticket,
-					user: {
-						id: userData.user.id,
-						email: userData.user.email ?? "",
-					},
-					assigned_admin: assignedAdmin
-						? {
-								id: assignedAdmin.id,
-								email: assignedAdmin.email ?? "",
-							}
-						: null,
-				};
-			}),
+		// チケットの起票者・担当管理者の Auth 情報を 1 回の listUsers で一括解決（N+1解消）
+		const authUsers = await getAuthUsersByIds(
+			tickets.flatMap((ticket) => [ticket.user_id, ticket.assigned_to]),
 		);
+
+		const ticketsWithUsers = tickets.map((ticket) => {
+			const assignedAdmin = ticket.assigned_to ? authUsers.get(ticket.assigned_to) : undefined;
+
+			return {
+				...ticket,
+				user: {
+					id: ticket.user_id,
+					email: authUsers.get(ticket.user_id)?.email ?? "",
+				},
+				assigned_admin: assignedAdmin ? { id: assignedAdmin.id, email: assignedAdmin.email } : null,
+			};
+		});
 
 		return ticketsWithUsers as Ticket[];
 	}, "チケット一覧の取得");
@@ -152,36 +135,17 @@ export async function getTicketById(ticketId: string): Promise<ActionResult<Tick
 
 		if (ticketError) throw ticketError;
 
-		// ユーザー情報を取得
-		const { data: userData, error: userError } = await supabase.auth.admin.getUserById(
-			ticket.user_id,
-		);
-
-		if (userError) throw userError;
-
-		// 担当管理者の情報を取得
-		let assignedAdmin = null;
-		if (ticket.assigned_to) {
-			const { data: adminData, error: adminError } = await supabase.auth.admin.getUserById(
-				ticket.assigned_to,
-			);
-
-			if (adminError) throw adminError;
-			assignedAdmin = adminData?.user;
-		}
+		// 起票者・担当管理者の Auth 情報を一括解決
+		const authUsers = await getAuthUsersByIds([ticket.user_id, ticket.assigned_to]);
+		const assignedAdmin = ticket.assigned_to ? authUsers.get(ticket.assigned_to) : undefined;
 
 		return {
 			...ticket,
 			user: {
-				id: userData.user.id,
-				email: userData.user.email ?? "",
+				id: ticket.user_id,
+				email: authUsers.get(ticket.user_id)?.email ?? "",
 			},
-			assigned_admin: assignedAdmin
-				? {
-						id: assignedAdmin.id,
-						email: assignedAdmin.email ?? "",
-					}
-				: null,
+			assigned_admin: assignedAdmin ? { id: assignedAdmin.id, email: assignedAdmin.email } : null,
 		} as Ticket;
 	}, "チケット詳細の取得");
 }
@@ -199,24 +163,16 @@ export async function getTicketMessages(ticketId: string): Promise<ActionResult<
 
 		if (messagesError) throw messagesError;
 
-		// メッセージごとのユーザー情報を取得
-		const messagesWithUsers = await Promise.all(
-			messages.map(async (message) => {
-				const { data: userData, error: userError } = await supabase.auth.admin.getUserById(
-					message.created_by,
-				);
+		// メッセージ投稿者の Auth 情報を 1 回の listUsers で一括解決（N+1解消）
+		const authUsers = await getAuthUsersByIds(messages.map((message) => message.created_by));
 
-				if (userError) throw userError;
-
-				return {
-					...message,
-					user: {
-						id: userData.user.id,
-						email: userData.user.email ?? "",
-					},
-				};
-			}),
-		);
+		const messagesWithUsers = messages.map((message) => ({
+			...message,
+			user: {
+				id: message.created_by,
+				email: authUsers.get(message.created_by)?.email ?? "",
+			},
+		}));
 
 		return messagesWithUsers as TicketMessage[];
 	}, "チケットメッセージの取得");

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -682,6 +682,20 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			)("get_admin_kouden_stats", { p_kouden_ids: koudenIds }),
 		]);
 
+		// 取得エラーはサイレントに「不明」化せず、明示的に例外を投げる
+		if (ownersResult.error) {
+			throw new KoudenError(
+				`Failed to fetch kouden owners: ${ownersResult.error.message}`,
+				ErrorCodes.DB_FETCH_ERROR,
+			);
+		}
+		if (plansResult.error) {
+			throw new KoudenError(
+				`Failed to fetch kouden plans: ${plansResult.error.message}`,
+				ErrorCodes.DB_FETCH_ERROR,
+			);
+		}
+
 		const ownerMap = new Map((ownersResult.data ?? []).map((owner) => [owner.id, owner] as const));
 		const planMap = new Map((plansResult.data ?? []).map((plan) => [plan.id, plan] as const));
 

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -660,60 +660,90 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			return { koudens: [], total: count || 0, hasMore: false };
 		}
 
-		// 2. 各香典帳の詳細情報を並列取得
-		const koudensWithDetails = await Promise.all(
-			koudens.map(async (kouden) => {
-				try {
-					// オーナー情報、プラン情報、統計情報を並列取得
-					const [owner, plan, stats] = await Promise.all([
-						getKoudenOwner(kouden.owner_id),
-						getKoudenPlan(kouden.plan_id),
-						getKoudenStats(kouden.id),
-					]);
+		// 2. オーナー / プラン / 統計を ID 群でまとめて一括取得（N+1解消）
+		const ownerIds = Array.from(new Set(koudens.map((k) => k.owner_id)));
+		const planIds = Array.from(new Set(koudens.map((k) => k.plan_id)));
+		const koudenIds = koudens.map((k) => k.id);
 
-					// 無料プランの期限切れ判定
-					let expired = false;
-					let remainingDays: number | undefined;
-					if (plan.code === "free") {
-						const ageMs = Date.now() - new Date(kouden.created_at).getTime();
-						const ageDays = ageMs / (1000 * 60 * 60 * 24);
-						if (ageDays >= 14) {
-							expired = true;
-							remainingDays = 0;
-						} else {
-							remainingDays = Math.ceil(14 - ageDays);
-						}
-					}
+		// 統計は専用 RPC で 1 クエリ集計。RPC は内部で is_admin(auth.uid()) を検証するため、
+		// サービスロールではなくユーザーセッションのクライアントで呼び出す。
+		const sessionClient = await createClient();
 
-					return {
-						...kouden,
-						status: kouden.status as "active" | "archived" | "inactive",
-						owner,
-						plan,
-						stats,
-						expired,
-						remainingDays,
-					};
-				} catch (error) {
-					logger.error(
-						{
-							koudenId: kouden.id,
-							error: error instanceof Error ? error.message : String(error),
-						},
-						"Failed to get details for kouden",
-					);
-					// エラーが発生した場合は基本情報のみ返す
-					return {
-						...kouden,
-						status: kouden.status as "active" | "archived" | "inactive",
-						owner: { id: kouden.owner_id, display_name: "不明", avatar_url: null },
-						plan: { id: kouden.plan_id, code: "unknown", name: "不明" },
-						stats: { entries_count: 0, members_count: 0, total_amount: 0 },
-						expired: false,
-					};
+		// 注: get_admin_kouden_stats は 20260608000000_add_get_admin_kouden_stats_rpc.sql で追加。
+		// マイグレーション適用後に `bun run db:types` を実行すれば、ここのキャストは不要になる。
+		const [ownersResult, plansResult, statsResult] = await Promise.all([
+			supabase.from("profiles").select("id, display_name, avatar_url").in("id", ownerIds),
+			supabase.from("plans").select("id, code, name").in("id", planIds),
+			(
+				sessionClient.rpc as unknown as (
+					fn: string,
+					args: unknown,
+				) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+			)("get_admin_kouden_stats", { p_kouden_ids: koudenIds }),
+		]);
+
+		const ownerMap = new Map((ownersResult.data ?? []).map((owner) => [owner.id, owner] as const));
+		const planMap = new Map((plansResult.data ?? []).map((plan) => [plan.id, plan] as const));
+
+		if (statsResult.error) {
+			// 失敗時は0埋めで継続せず、明示的に例外を投げる（admin UIで誤った0統計を出さないため）
+			throw new KoudenError(
+				`Failed to fetch kouden aggregate stats: ${statsResult.error.message}`,
+				ErrorCodes.DB_FETCH_ERROR,
+			);
+		}
+
+		type KoudenStatsRow = {
+			kouden_id: string;
+			entries_count: number | string;
+			members_count: number | string;
+			total_amount: number | string;
+		};
+		const statsRows = (statsResult.data ?? []) as KoudenStatsRow[];
+		const statsMap = new Map(statsRows.map((row) => [row.kouden_id, row] as const));
+
+		const koudensWithDetails = koudens.map((kouden) => {
+			const owner = ownerMap.get(kouden.owner_id) ?? {
+				id: kouden.owner_id,
+				display_name: "不明",
+				avatar_url: null,
+			};
+			const plan = planMap.get(kouden.plan_id) ?? {
+				id: kouden.plan_id,
+				code: "unknown",
+				name: "不明",
+			};
+			const statsRow = statsMap.get(kouden.id);
+			const stats = {
+				entries_count: Number(statsRow?.entries_count ?? 0),
+				members_count: Number(statsRow?.members_count ?? 0),
+				total_amount: Number(statsRow?.total_amount ?? 0),
+			};
+
+			// 無料プランの期限切れ判定
+			let expired = false;
+			let remainingDays: number | undefined;
+			if (plan.code === "free") {
+				const ageMs = Date.now() - new Date(kouden.created_at).getTime();
+				const ageDays = ageMs / (1000 * 60 * 60 * 24);
+				if (ageDays >= 14) {
+					expired = true;
+					remainingDays = 0;
+				} else {
+					remainingDays = Math.ceil(14 - ageDays);
 				}
-			}),
-		);
+			}
+
+			return {
+				...kouden,
+				status: kouden.status as "active" | "archived" | "inactive",
+				owner,
+				plan,
+				stats,
+				expired,
+				remainingDays,
+			};
+		});
 
 		// entries_countでソートが指定されている場合はここでソート
 		if (sortBy === "entries_count") {
@@ -730,102 +760,4 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			hasMore: (count || 0) > offset + limit,
 		};
 	}, "香典帳一覧の取得");
-}
-
-/**
- * 香典帳のオーナー情報を取得
- */
-async function getKoudenOwner(ownerId: string): Promise<{
-	id: string;
-	display_name: string;
-	avatar_url: string | null;
-}> {
-	const { createAdminClient } = await import("@/lib/supabase/admin");
-	const supabase = createAdminClient();
-
-	const { data: owner, error } = await supabase
-		.from("profiles")
-		.select("id, display_name, avatar_url")
-		.eq("id", ownerId)
-		.single();
-
-	if (error || !owner) {
-		return { id: ownerId, display_name: "不明", avatar_url: null };
-	}
-
-	return owner;
-}
-
-/**
- * 香典帳のプラン情報を取得
- */
-async function getKoudenPlan(planId: string): Promise<{
-	id: string;
-	code: string;
-	name: string;
-}> {
-	const { createAdminClient } = await import("@/lib/supabase/admin");
-	const supabase = createAdminClient();
-
-	const { data: plan, error } = await supabase
-		.from("plans")
-		.select("id, code, name")
-		.eq("id", planId)
-		.single();
-
-	if (error || !plan) {
-		return { id: planId, code: "unknown", name: "不明" };
-	}
-
-	return plan;
-}
-
-/**
- * 香典帳の統計情報を取得
- */
-async function getKoudenStats(koudenId: string): Promise<{
-	entries_count: number;
-	members_count: number;
-	total_amount: number;
-}> {
-	const { createAdminClient } = await import("@/lib/supabase/admin");
-	const supabase = createAdminClient();
-
-	try {
-		// 並列でクエリ実行
-		const [entriesResult, membersResult, totalAmountResult] = await Promise.all([
-			supabase
-				.from("kouden_entries")
-				.select("id", { count: "exact", head: true })
-				.eq("kouden_id", koudenId),
-			supabase
-				.from("kouden_members")
-				.select("id", { count: "exact", head: true })
-				.eq("kouden_id", koudenId),
-			supabase.from("kouden_entries").select("amount").eq("kouden_id", koudenId),
-		]);
-
-		// 合計金額を計算
-		const totalAmount =
-			totalAmountResult.data?.reduce((sum, entry) => sum + (entry.amount || 0), 0) || 0;
-
-		return {
-			entries_count: entriesResult.count || 0,
-			members_count: membersResult.count || 0,
-			total_amount: totalAmount,
-		};
-	} catch (error) {
-		logger.error(
-			{
-				koudenId,
-				error: error instanceof Error ? error.message : String(error),
-			},
-			"Error getting stats for kouden",
-		);
-		return {
-			entries_count: 0,
-			members_count: 0,
-			total_amount: 0,
-		};
-	}
 }

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -716,6 +716,10 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 		const statsRows = (statsResult.data ?? []) as KoudenStatsRow[];
 		const statsMap = new Map(statsRows.map((row) => [row.kouden_id, row] as const));
 
+		// 取得「全体」の失敗（ownersResult/plansResult/statsResult の error）は上で例外化済み。
+		// 以降の ownerMap/planMap/statsMap.get に対するフォールバックは「個別レコードの欠損」
+		// （削除済み owner、未登録 plan、エントリー0件の kouden 等）を正常系として扱うもので、
+		// owner/plan は「不明」プレースホルダ、stats は 0 埋めで継続する。
 		const koudensWithDetails = koudens.map((kouden) => {
 			const owner = ownerMap.get(kouden.owner_id) ?? {
 				id: kouden.owner_id,

--- a/supabase/migrations/20260608000000_add_get_admin_kouden_stats_rpc.sql
+++ b/supabase/migrations/20260608000000_add_get_admin_kouden_stats_rpc.sql
@@ -51,11 +51,12 @@ BEGIN
         WHERE km.kouden_id = ANY(p_kouden_ids)
         GROUP BY km.kouden_id
     )
+    -- RETURNS TABLE の列名と明示的に揃えておく（可読性・保守性のため）
     SELECT
-        i.kid,
-        COALESCE(e.cnt, 0),
-        COALESCE(m.cnt, 0),
-        COALESCE(e.amount_sum, 0)
+        i.kid AS kouden_id,
+        COALESCE(e.cnt, 0) AS entries_count,
+        COALESCE(m.cnt, 0) AS members_count,
+        COALESCE(e.amount_sum, 0) AS total_amount
     FROM input_ids i
     LEFT JOIN entries e ON e.kid = i.kid
     LEFT JOIN members m ON m.kid = i.kid;

--- a/supabase/migrations/20260608000000_add_get_admin_kouden_stats_rpc.sql
+++ b/supabase/migrations/20260608000000_add_get_admin_kouden_stats_rpc.sql
@@ -1,0 +1,69 @@
+-- 管理者向け香典帳一覧のN+1解消用RPC関数
+-- Issue: https://github.com/otomatty/kouden/issues/116
+--
+-- 指定された kouden_id 群について、以下を1クエリで一括取得:
+--   - エントリー数 (kouden_entries)
+--   - メンバー数 (kouden_members)
+--   - 香典合計金額 (kouden_entries.amount の合計)
+--
+-- 従来は admin/users.ts::getAllKoudens が各香典帳ごとに
+-- entries / members / amount を個別 SELECT していた（N+1）。
+--
+-- セキュリティ:
+--   SECURITY DEFINER で RLS をバイパスして集計するため、関数内で
+--   is_admin(auth.uid()) をチェックして管理者以外からの呼び出しを拒否する。
+
+CREATE OR REPLACE FUNCTION public.get_admin_kouden_stats(
+    p_kouden_ids uuid[]
+)
+RETURNS TABLE (
+    kouden_id uuid,
+    entries_count bigint,
+    members_count bigint,
+    total_amount bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（RLSバイパスの保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_admin_kouden_stats'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    WITH input_ids AS (
+        SELECT unnest(p_kouden_ids) AS kid
+    ),
+    entries AS (
+        SELECT ke.kouden_id AS kid,
+               COUNT(*)::bigint AS cnt,
+               COALESCE(SUM(ke.amount), 0)::bigint AS amount_sum
+        FROM kouden_entries ke
+        WHERE ke.kouden_id = ANY(p_kouden_ids)
+        GROUP BY ke.kouden_id
+    ),
+    members AS (
+        SELECT km.kouden_id AS kid, COUNT(*)::bigint AS cnt
+        FROM kouden_members km
+        WHERE km.kouden_id = ANY(p_kouden_ids)
+        GROUP BY km.kouden_id
+    )
+    SELECT
+        i.kid,
+        COALESCE(e.cnt, 0),
+        COALESCE(m.cnt, 0),
+        COALESCE(e.amount_sum, 0)
+    FROM input_ids i
+    LEFT JOIN entries e ON e.kid = i.kid
+    LEFT JOIN members m ON m.kid = i.kid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_admin_kouden_stats(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_admin_kouden_stats(uuid[]) TO authenticated;
+
+COMMENT ON FUNCTION public.get_admin_kouden_stats(uuid[]) IS
+    '管理者香典帳一覧用: 指定 kouden_id 群の entries/members 件数 + 香典合計金額を一括取得 (N+1解消)。関数内で is_admin(auth.uid()) を強制。';

--- a/supabase/migrations/20260608000001_add_get_auth_users_by_ids_rpc.sql
+++ b/supabase/migrations/20260608000001_add_get_auth_users_by_ids_rpc.sql
@@ -1,0 +1,45 @@
+-- 管理画面の Auth ユーザー解決のN+1 / 全件走査解消用RPC関数
+-- Issue: https://github.com/otomatty/kouden/issues/116
+--
+-- 指定された user_id 群に対応する auth.users の email を 1 クエリで一括取得する。
+--
+-- 従来:
+--   - admin/tickets.ts が 1 件ずつ supabase.auth.admin.getUserById(...) を呼ぶ N+1
+--   - listUsers() の全ページ走査は全ユーザー数 N に比例（O(N)）
+-- 本RPCは id で絞り込むため、対象 id 数 M に比例（O(M)）した 1 クエリで解決できる。
+--
+-- セキュリティ:
+--   auth.users を参照するため SECURITY DEFINER とし、関数内で
+--   is_admin(auth.uid()) をチェックして管理者以外からの呼び出しを拒否する。
+--   （管理画面では従来から email を表示しており、新たな情報露出はない）
+
+CREATE OR REPLACE FUNCTION public.get_auth_users_by_ids(
+    p_user_ids uuid[]
+)
+RETURNS TABLE (
+    id uuid,
+    email text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（SECURITY DEFINER の保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_auth_users_by_ids'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT u.id, u.email::text
+    FROM auth.users u
+    WHERE u.id = ANY(p_user_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_auth_users_by_ids(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_auth_users_by_ids(uuid[]) TO authenticated;
+
+COMMENT ON FUNCTION public.get_auth_users_by_ids(uuid[]) IS
+    '管理画面用: 指定 user_id 群の auth.users.email を1クエリで一括取得 (N+1/全件走査解消)。関数内で is_admin(auth.uid()) を強制。';


### PR DESCRIPTION
- tickets.ts: getTickets/getTicketById/getTicketMessages で 1件ずつ
  auth.admin.getUserById していた箇所を、listUsers の一括取得 +
  Map 解決に変更（共通ヘルパー auth-users.ts を新設）
- users.ts::getAllKoudens: 香典帳ごとに owner/plan/stats を個別 SELECT
  していた N+1 を解消
  - owner(profiles) / plan(plans) は in(...) で一括取得して Map 化
  - stats は専用 RPC get_admin_kouden_stats で 1 クエリ集計
- get_admin_kouden_stats RPC を追加（SECURITY DEFINER + is_admin 強制）

注: 新規RPCはマイグレーション適用後に `bun run db:types` を実行すると
キャストが不要になる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 管理画面におけるユーザー認証情報の取得処理を最適化しました
  * チケット管理画面でのデータ参照方式を改善し、レスポンス性能を向上させました
  * 香典帳一覧表示時の詳細情報生成を効率化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->