### PR TITLE
fix: acceptInvitation を RPC でアトミック化 (#113)

### DIFF
--- a/src/app/_actions/invitations.ts
+++ b/src/app/_actions/invitations.ts
@@ -180,6 +180,31 @@ export async function getInvitation(token: string): Promise<ActionResult<Invitat
 	}, "招待情報の取得");
 }
 
+/**
+ * `accept_invitation_atomic` RPC が raise するメッセージトークンを
+ * `KoudenError` にマップする。RPC 内で `select ... for update` により
+ * 検証〜INSERT〜used_count 更新を 1 トランザクションで実行するため、
+ * 既存のエラーコード (NOT_FOUND / ALREADY_EXISTS / INVALID_OPERATION) は
+ * ここで再現する。マップに無いエラーは withActionResult 側で
+ * KoudenError.fromSupabase により変換させる (null を返す)。
+ */
+function mapAcceptInvitationRpcError(rpcError: PostgrestError): KoudenError | null {
+	switch (rpcError.message) {
+		case "invitation_not_found":
+			return new KoudenError("招待が見つかりません", ErrorCodes.NOT_FOUND);
+		case "invitation_not_pending":
+			return new KoudenError("この招待は既に使用されています", ErrorCodes.INVALID_OPERATION);
+		case "invitation_expired":
+			return new KoudenError("招待の有効期限が切れています", ErrorCodes.INVALID_OPERATION);
+		case "invitation_max_uses_reached":
+			return new KoudenError("招待の使用回数が上限に達しました", ErrorCodes.INVALID_OPERATION);
+		case "already_member":
+			return new KoudenError("すでにメンバーとして参加しています", ErrorCodes.ALREADY_EXISTS);
+		default:
+			return null;
+	}
+}
+
 export async function acceptInvitation(token: string): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
 		// 入力検証: UUID 以外は弾く
@@ -198,102 +223,39 @@ export async function acceptInvitation(token: string): Promise<ActionResult<null
 			throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 以降は service-role で操作する:
-		// - kouden_invitations は RLS で匿名/他人からのSELECTを禁止しているため admin で参照
-		// - kouden_members への INSERT は所有者のみ許可するポリシーに変更したため
-		//   招待経由の自分自身の追加もサーバー側で検証してから admin で実施する
+		// 招待の検証・メンバー追加・used_count 更新は RPC でアトミックに行う。
+		// 非アトミックに展開すると、max_uses 制限のある招待が並列受諾で上限超過
+		// する競合が成立するため (issue #113)。
+		//
+		// service-role で呼び出す:
+		// - kouden_invitations は RLS で匿名/他人からの SELECT を禁止している
+		// - kouden_members への INSERT は所有者のみ許可するポリシーのため、招待
+		//   経由の自分自身の追加もサーバー側で検証してから admin で実施する
+		// RPC 内では auth.uid() が取れない (service-role セッション) ため、
+		// 通常クライアントで検証した user.id を渡す。
 		const supabase = createAdminClient();
 
-		// 1. 招待情報を取得
-		const { data: invitation, error: invitationError } = await supabase
-			.from("kouden_invitations")
-			.select("*")
-			.eq("invitation_token", parsedToken.data)
-			.single();
-
-		if (invitationError) {
-			if (invitationError.code === "PGRST116") {
-				throw new KoudenError("招待が見つかりません", ErrorCodes.NOT_FOUND);
-			}
-			throw invitationError;
-		}
-
-		if (!invitation) {
-			throw new KoudenError("招待が見つかりません", ErrorCodes.NOT_FOUND);
-		}
-
-		// 2. 招待の有効性チェック
-		if (invitation.status !== "pending") {
-			throw new KoudenError("この招待は既に使用されています", ErrorCodes.INVALID_OPERATION);
-		}
-
-		const now = new Date();
-		const expiresAt = new Date(invitation.expires_at);
-		if (expiresAt < now) {
-			throw new KoudenError("招待の有効期限が切れています", ErrorCodes.INVALID_OPERATION);
-		}
-
-		if (invitation.max_uses && invitation.used_count >= invitation.max_uses) {
-			throw new KoudenError("招待の使用回数が上限に達しました", ErrorCodes.INVALID_OPERATION);
-		}
-
-		// 3. 既存メンバーチェック
-		const { data: existingMember, error: memberCheckError } = await supabase
-			.from("kouden_members")
-			.select("id")
-			.eq("kouden_id", invitation.kouden_id)
-			.eq("user_id", user.id)
-			.single();
-
-		if (memberCheckError && memberCheckError.code !== "PGRST116") {
-			throw memberCheckError;
-		}
-
-		if (existingMember) {
-			throw new KoudenError("すでにメンバーとして参加しています", ErrorCodes.ALREADY_EXISTS);
-		}
-
-		// 4. メンバー追加（招待の created_by を added_by として記録する）
-		const { error: memberError } = await supabase.from("kouden_members").insert({
-			kouden_id: invitation.kouden_id,
-			user_id: user.id,
-			role_id: invitation.role_id,
-			invitation_id: invitation.id,
-			added_by: invitation.created_by,
+		const { error: rpcError } = await supabase.rpc("accept_invitation_atomic", {
+			p_token: parsedToken.data,
+			p_user_id: user.id,
 		});
 
-		if (memberError) throw memberError;
-
-		// 5. 招待のステータスと使用回数を更新
-		// マルチユーズ招待 (max_uses > 1 もしくは max_uses IS NULL) は、まだ枠が
-		// 残っている間 status='pending' のままにする。`getInvitation` は
-		// status='pending' のレコードのみを返すため、初回受諾で 'accepted' に
-		// すると 2 人目以降がトークンを使えなくなる。
-		const newUsedCount = invitation.used_count + 1;
-		const isExhausted = invitation.max_uses !== null && newUsedCount >= invitation.max_uses;
-		const invitationUpdate: { used_count: number; status?: "accepted" } = {
-			used_count: newUsedCount,
-		};
-		if (isExhausted) {
-			invitationUpdate.status = "accepted";
-		}
-
-		const { error: updateError } = await supabase
-			.from("kouden_invitations")
-			.update(invitationUpdate)
-			.eq("id", invitation.id);
-
-		if (updateError) {
-			// メンバー追加は成功しているので、招待の更新失敗は警告レベル
-			logger.warn(
+		if (rpcError) {
+			const mapped = mapAcceptInvitationRpcError(rpcError);
+			if (mapped) {
+				throw mapped;
+			}
+			// 想定外の DB エラー。詳細はログに残し、withActionResult で変換させる。
+			logger.error(
 				{
-					error: updateError.message,
-					code: updateError.code,
-					invitationId: invitation.id,
+					error: rpcError.message,
+					code: rpcError.code,
+					token: parsedToken.data,
 					userId: user.id,
 				},
-				"Member was added but invitation update failed",
+				"accept_invitation_atomic RPC failed",
 			);
+			throw rpcError;
 		}
 
 		return null;

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -3231,8 +3231,8 @@ export type Database = {
       }
     }
     Functions: {
-      accept_invitation: {
-        Args: { p_invitation_token: string; p_user_id: string }
+      accept_invitation_atomic: {
+        Args: { p_token: string; p_user_id: string }
         Returns: undefined
       }
       bulk_mark_funeral_gift_returned: {

--- a/supabase/migrations/20260608000002_add_accept_invitation_atomic_rpc.sql
+++ b/supabase/migrations/20260608000002_add_accept_invitation_atomic_rpc.sql
@@ -1,0 +1,137 @@
+-- 2026-06-08: 招待受諾のアトミック化用 RPC 関数
+-- Issue: https://github.com/otomatty/kouden/issues/113
+--
+-- 背景:
+--   `acceptInvitation` Server Action (src/app/_actions/invitations.ts) では
+--   以下の処理が非アトミックに実行されていた:
+--     1. 招待トークンを SELECT
+--     2. status / expires_at / used_count を check
+--     3. 既存メンバーを check
+--     4. kouden_members へ INSERT
+--     5. used_count を +1、枠が尽きたら status='accepted' に UPDATE
+--
+--   ステップ 2〜5 の間に他セッションが同じ招待を受諾するレースが成立し、
+--   `max_uses` 制限のある招待が上限を超えて消化される / used_count が
+--   max_uses を超えてカウントされる / 二重 INSERT で uniq violation が
+--   起こり得た。
+--
+-- 本マイグレーションでは:
+--   - 一連の処理を単一の Postgres 関数 (= 1トランザクション) にまとめる
+--   - `select ... for update` で招待行をロックし、同一トークンの同時受諾を直列化する
+--   - kouden_members への INSERT は `on conflict (kouden_id, user_id) do nothing`
+--     とし、レース時の二重 INSERT を握りつぶす (実際に挿入できたかで分岐)
+--   - 失敗ケースは Server Action 側が KoudenError にマップできるよう、安定した
+--     メッセージトークン (invitation_not_found / invitation_not_pending /
+--     invitation_expired / invitation_max_uses_reached / already_member) と
+--     SQLSTATE で raise する
+--
+-- 呼び出し元は service-role (admin client) のみを想定。
+--   - kouden_invitations は RLS で匿名/他人からの SELECT を禁止している
+--   - kouden_members への INSERT は所有者のみ許可するポリシーのため、招待経由の
+--     自分自身の追加もサーバー側で検証してから service-role で実施する
+-- そのため authenticated/anon からの実行は許可しない (EXECUTE を REVOKE)。
+--
+-- 認証ユーザー (auth.uid()) は service-role セッションでは取得できないため、
+-- 受諾するユーザー ID は呼び出し元が p_user_id として渡す。Server Action 側で
+-- 通常クライアントの auth.getUser() から取得した値のみを渡す (クライアント入力は信用しない)。
+
+-- ------------------------------------------------------------------------
+-- 1. 壊れている旧 accept_invitation を削除する
+-- ------------------------------------------------------------------------
+-- 旧関数 (20250128134809_remote_schema.sql) は v_invitation.invitation_type を
+-- 参照しているが、kouden_invitations テーブルに invitation_type カラムは存在せず、
+-- 実行すれば確実に失敗する。アプリからの呼び出しも無い (Server Action が手続きを
+-- 自前で展開していた) ため、ここで破棄して新しい RPC に置き換える。
+DROP FUNCTION IF EXISTS public.accept_invitation(uuid, uuid);
+
+-- ------------------------------------------------------------------------
+-- 2. アトミックな招待受諾用 RPC
+-- ------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.accept_invitation_atomic(
+    p_token uuid,
+    p_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_invitation     public.kouden_invitations%ROWTYPE;
+    v_new_used_count integer;
+    v_is_exhausted   boolean;
+    v_inserted_id    uuid;
+BEGIN
+    -- 1. 招待行をロックして取得 (FOR UPDATE で同一トークンの同時受諾を直列化)
+    SELECT * INTO v_invitation
+    FROM public.kouden_invitations
+    WHERE invitation_token = p_token
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'invitation_not_found'
+            USING ERRCODE = 'P0002'; -- no_data_found
+    END IF;
+
+    -- 2. 招待の有効性チェック
+    IF v_invitation.status <> 'pending' THEN
+        RAISE EXCEPTION 'invitation_not_pending'
+            USING ERRCODE = 'P0001'; -- raise_exception
+    END IF;
+
+    IF v_invitation.expires_at < now() THEN
+        RAISE EXCEPTION 'invitation_expired'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF v_invitation.max_uses IS NOT NULL
+       AND v_invitation.used_count >= v_invitation.max_uses THEN
+        RAISE EXCEPTION 'invitation_max_uses_reached'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    -- 3. メンバー追加 (招待の created_by を added_by として記録する)。
+    --    ロック後でも別トークン経由の同時受諾などで既メンバーになり得るため、
+    --    on conflict do nothing でレースを握りつぶし、挿入できたかで分岐する。
+    INSERT INTO public.kouden_members (
+        kouden_id,
+        user_id,
+        role_id,
+        invitation_id,
+        added_by
+    ) VALUES (
+        v_invitation.kouden_id,
+        p_user_id,
+        v_invitation.role_id,
+        v_invitation.id,
+        v_invitation.created_by
+    )
+    ON CONFLICT (kouden_id, user_id) DO NOTHING
+    RETURNING id INTO v_inserted_id;
+
+    -- 挿入できなかった = 既にメンバー。used_count は増やさず ALREADY_EXISTS で返す。
+    IF v_inserted_id IS NULL THEN
+        RAISE EXCEPTION 'already_member'
+            USING ERRCODE = '23505'; -- unique_violation
+    END IF;
+
+    -- 4. 招待の使用回数を更新。
+    --    マルチユーズ招待 (max_uses > 1 もしくは max_uses IS NULL) は、枠が残る間
+    --    status='pending' のままにする (getInvitation が pending のみ返すため、
+    --    初回受諾で 'accepted' にすると 2 人目以降がトークンを使えなくなる)。
+    v_new_used_count := v_invitation.used_count + 1;
+    v_is_exhausted := v_invitation.max_uses IS NOT NULL
+                      AND v_new_used_count >= v_invitation.max_uses;
+
+    UPDATE public.kouden_invitations
+    SET used_count = v_new_used_count,
+        status     = CASE WHEN v_is_exhausted THEN 'accepted'::invitation_status ELSE status END,
+        updated_at = now()
+    WHERE id = v_invitation.id;
+END;
+$$;
+
+-- service-role のみが実行可能 (admin client 経由で呼び出す想定)
+REVOKE ALL ON FUNCTION public.accept_invitation_atomic(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.accept_invitation_atomic(uuid, uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_invitation_atomic(uuid, uuid) TO service_role;


### PR DESCRIPTION
招待受諾の検証・メンバー追加・used_count 更新を非アトミックに実行していたため、
max_uses 制限のある招待が並列受諾で上限を超えて消化される競合が成立し得た。

- accept_invitation_atomic RPC を追加 (select ... for update で招待行をロックし、
  検証〜kouden_members INSERT〜used_count 更新を 1 トランザクションで実行)
- kouden_members への INSERT は on conflict (kouden_id, user_id) do nothing で
  レース時の二重 INSERT を握りつぶし、挿入できたかで ALREADY_EXISTS を判定
- Server Action は RPC を呼ぶだけにし、RPC の raise を既存エラーコード
  (NOT_FOUND / ALREADY_EXISTS / INVALID_OPERATION) にマップ
- invitation_type 列を参照していて確実に失敗する旧 accept_invitation を削除
- 生成型 (supabase.d.ts) を更新

https://claude.ai/code/session_01T6Y78F4VNLZSjEYGkL7Lzo