### PR TITLE
fix(admin): ページネーション後の計算列ソートで全件ソートを効かせる (#117)

### DIFF
--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -119,17 +119,20 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<
 				);
 			}
 
+			// RPC は全件数を常に返す（ページが空でも id = NULL のセンチネル行で total_count
+			// を返す）。total はページ行に依存せず先頭行の total_count から読み、順序付き ID は
+			// id = NULL を除外して組み立てる。
 			const orderedRows = (orderedResult.data ?? []) as Array<{
-				id: string;
+				id: string | null;
 				total_count: number | string;
 			}>;
 			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
 
-			if (orderedRows.length === 0) {
+			const orderedIds = orderedRows.map((row) => row.id).filter((id): id is string => id !== null);
+
+			if (orderedIds.length === 0) {
 				return { users: [], total: count, hasMore: false };
 			}
-
-			const orderedIds = orderedRows.map((row) => row.id);
 			const { data: fetchedProfiles, error: profilesError } = await supabase
 				.from("profiles")
 				.select("id, display_name, avatar_url, created_at, updated_at")
@@ -727,17 +730,20 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 				);
 			}
 
+			// RPC は全件数を常に返す（ページが空でも id = NULL のセンチネル行で total_count
+			// を返す）。total はページ行に依存せず先頭行の total_count から読み、順序付き ID は
+			// id = NULL を除外して組み立てる。
 			const orderedRows = (orderedResult.data ?? []) as Array<{
-				id: string;
+				id: string | null;
 				total_count: number | string;
 			}>;
 			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
 
-			if (orderedRows.length === 0) {
+			const orderedIds = orderedRows.map((row) => row.id).filter((id): id is string => id !== null);
+
+			if (orderedIds.length === 0) {
 				return { koudens: [], total: count, hasMore: false };
 			}
-
-			const orderedIds = orderedRows.map((row) => row.id);
 			const { data: fetchedKoudens, error: koudensError } = await supabase
 				.from("koudens")
 				.select(KOUDEN_BASE_SELECT)

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -81,60 +81,124 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<
 		} = params;
 		const offset = (page - 1) * limit;
 
-		// 1. まずprofilesテーブルから基本情報を取得
-		let query = supabase.from("profiles").select(
-			`
+		// profilesの基本情報とページ全体の総件数。
+		// last_sign_in_at ソートのみ DB 側で全件ソート + ページネーションするため別経路。
+		type ProfileRow = {
+			id: string;
+			display_name: string;
+			avatar_url: string | null;
+			created_at: string;
+			updated_at: string;
+		};
+		let profiles: ProfileRow[];
+		let count: number;
+
+		if (sortBy === "last_sign_in_at") {
+			// last_sign_in_at は auth.users 由来の計算列のため、JS側で現ページ内だけを
+			// 並べ替えると全件ソートにならない。DB 側 (RPC) で auth.users を結合して
+			// 全件ソート + ページネーションし、正しい順序の user_id と全件数を取得する。
+			// 注: get_admin_user_ids_by_last_sign_in は
+			//   20260608000003_add_admin_sorted_page_rpcs.sql で追加。
+			const orderedResult = await (
+				supabase.rpc as unknown as (
+					fn: string,
+					args: unknown,
+				) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+			)("get_admin_user_ids_by_last_sign_in", {
+				p_search: search ? escapeIlikePattern(search) : null,
+				p_filter: filter ?? "all",
+				p_sort_order: sortOrder,
+				p_limit: limit,
+				p_offset: offset,
+			});
+
+			if (orderedResult.error) {
+				throw new KoudenError(
+					`Failed to fetch sorted user ids: ${orderedResult.error.message}`,
+					ErrorCodes.DB_FETCH_ERROR,
+				);
+			}
+
+			const orderedRows = (orderedResult.data ?? []) as Array<{
+				id: string;
+				total_count: number | string;
+			}>;
+			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
+
+			if (orderedRows.length === 0) {
+				return { users: [], total: count, hasMore: false };
+			}
+
+			const orderedIds = orderedRows.map((row) => row.id);
+			const { data: fetchedProfiles, error: profilesError } = await supabase
+				.from("profiles")
+				.select("id, display_name, avatar_url, created_at, updated_at")
+				.in("id", orderedIds);
+			if (profilesError) throw profilesError;
+
+			// RPC が返したソート順を保持して並べ直す（.in() は順序を保証しないため）
+			const profileMap = new Map((fetchedProfiles ?? []).map((p) => [p.id, p]));
+			profiles = orderedIds
+				.map((id) => profileMap.get(id))
+				.filter((p): p is ProfileRow => p !== undefined);
+		} else {
+			// 1. まずprofilesテーブルから基本情報を取得
+			let query = supabase.from("profiles").select(
+				`
         id,
         display_name,
         avatar_url,
         created_at,
         updated_at
       `,
-			{ count: "exact" },
-		);
+				{ count: "exact" },
+			);
 
-		// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
-		if (search) {
-			query = query.ilike("display_name", `%${escapeIlikePattern(search)}%`);
-		}
-
-		// フィルタリング
-		if (filter === "admin") {
-			const { data: adminUserIds } = await supabase.from("admin_users").select("user_id");
-
-			if (adminUserIds && adminUserIds.length > 0) {
-				query = query.in(
-					"id",
-					adminUserIds.map((admin) => admin.user_id),
-				);
-			} else {
-				// 管理者が存在しない場合は空の結果を返す
-				return { users: [], total: 0, hasMore: false };
+			// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
+			if (search) {
+				query = query.ilike("display_name", `%${escapeIlikePattern(search)}%`);
 			}
-		} else if (filter === "regular") {
-			const { data: adminUserIds } = await supabase.from("admin_users").select("user_id");
 
-			if (adminUserIds && adminUserIds.length > 0) {
-				query = query.not(
-					"id",
-					"in",
-					adminUserIds.map((admin) => admin.user_id),
-				);
+			// フィルタリング
+			if (filter === "admin") {
+				const { data: adminUserIds } = await supabase.from("admin_users").select("user_id");
+
+				if (adminUserIds && adminUserIds.length > 0) {
+					query = query.in(
+						"id",
+						adminUserIds.map((admin) => admin.user_id),
+					);
+				} else {
+					// 管理者が存在しない場合は空の結果を返す
+					return { users: [], total: 0, hasMore: false };
+				}
+			} else if (filter === "regular") {
+				const { data: adminUserIds } = await supabase.from("admin_users").select("user_id");
+
+				if (adminUserIds && adminUserIds.length > 0) {
+					query = query.not(
+						"id",
+						"in",
+						adminUserIds.map((admin) => admin.user_id),
+					);
+				}
 			}
-		}
 
-		// ソート（last_sign_in_atは後でソートするため、ここではcreated_atでソート）
-		const orderBy = sortBy === "last_sign_in_at" ? "created_at" : sortBy;
-		query = query.order(orderBy, { ascending: sortOrder === "asc" });
+			// ソート
+			query = query.order(sortBy, { ascending: sortOrder === "asc" });
 
-		// ページネーション
-		query = query.range(offset, offset + limit - 1);
+			// ページネーション
+			query = query.range(offset, offset + limit - 1);
 
-		const { data: profiles, error: profilesError, count } = await query;
-		if (profilesError) throw profilesError;
+			const { data: fetchedProfiles, error: profilesError, count: fetchedCount } = await query;
+			if (profilesError) throw profilesError;
 
-		if (!profiles || profiles.length === 0) {
-			return { users: [], total: count || 0, hasMore: false };
+			if (!fetchedProfiles || fetchedProfiles.length === 0) {
+				return { users: [], total: fetchedCount || 0, hasMore: false };
+			}
+
+			profiles = fetchedProfiles;
+			count = fetchedCount || 0;
 		}
 
 		// 2. 認証情報と集計統計をそれぞれ1クエリで一括取得（N+1解消）
@@ -189,26 +253,17 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<
 		});
 
 		// 認証情報をマージ
+		// 並び順は profiles の順序（通常パスはクエリ、last_sign_in_at パスは RPC で
+		// 全件ソート済み）をそのまま保持するため、ここでの再ソートは不要。
 		const finalUsersWithDetails = usersWithDetails.map((user) => ({
 			...user,
 			...authInfoMap[user.id],
 		}));
 
-		// last_sign_in_atでソートが指定されている場合はここでソート
-		if (sortBy === "last_sign_in_at") {
-			finalUsersWithDetails.sort((a, b) => {
-				const aLastSignIn = (a as UserListItem).last_sign_in_at;
-				const bLastSignIn = (b as UserListItem).last_sign_in_at;
-				const aDate = aLastSignIn ? new Date(aLastSignIn).getTime() : 0;
-				const bDate = bLastSignIn ? new Date(bLastSignIn).getTime() : 0;
-				return sortOrder === "asc" ? aDate - bDate : bDate - aDate;
-			});
-		}
-
 		return {
 			users: finalUsersWithDetails,
-			total: count || 0,
-			hasMore: (count || 0) > offset + limit,
+			total: count,
+			hasMore: count > offset + limit,
 		};
 	}, "ユーザー一覧の取得");
 }
@@ -616,9 +671,11 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
 		}
 
-		// 1. 香典帳の基本情報を取得
-		let query = supabase.from("koudens").select(
-			`
+		// 統計やソート RPC は内部で is_admin(auth.uid()) を検証するため、
+		// サービスロールではなくユーザーセッションのクライアントで呼び出す。
+		const sessionClient = await createClient();
+
+		const KOUDEN_BASE_SELECT = `
         id,
         title,
         description,
@@ -627,47 +684,105 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
         updated_at,
         owner_id,
         plan_id
-      `,
-			{ count: "exact" },
-		);
+      `;
+		type KoudenBaseRow = {
+			id: string;
+			title: string;
+			description: string | null;
+			status: string;
+			created_at: string;
+			updated_at: string;
+			owner_id: string;
+			plan_id: string;
+		};
 
-		// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
-		if (search) {
-			query = query.ilike("title", `%${escapeIlikePattern(search)}%`);
-		}
+		// 1. 香典帳の基本情報とページ全体の総件数を取得。
+		// entries_count ソートのみ DB 側で全件ソート + ページネーションするため別経路。
+		let koudens: KoudenBaseRow[];
+		let count: number;
 
-		// ステータスフィルタリング
-		if (status !== "all") {
-			query = query.eq("status", status);
-		}
+		if (sortBy === "entries_count") {
+			// entries_count は kouden_entries の集計値（計算列）のため、JS側で現ページ内
+			// だけを並べ替えると全件ソートにならない。DB 側 (RPC) で集計を含めて全件ソート +
+			// ページネーションし、正しい順序の kouden_id と全件数を取得する。
+			// 注: get_admin_kouden_ids_by_entries_count は
+			//   20260608000003_add_admin_sorted_page_rpcs.sql で追加。
+			const orderedResult = await (
+				sessionClient.rpc as unknown as (
+					fn: string,
+					args: unknown,
+				) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+			)("get_admin_kouden_ids_by_entries_count", {
+				p_search: search ? escapeIlikePattern(search) : null,
+				p_status: status,
+				p_sort_order: sortOrder,
+				p_limit: limit,
+				p_offset: offset,
+			});
 
-		// ソート（entries_count以外）
-		if (sortBy !== "entries_count") {
-			query = query.order(sortBy, { ascending: sortOrder === "asc" });
+			if (orderedResult.error) {
+				throw new KoudenError(
+					`Failed to fetch sorted kouden ids: ${orderedResult.error.message}`,
+					ErrorCodes.DB_FETCH_ERROR,
+				);
+			}
+
+			const orderedRows = (orderedResult.data ?? []) as Array<{
+				id: string;
+				total_count: number | string;
+			}>;
+			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
+
+			if (orderedRows.length === 0) {
+				return { koudens: [], total: count, hasMore: false };
+			}
+
+			const orderedIds = orderedRows.map((row) => row.id);
+			const { data: fetchedKoudens, error: koudensError } = await supabase
+				.from("koudens")
+				.select(KOUDEN_BASE_SELECT)
+				.in("id", orderedIds);
+			if (koudensError) throw koudensError;
+
+			// RPC が返したソート順を保持して並べ直す（.in() は順序を保証しないため）
+			const koudenMap = new Map((fetchedKoudens ?? []).map((k) => [k.id, k as KoudenBaseRow]));
+			koudens = orderedIds
+				.map((id) => koudenMap.get(id))
+				.filter((k): k is KoudenBaseRow => k !== undefined);
 		} else {
-			// entries_countでソートする場合は後でソート
-			query = query.order("created_at", { ascending: false });
-		}
+			let query = supabase.from("koudens").select(KOUDEN_BASE_SELECT, { count: "exact" });
 
-		// ページネーション
-		query = query.range(offset, offset + limit - 1);
+			// 検索条件 (ILIKE のワイルドカード % _ は意図しない一致を生むためエスケープ)
+			if (search) {
+				query = query.ilike("title", `%${escapeIlikePattern(search)}%`);
+			}
 
-		const { data: koudens, error: koudensError, count } = await query;
+			// ステータスフィルタリング
+			if (status !== "all") {
+				query = query.eq("status", status);
+			}
 
-		if (koudensError) throw koudensError;
+			// ソート
+			query = query.order(sortBy, { ascending: sortOrder === "asc" });
 
-		if (!koudens || koudens.length === 0) {
-			return { koudens: [], total: count || 0, hasMore: false };
+			// ページネーション
+			query = query.range(offset, offset + limit - 1);
+
+			const { data: fetchedKoudens, error: koudensError, count: fetchedCount } = await query;
+			if (koudensError) throw koudensError;
+
+			if (!fetchedKoudens || fetchedKoudens.length === 0) {
+				return { koudens: [], total: fetchedCount || 0, hasMore: false };
+			}
+
+			koudens = fetchedKoudens as KoudenBaseRow[];
+			count = fetchedCount || 0;
 		}
 
 		// 2. オーナー / プラン / 統計を ID 群でまとめて一括取得（N+1解消）
 		const ownerIds = Array.from(new Set(koudens.map((k) => k.owner_id)));
 		const planIds = Array.from(new Set(koudens.map((k) => k.plan_id)));
 		const koudenIds = koudens.map((k) => k.id);
-
-		// 統計は専用 RPC で 1 クエリ集計。RPC は内部で is_admin(auth.uid()) を検証するため、
-		// サービスロールではなくユーザーセッションのクライアントで呼び出す。
-		const sessionClient = await createClient();
 
 		// 注: get_admin_kouden_stats は 20260608000000_add_get_admin_kouden_stats_rpc.sql で追加。
 		// マイグレーション適用後に `bun run db:types` を実行すれば、ここのキャストは不要になる。
@@ -763,19 +878,12 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 			};
 		});
 
-		// entries_countでソートが指定されている場合はここでソート
-		if (sortBy === "entries_count") {
-			koudensWithDetails.sort((a, b) => {
-				const aCount = a.stats.entries_count;
-				const bCount = b.stats.entries_count;
-				return sortOrder === "asc" ? aCount - bCount : bCount - aCount;
-			});
-		}
-
+		// 並び順は koudens の順序（通常パスはクエリ、entries_count パスは RPC で
+		// 全件ソート済み）をそのまま保持するため、ここでの再ソートは不要。
 		return {
 			koudens: koudensWithDetails,
-			total: count || 0,
-			hasMore: (count || 0) > offset + limit,
+			total: count,
+			hasMore: count > offset + limit,
 		};
 	}, "香典帳一覧の取得");
 }

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -391,40 +391,51 @@ async function getAllUsersAuthInfo(userIds: string[]): Promise<
 		}
 	> = {};
 
+	// 既定では各ユーザーを空情報で埋めておき、取得できたものだけ上書きする。
+	for (const id of userIds) {
+		result[id] = {};
+	}
+	if (userIds.length === 0) {
+		return result;
+	}
+
 	try {
-		// Admin APIで全ユーザーを一括取得
-		const { data: users, error } = await supabase.auth.admin.listUsers();
+		// id で絞り込む SECURITY DEFINER RPC で auth 情報を一括取得。
+		// listUsers() は先頭ページのみを返し、かつ admin API はサービスロールを要するため
+		// ユーザーセッションでは取得漏れ/失敗し得る。本RPCは auth ページングに依存しない。
+		// 注: get_admin_auth_user_details_by_ids は
+		//   20260608000003_add_admin_sorted_page_rpcs.sql で追加。
+		const { data, error } = await (
+			supabase.rpc as unknown as (
+				fn: string,
+				args: unknown,
+			) => PromiseLike<{ data: unknown; error: { message: string } | null }>
+		)("get_admin_auth_user_details_by_ids", { p_user_ids: userIds });
 
 		if (error) {
 			logger.error(
 				{
 					error: error.message,
-					code: error.code,
 					userIdsCount: userIds.length,
 				},
 				"Failed to get all users auth info",
 			);
-			// エラーの場合は空のオブジェクトを各ユーザーに設定
-			for (const id of userIds) {
-				result[id] = {};
-			}
 			return result;
 		}
 
-		// 必要なユーザーのみフィルタリングしてマップに変換
-		const userMap = new Map(users.users.map((user) => [user.id, user]));
+		const rows = (data ?? []) as Array<{
+			id: string;
+			email: string | null;
+			last_sign_in_at: string | null;
+			email_confirmed_at: string | null;
+		}>;
 
-		for (const userId of userIds) {
-			const user = userMap.get(userId);
-			if (user) {
-				result[userId] = {
-					email: user.email,
-					last_sign_in_at: user.last_sign_in_at,
-					email_confirmed_at: user.email_confirmed_at,
-				};
-			} else {
-				result[userId] = {};
-			}
+		for (const row of rows) {
+			result[row.id] = {
+				email: row.email ?? undefined,
+				last_sign_in_at: row.last_sign_in_at ?? undefined,
+				email_confirmed_at: row.email_confirmed_at ?? undefined,
+			};
 		}
 
 		return result;
@@ -436,10 +447,6 @@ async function getAllUsersAuthInfo(userIds: string[]): Promise<
 			},
 			"Error getting all users auth info",
 		);
-		// エラーの場合は空のオブジェクトを各ユーザーに設定
-		for (const id of userIds) {
-			result[id] = {};
-		}
 		return result;
 	}
 }

--- a/src/app/_actions/admin/users.ts
+++ b/src/app/_actions/admin/users.ts
@@ -126,7 +126,7 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<
 				id: string | null;
 				total_count: number | string;
 			}>;
-			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
+			count = Number(orderedRows[0]?.total_count ?? 0);
 
 			const orderedIds = orderedRows.map((row) => row.id).filter((id): id is string => id !== null);
 
@@ -744,7 +744,7 @@ export async function getAllKoudens(params: GetAdminKoudensParams = {}): Promise
 				id: string | null;
 				total_count: number | string;
 			}>;
-			count = orderedRows.length > 0 ? Number(orderedRows[0].total_count) : 0;
+			count = Number(orderedRows[0]?.total_count ?? 0);
 
 			const orderedIds = orderedRows.map((row) => row.id).filter((id): id is string => id !== null);
 

--- a/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
+++ b/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
@@ -1,0 +1,149 @@
+-- 管理画面一覧の「計算列ソート + ページネーション」整合性修正用RPC関数
+-- Issue: https://github.com/otomatty/kouden/issues/117
+--
+-- 背景:
+--   admin/users.ts::getAllUsers (last_sign_in_at ソート) および
+--   admin/users.ts::getAllKoudens (entries_count ソート) は、先に created_at で
+--   range (ページネーション) してから、取得済みページ内だけを JS 側で並べ替えていた。
+--   そのため対象ページの範囲内でしか並べ替えが効かず、全件にわたる正しい順序に
+--   ならない（例: 「last_sign_in_at 降順の最初の20名」が、実際は「created_at 降順の
+--   最初の20名を last_sign_in_at で並べ替えただけ」になっていた）。
+--
+-- 対応:
+--   ソートキー（auth.users.last_sign_in_at / kouden_entries の集計件数）を含めて
+--   DB 側で order + range を行い、正しい順序のページ分の ID と全件数を返す。
+--   詳細情報（profiles / 統計 / owner / plan 等）は既存 RPC を再利用して取得し、
+--   呼び出し側で本関数の順序に並べ直す。
+--
+-- セキュリティ:
+--   auth.users / 集計対象テーブルを RLS バイパスで参照するため SECURITY DEFINER とし、
+--   関数内で is_admin(auth.uid()) をチェックして管理者以外からの呼び出しを拒否する。
+--
+-- 注意:
+--   p_search は呼び出し側で escapeIlikePattern（ILIKE の % _ \ を \ でエスケープ）
+--   済みの値を受け取る前提で、ILIKE ... ESCAPE '\' で照合する。
+
+-- ============================================================================
+-- 1. ユーザー一覧: last_sign_in_at で全件ソート + ページネーション
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_admin_user_ids_by_last_sign_in(
+    p_search text DEFAULT NULL,
+    p_filter text DEFAULT 'all',      -- 'all' | 'admin' | 'regular'
+    p_sort_order text DEFAULT 'desc', -- 'asc' | 'desc'
+    p_limit int DEFAULT 20,
+    p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+    id uuid,
+    total_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（RLSバイパスの保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_admin_user_ids_by_last_sign_in'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    WITH filtered AS (
+        SELECT
+            p.id AS uid,
+            u.last_sign_in_at AS lsa,
+            p.created_at AS created_at
+        FROM profiles p
+        JOIN auth.users u ON u.id = p.id
+        WHERE
+            (p_search IS NULL OR p.display_name ILIKE '%' || p_search || '%' ESCAPE '\')
+            AND (
+                p_filter = 'all'
+                OR (p_filter = 'admin'
+                    AND EXISTS (SELECT 1 FROM admin_users a WHERE a.user_id = p.id))
+                OR (p_filter = 'regular'
+                    AND NOT EXISTS (SELECT 1 FROM admin_users a WHERE a.user_id = p.id))
+            )
+    ),
+    counted AS (
+        SELECT COUNT(*)::bigint AS total FROM filtered
+    )
+    -- 未ログイン (last_sign_in_at IS NULL) は「最も古い」として扱う JS 実装に合わせ、
+    -- desc は NULLS LAST、asc は NULLS FIRST。created_at / uid は安定ソート用の tiebreaker。
+    SELECT f.uid, c.total
+    FROM filtered f
+    CROSS JOIN counted c
+    ORDER BY
+        CASE WHEN p_sort_order = 'asc' THEN f.lsa END ASC NULLS FIRST,
+        CASE WHEN p_sort_order = 'desc' THEN f.lsa END DESC NULLS LAST,
+        f.created_at DESC,
+        f.uid
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, text, int, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, text, int, int) TO authenticated;
+
+COMMENT ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, text, int, int) IS
+    '管理者ユーザー一覧用: last_sign_in_at で全件ソート + ページネーションした user_id と全件数を返す。関数内で is_admin(auth.uid()) を強制。';
+
+-- ============================================================================
+-- 2. 香典帳一覧: entries_count で全件ソート + ページネーション
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_admin_kouden_ids_by_entries_count(
+    p_search text DEFAULT NULL,
+    p_status text DEFAULT 'all',      -- 'all' | 'active' | 'archived' | 'inactive'
+    p_sort_order text DEFAULT 'desc', -- 'asc' | 'desc'
+    p_limit int DEFAULT 20,
+    p_offset int DEFAULT 0
+)
+RETURNS TABLE (
+    id uuid,
+    total_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（RLSバイパスの保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_admin_kouden_ids_by_entries_count'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    WITH base AS (
+        SELECT k.id AS kid
+        FROM koudens k
+        WHERE
+            (p_search IS NULL OR k.title ILIKE '%' || p_search || '%' ESCAPE '\')
+            AND (p_status = 'all' OR k.status::text = p_status)
+    ),
+    filtered AS (
+        SELECT
+            b.kid,
+            (SELECT COUNT(*)::bigint FROM kouden_entries ke WHERE ke.kouden_id = b.kid) AS ecount
+        FROM base b
+    ),
+    counted AS (
+        SELECT COUNT(*)::bigint AS total FROM filtered
+    )
+    SELECT f.kid, c.total
+    FROM filtered f
+    CROSS JOIN counted c
+    ORDER BY
+        CASE WHEN p_sort_order = 'asc' THEN f.ecount END ASC,
+        CASE WHEN p_sort_order = 'desc' THEN f.ecount END DESC,
+        f.kid
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) TO authenticated;
+
+COMMENT ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) IS
+    '管理者香典帳一覧用: entries_count で全件ソート + ページネーションした kouden_id と全件数を返す。関数内で is_admin(auth.uid()) を強制。';

--- a/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
+++ b/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
@@ -182,3 +182,56 @@ GRANT EXECUTE ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, tex
 
 COMMENT ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) IS
     '管理者香典帳一覧用: entries_count で全件ソート + ページネーションした kouden_id と全件数を返す。ページが空でも total_count をセンチネル行で返す。関数内で is_admin(auth.uid()) を強制。';
+
+-- ============================================================================
+-- 3. ユーザー一覧: 指定 user_id 群の auth 情報（email / last_sign_in_at /
+--    email_confirmed_at）を一括取得
+-- ============================================================================
+-- 背景:
+--   getAllUsers は従来 supabase.auth.admin.listUsers() で auth 情報を取得していたが、
+--   listUsers() は既定で「先頭ページのみ」を返すため、auth ユーザーが1ページを超える
+--   テナントでは対象ユーザーが先頭ページ外だと email / last_sign_in_at が空欄になる。
+--   特に last_sign_in_at ソート経路（上記RPC）では全 auth.users から並べた任意の
+--   ユーザーが選ばれ得るため、並べ替えキーである last_sign_in_at 自体が表示で欠落し得る。
+--   さらに admin API はサービスロールJWTを要するため、ユーザーセッションのクライアントでは
+--   そもそも失敗し得る。
+--
+--   本RPCは id で絞り込んで auth.users を直接参照するため、auth のページングに依存せず
+--   対象 id 数に比例した1クエリで正確に解決できる（get_auth_users_by_ids と同じ方針。
+--   こちらは email に加え last_sign_in_at / email_confirmed_at も返す）。
+--
+-- セキュリティ:
+--   auth.users を参照するため SECURITY DEFINER とし、関数内で is_admin(auth.uid()) を
+--   チェックして管理者以外からの呼び出しを拒否する。
+CREATE OR REPLACE FUNCTION public.get_admin_auth_user_details_by_ids(
+    p_user_ids uuid[]
+)
+RETURNS TABLE (
+    id uuid,
+    email text,
+    last_sign_in_at timestamptz,
+    email_confirmed_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- 呼び出し元が管理者であることを必須化（SECURITY DEFINER の保護）
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'permission denied: admin role required for get_admin_auth_user_details_by_ids'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT u.id, u.email::text, u.last_sign_in_at, u.email_confirmed_at
+    FROM auth.users u
+    WHERE u.id = ANY(p_user_ids);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_admin_auth_user_details_by_ids(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_admin_auth_user_details_by_ids(uuid[]) TO authenticated;
+
+COMMENT ON FUNCTION public.get_admin_auth_user_details_by_ids(uuid[]) IS
+    '管理画面ユーザー一覧用: 指定 user_id 群の auth.users.email / last_sign_in_at / email_confirmed_at を1クエリで一括取得 (auth ページング非依存)。関数内で is_admin(auth.uid()) を強制。';

--- a/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
+++ b/supabase/migrations/20260608000003_add_admin_sorted_page_rpcs.sql
@@ -15,6 +15,11 @@
 --   詳細情報（profiles / 統計 / owner / plan 等）は既存 RPC を再利用して取得し、
 --   呼び出し側で本関数の順序に並べ直す。
 --
+--   total_count は「ページ行に依存せず」常に返す。範囲外オフセット等でページ行が
+--   空になっても全件数を失わないよう、件数 CTE を起点に LEFT JOIN し、ページが空の
+--   場合は id = NULL のセンチネル 1 行（total_count のみ有効）を返す。呼び出し側は
+--   id = NULL を除外して順序付き ID を組み立て、total_count は先頭行から読む。
+--
 -- セキュリティ:
 --   auth.users / 集計対象テーブルを RLS バイパスで参照するため SECURITY DEFINER とし、
 --   関数内で is_admin(auth.uid()) をチェックして管理者以外からの呼び出しを拒否する。
@@ -53,7 +58,7 @@ BEGIN
         SELECT
             p.id AS uid,
             u.last_sign_in_at AS lsa,
-            p.created_at AS created_at
+            p.created_at AS cat
         FROM profiles p
         JOIN auth.users u ON u.id = p.id
         WHERE
@@ -68,18 +73,32 @@ BEGIN
     ),
     counted AS (
         SELECT COUNT(*)::bigint AS total FROM filtered
-    )
+    ),
     -- 未ログイン (last_sign_in_at IS NULL) は「最も古い」として扱う JS 実装に合わせ、
-    -- desc は NULLS LAST、asc は NULLS FIRST。created_at / uid は安定ソート用の tiebreaker。
-    SELECT f.uid, c.total
-    FROM filtered f
-    CROSS JOIN counted c
-    ORDER BY
-        CASE WHEN p_sort_order = 'asc' THEN f.lsa END ASC NULLS FIRST,
-        CASE WHEN p_sort_order = 'desc' THEN f.lsa END DESC NULLS LAST,
-        f.created_at DESC,
-        f.uid
-    LIMIT p_limit OFFSET p_offset;
+    -- desc は NULLS LAST、asc は NULLS FIRST。cat / uid は安定ソート用の tiebreaker。
+    ranked AS (
+        SELECT
+            f.uid,
+            ROW_NUMBER() OVER (
+                ORDER BY
+                    CASE WHEN p_sort_order = 'asc' THEN f.lsa END ASC NULLS FIRST,
+                    CASE WHEN p_sort_order = 'desc' THEN f.lsa END DESC NULLS LAST,
+                    f.cat DESC,
+                    f.uid
+            ) AS rn
+        FROM filtered f
+    ),
+    page AS (
+        SELECT r.uid, r.rn
+        FROM ranked r
+        ORDER BY r.rn
+        OFFSET p_offset
+        LIMIT p_limit
+    )
+    SELECT pg.uid AS id, c.total AS total_count
+    FROM counted c
+    LEFT JOIN page pg ON true
+    ORDER BY pg.rn NULLS LAST;
 END;
 $$;
 
@@ -87,7 +106,7 @@ REVOKE ALL ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, tex
 GRANT EXECUTE ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, text, int, int) TO authenticated;
 
 COMMENT ON FUNCTION public.get_admin_user_ids_by_last_sign_in(text, text, text, int, int) IS
-    '管理者ユーザー一覧用: last_sign_in_at で全件ソート + ページネーションした user_id と全件数を返す。関数内で is_admin(auth.uid()) を強制。';
+    '管理者ユーザー一覧用: last_sign_in_at で全件ソート + ページネーションした user_id と全件数を返す。ページが空でも total_count をセンチネル行で返す。関数内で is_admin(auth.uid()) を強制。';
 
 -- ============================================================================
 -- 2. 香典帳一覧: entries_count で全件ソート + ページネーション
@@ -122,23 +141,39 @@ BEGIN
             (p_search IS NULL OR k.title ILIKE '%' || p_search || '%' ESCAPE '\')
             AND (p_status = 'all' OR k.status::text = p_status)
     ),
-    filtered AS (
+    -- 全件数は base の行数に等しいため、entries 集計を含む with_counts ではなく
+    -- base から直接数えて集計のオーバーヘッドを避ける。
+    counted AS (
+        SELECT COUNT(*)::bigint AS total FROM base
+    ),
+    with_counts AS (
         SELECT
             b.kid,
             (SELECT COUNT(*)::bigint FROM kouden_entries ke WHERE ke.kouden_id = b.kid) AS ecount
         FROM base b
     ),
-    counted AS (
-        SELECT COUNT(*)::bigint AS total FROM filtered
+    ranked AS (
+        SELECT
+            w.kid,
+            ROW_NUMBER() OVER (
+                ORDER BY
+                    CASE WHEN p_sort_order = 'asc' THEN w.ecount END ASC,
+                    CASE WHEN p_sort_order = 'desc' THEN w.ecount END DESC,
+                    w.kid
+            ) AS rn
+        FROM with_counts w
+    ),
+    page AS (
+        SELECT r.kid, r.rn
+        FROM ranked r
+        ORDER BY r.rn
+        OFFSET p_offset
+        LIMIT p_limit
     )
-    SELECT f.kid, c.total
-    FROM filtered f
-    CROSS JOIN counted c
-    ORDER BY
-        CASE WHEN p_sort_order = 'asc' THEN f.ecount END ASC,
-        CASE WHEN p_sort_order = 'desc' THEN f.ecount END DESC,
-        f.kid
-    LIMIT p_limit OFFSET p_offset;
+    SELECT pg.kid AS id, c.total AS total_count
+    FROM counted c
+    LEFT JOIN page pg ON true
+    ORDER BY pg.rn NULLS LAST;
 END;
 $$;
 
@@ -146,4 +181,4 @@ REVOKE ALL ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, 
 GRANT EXECUTE ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) TO authenticated;
 
 COMMENT ON FUNCTION public.get_admin_kouden_ids_by_entries_count(text, text, text, int, int) IS
-    '管理者香典帳一覧用: entries_count で全件ソート + ページネーションした kouden_id と全件数を返す。関数内で is_admin(auth.uid()) を強制。';
+    '管理者香典帳一覧用: entries_count で全件ソート + ページネーションした kouden_id と全件数を返す。ページが空でも total_count をセンチネル行で返す。関数内で is_admin(auth.uid()) を強制。';

--- a/supabase/migrations/20260608000004_harden_is_admin_search_path.sql
+++ b/supabase/migrations/20260608000004_harden_is_admin_search_path.sql
@@ -1,0 +1,30 @@
+-- public.is_admin の SECURITY DEFINER 堅牢化
+-- PR #146 (issue #117) レビュー (CodeRabbit) 指摘対応
+--
+-- 背景:
+--   認可ゲートである public.is_admin は SECURITY DEFINER だが SET search_path が無く、
+--   未修飾の admin_users を参照していた（20250128134809_remote_schema.sql で定義）。
+--   SECURITY DEFINER 関数で search_path を固定しないと、呼び出し元の search_path に
+--   依存して意図しないスキーマのオブジェクトを参照し得る（search_path 注入）。
+--   is_admin は多数の RLS ポリシー・RPC が依存する共有認可関数のため、明示的に固定する。
+--
+-- 変更:
+--   - SET search_path = public を追加
+--   - 参照を FROM public.admin_users にスキーマ修飾
+--   引数・戻り値・ロジックは従来どおりで、CREATE OR REPLACE のため既存の
+--   GRANT / 依存（RLS ポリシー等）は維持される。
+
+CREATE OR REPLACE FUNCTION public.is_admin(user_uid uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path = public
+AS $function$
+BEGIN
+    RETURN EXISTS (
+        SELECT 1
+        FROM public.admin_users
+        WHERE user_id = user_uid
+    );
+END;
+$function$;


### PR DESCRIPTION
getAllUsers (last_sign_in_at) / getAllKoudens (entries_count) は、先に
created_at で range (ページネーション) してから現ページ内だけを JS 側で
並べ替えていたため、対象ページ範囲内でしか並べ替えが効かず、全件にわたる
正しい順序にならなかった。

ソートキー (auth.users.last_sign_in_at / kouden_entries の集計件数) を含めて
DB 側で order + range を行う RPC を追加し、正しい順序のページ分 ID と全件数を
取得するよう修正。詳細情報は既存 RPC を再利用し、RPC が返す順序に並べ直す。

- 追加 migration: get_admin_user_ids_by_last_sign_in /
  get_admin_kouden_ids_by_entries_count (どちらも is_admin(auth.uid()) を強制)
- JS 側の現ページ内ソートを撤去

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 管理画面のユーザー一覧で「最終ログイン日時」によるソートとページネーションの精度を向上
  * 管理画面の香典一覧で「エントリ数」によるソートとページネーションの精度を向上
  * 管理画面での検索結果フィルタリングの整合性を改善

* **Chores**
  * 管理画面の大規模データセット処理パフォーマンスを最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->