### PR TITLE
fix(admin): super-admin 権限チェックで DB エラーを FORBIDDEN と誤分類しない (#120)

### DIFF
--- a/src/app/_actions/admin/__tests__/middleware.test.ts
+++ b/src/app/_actions/admin/__tests__/middleware.test.ts
@@ -1,0 +1,80 @@
+import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { createClient } from "@/lib/supabase/server";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import { withSuperAdmin } from "../middleware";
+
+class RedirectError extends Error {
+	constructor(public readonly url: string) {
+		super(`NEXT_REDIRECT:${url}`);
+	}
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn((url: string) => {
+		throw new RedirectError(url);
+	}),
+}));
+vi.mock("../audit-logs", () => ({
+	createAuditLog: vi.fn().mockResolvedValue({ ok: true, data: null }),
+}));
+
+describe("withSuperAdmin", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
+	let supabaseMock: any;
+
+	const buildSupabase = (adminUserResult: { data: unknown; error: unknown }) => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: { id: "user-1" } },
+				error: null,
+			}),
+		},
+		from: vi.fn().mockReturnValue({
+			select: () => ({
+				eq: () => ({
+					single: () => Promise.resolve(adminUserResult),
+				}),
+			}),
+		}),
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("super_admin の場合は action を実行して結果を返す", async () => {
+		supabaseMock = buildSupabase({ data: { role: "super_admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const result = await withSuperAdmin(async () => "ok");
+		expect(result).toBe("ok");
+	});
+
+	it("super_admin でない場合は / にリダイレクトする (action は実行されない)", async () => {
+		supabaseMock = buildSupabase({ data: { role: "admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const action = vi.fn();
+		const error = await withSuperAdmin(action).catch((e) => e);
+		expect(error).toBeInstanceOf(RedirectError);
+		expect((error as RedirectError).url).toBe("/");
+		expect(action).not.toHaveBeenCalled();
+	});
+
+	it("DB エラー (PGRST116 以外) の場合はリダイレクトせず DB_FETCH_ERROR を投げる", async () => {
+		supabaseMock = buildSupabase({
+			data: null,
+			error: { code: "57P01", message: "database connection lost" },
+		});
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const action = vi.fn();
+		const error = await withSuperAdmin(action).catch((e) => e);
+		expect(error).toBeInstanceOf(KoudenError);
+		expect((error as KoudenError).code).toBe(ErrorCodes.DB_FETCH_ERROR);
+		expect(action).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/_actions/admin/__tests__/middleware.test.ts
+++ b/src/app/_actions/admin/__tests__/middleware.test.ts
@@ -3,11 +3,16 @@ import { createClient } from "@/lib/supabase/server";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { withSuperAdmin } from "../middleware";
 
-class RedirectError extends Error {
-	constructor(public readonly url: string) {
-		super(`NEXT_REDIRECT:${url}`);
+// vi.mock ファクトリはモジュール先頭にホイストされるため、ファクトリから参照する
+// RedirectError は vi.hoisted で同様に巻き上げて TDZ 参照を防ぐ。
+const { RedirectError } = vi.hoisted(() => {
+	class RedirectError extends Error {
+		constructor(public readonly url: string) {
+			super(`NEXT_REDIRECT:${url}`);
+		}
 	}
-}
+	return { RedirectError };
+});
 
 vi.mock("@/lib/supabase/server", () => ({
 	createClient: vi.fn(),

--- a/src/app/_actions/admin/__tests__/middleware.test.ts
+++ b/src/app/_actions/admin/__tests__/middleware.test.ts
@@ -17,11 +17,17 @@ const { RedirectError } = vi.hoisted(() => {
 vi.mock("@/lib/supabase/server", () => ({
 	createClient: vi.fn(),
 }));
-vi.mock("next/navigation", () => ({
-	redirect: vi.fn((url: string) => {
-		throw new RedirectError(url);
-	}),
-}));
+// 部分モック: redirect だけ差し替え、unstable_rethrow など他の実エクスポートは残す。
+// (@/lib/errors が unstable_rethrow を import/呼び出しするため全置換すると壊れる)
+vi.mock("next/navigation", async (importActual) => {
+	const actual = await importActual<typeof import("next/navigation")>();
+	return {
+		...actual,
+		redirect: vi.fn((url: string) => {
+			throw new RedirectError(url);
+		}),
+	};
+});
 vi.mock("../audit-logs", () => ({
 	createAuditLog: vi.fn().mockResolvedValue({ ok: true, data: null }),
 }));

--- a/src/app/_actions/admin/__tests__/permissions.test.ts
+++ b/src/app/_actions/admin/__tests__/permissions.test.ts
@@ -1,0 +1,84 @@
+import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { createClient } from "@/lib/supabase/server";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkSuperAdminPermission } from "../permissions";
+
+// next/navigation の redirect は呼ばれたら専用エラーを投げてフローを中断する挙動を再現する。
+class RedirectError extends Error {
+	constructor(public readonly url: string) {
+		super(`NEXT_REDIRECT:${url}`);
+	}
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn((url: string) => {
+		throw new RedirectError(url);
+	}),
+}));
+
+describe("checkSuperAdminPermission", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
+	let supabaseMock: any;
+
+	const buildSupabase = (adminUserResult: { data: unknown; error: unknown }) => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: { id: "user-1" } },
+				error: null,
+			}),
+		},
+		from: vi.fn().mockReturnValue({
+			select: () => ({
+				eq: () => ({
+					single: () => Promise.resolve(adminUserResult),
+				}),
+			}),
+		}),
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("super_admin の場合は supabase/user を返す", async () => {
+		supabaseMock = buildSupabase({ data: { role: "super_admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const result = await checkSuperAdminPermission();
+		expect(result.user).toEqual({ id: "user-1" });
+		expect(result.supabase).toBe(supabaseMock);
+	});
+
+	it("管理者未登録 (PGRST116) の場合は FORBIDDEN を投げる", async () => {
+		supabaseMock = buildSupabase({ data: null, error: { code: "PGRST116" } });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		await expect(checkSuperAdminPermission()).rejects.toMatchObject({
+			code: ErrorCodes.FORBIDDEN,
+		});
+	});
+
+	it("一般管理者 (role !== super_admin) の場合は FORBIDDEN を投げる", async () => {
+		supabaseMock = buildSupabase({ data: { role: "admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		await expect(checkSuperAdminPermission()).rejects.toMatchObject({
+			code: ErrorCodes.FORBIDDEN,
+		});
+	});
+
+	it("DB エラー (PGRST116 以外) の場合は FORBIDDEN ではなく DB_FETCH_ERROR を投げる", async () => {
+		supabaseMock = buildSupabase({
+			data: null,
+			error: { code: "57P01", message: "database connection lost" },
+		});
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const error = await checkSuperAdminPermission().catch((e) => e);
+		expect(error).toBeInstanceOf(KoudenError);
+		expect((error as KoudenError).code).toBe(ErrorCodes.DB_FETCH_ERROR);
+	});
+});

--- a/src/app/_actions/admin/__tests__/permissions.test.ts
+++ b/src/app/_actions/admin/__tests__/permissions.test.ts
@@ -17,11 +17,17 @@ const { RedirectError } = vi.hoisted(() => {
 vi.mock("@/lib/supabase/server", () => ({
 	createClient: vi.fn(),
 }));
-vi.mock("next/navigation", () => ({
-	redirect: vi.fn((url: string) => {
-		throw new RedirectError(url);
-	}),
-}));
+// 部分モック: redirect だけ差し替え、unstable_rethrow など他の実エクスポートは残す。
+// (@/lib/errors が unstable_rethrow を import/呼び出しするため全置換すると壊れる)
+vi.mock("next/navigation", async (importActual) => {
+	const actual = await importActual<typeof import("next/navigation")>();
+	return {
+		...actual,
+		redirect: vi.fn((url: string) => {
+			throw new RedirectError(url);
+		}),
+	};
+});
 
 describe("checkSuperAdminPermission", () => {
 	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック

--- a/src/app/_actions/admin/__tests__/permissions.test.ts
+++ b/src/app/_actions/admin/__tests__/permissions.test.ts
@@ -4,11 +4,15 @@ import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { checkSuperAdminPermission } from "../permissions";
 
 // next/navigation の redirect は呼ばれたら専用エラーを投げてフローを中断する挙動を再現する。
-class RedirectError extends Error {
-	constructor(public readonly url: string) {
-		super(`NEXT_REDIRECT:${url}`);
+// vi.mock ファクトリはホイストされるため、参照する RedirectError も vi.hoisted で巻き上げる。
+const { RedirectError } = vi.hoisted(() => {
+	class RedirectError extends Error {
+		constructor(public readonly url: string) {
+			super(`NEXT_REDIRECT:${url}`);
+		}
 	}
-}
+	return { RedirectError };
+});
 
 vi.mock("@/lib/supabase/server", () => ({
 	createClient: vi.fn(),

--- a/src/app/_actions/admin/middleware.ts
+++ b/src/app/_actions/admin/middleware.ts
@@ -94,10 +94,17 @@ export async function withSuperAdmin<T>(action: () => Promise<T>): Promise<T> {
 	// 権限不足 (redirect) ではなく DB エラーとして扱う (上位で 500 化)。
 	if (adminError && adminError.code !== "PGRST116") {
 		logger.error(
-			{ error: adminError.message, code: adminError.code, userId: user.id },
+			{
+				error: adminError.message,
+				code: adminError.code,
+				details: adminError.details,
+				userId: user.id,
+			},
 			"admin_users lookup failed in withSuperAdmin",
 		);
-		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR, {
+			cause: adminError,
+		});
 	}
 
 	if (!adminUser || adminUser.role !== "super_admin") {

--- a/src/app/_actions/admin/middleware.ts
+++ b/src/app/_actions/admin/middleware.ts
@@ -84,11 +84,21 @@ export async function withSuperAdmin<T>(action: () => Promise<T>): Promise<T> {
 		redirect("/auth/login");
 	}
 
-	const { data: adminUser } = await supabase
+	const { data: adminUser, error: adminError } = await supabase
 		.from("admin_users")
 		.select("role")
 		.eq("user_id", user.id)
 		.single();
+
+	// PGRST116 (0 行) は「管理者未登録」= 権限不足。それ以外は DB エラーなので
+	// 権限不足 (redirect) ではなく DB エラーとして扱う (上位で 500 化)。
+	if (adminError && adminError.code !== "PGRST116") {
+		logger.error(
+			{ error: adminError.message, code: adminError.code, userId: user.id },
+			"admin_users lookup failed in withSuperAdmin",
+		);
+		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+	}
 
 	if (!adminUser || adminUser.role !== "super_admin") {
 		redirect("/");

--- a/src/app/_actions/admin/permissions.ts
+++ b/src/app/_actions/admin/permissions.ts
@@ -92,7 +92,9 @@ export async function checkSuperAdminPermission() {
 			},
 			"Super admin permission check error",
 		);
-		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR, {
+			cause: error,
+		});
 	}
 
 	if (!adminUser || adminUser.role !== "super_admin") {

--- a/src/app/_actions/admin/permissions.ts
+++ b/src/app/_actions/admin/permissions.ts
@@ -74,11 +74,26 @@ export async function checkSuperAdminPermission() {
 		redirect("/auth/login");
 	}
 
-	const { data: adminUser } = await supabase
+	const { data: adminUser, error } = await supabase
 		.from("admin_users")
 		.select("role")
 		.eq("user_id", user.id)
 		.single();
+
+	// PGRST116 (0 行) は「管理者未登録」= 権限不足。それ以外は DB エラーなので
+	// 権限不足ではなく DB_FETCH_ERROR として扱う (DB 障害を FORBIDDEN と誤分類しない)。
+	if (error && error.code !== "PGRST116") {
+		logger.error(
+			{
+				error: error.message,
+				code: error.code,
+				details: error.details,
+				userId: user.id,
+			},
+			"Super admin permission check error",
+		);
+		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+	}
 
 	if (!adminUser || adminUser.role !== "super_admin") {
 		throw new KoudenError("スーパー管理者権限が必要です", ErrorCodes.FORBIDDEN);


### PR DESCRIPTION
checkSuperAdminPermission / withSuperAdmin の admin_users クエリで
error を無視していたため、DB 障害時に adminUser が null となり
「権限不足 (FORBIDDEN / redirect)」として処理されていた。

is_admin RPC 呼び出し側 (#120 で既に対応済み) と同様に、
PGRST116 (0 行 = 管理者未登録) のみ権限不足とし、それ以外の
DB エラーは DB_FETCH_ERROR として分類するよう修正。
併せて両関数のテストを追加。