### PR TITLE
test(invitations): acceptInvitation RPC のテスト追加と stored_procedures 同期 (#113)

### DIFF
--- a/database/stored_procedures.sql
+++ b/database/stored_procedures.sql
@@ -1,52 +1,83 @@
--- 招待承認のためのストアドプロシージャ
-CREATE OR REPLACE FUNCTION accept_invitation(
-    p_invitation_token UUID,
+-- 招待承認のためのストアドプロシージャ (アトミック版)
+-- Issue: https://github.com/otomatty/kouden/issues/113
+-- Migration: supabase/migrations/20260608000002_add_accept_invitation_atomic_rpc.sql
+--
+-- Server Action (acceptInvitation) は service-role 経由で本 RPC のみを呼び出す。
+-- select ... for update により同一トークンの並列受諾を直列化し、
+-- kouden_members INSERT と used_count 更新を 1 トランザクションで実行する。
+CREATE OR REPLACE FUNCTION public.accept_invitation_atomic(
+    p_token UUID,
     p_user_id UUID
-) RETURNS void AS $$
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
 DECLARE
-    v_invitation RECORD;
+    v_invitation     public.kouden_invitations%ROWTYPE;
+    v_new_used_count integer;
+    v_is_exhausted   boolean;
+    v_inserted_id    uuid;
 BEGIN
-    -- 招待情報を取得
     SELECT * INTO v_invitation
-    FROM kouden_invitations
-    WHERE invitation_token = p_invitation_token
-    AND status = 'pending'
+    FROM public.kouden_invitations
+    WHERE invitation_token = p_token
     FOR UPDATE;
 
-    -- 招待が存在しない場合はエラー
     IF NOT FOUND THEN
-        RAISE EXCEPTION '招待が見つからないか、既に処理されています';
+        RAISE EXCEPTION 'invitation_not_found'
+            USING ERRCODE = 'P0002';
     END IF;
 
-    -- 有効期限をチェック
-    IF v_invitation.expires_at < NOW() THEN
-        UPDATE kouden_invitations
-        SET status = 'expired'
-        WHERE invitation_token = p_invitation_token;
-        
-        RAISE EXCEPTION '招待の有効期限が切れています';
+    IF v_invitation.status <> 'pending' THEN
+        RAISE EXCEPTION 'invitation_not_pending'
+            USING ERRCODE = 'P0001';
     END IF;
 
-    -- メンバーとして追加
-    INSERT INTO kouden_members (
+    IF v_invitation.expires_at < now() THEN
+        RAISE EXCEPTION 'invitation_expired'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF v_invitation.max_uses IS NOT NULL
+       AND v_invitation.used_count >= v_invitation.max_uses THEN
+        RAISE EXCEPTION 'invitation_max_uses_reached'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    INSERT INTO public.kouden_members (
         kouden_id,
         user_id,
         role_id,
+        invitation_id,
         added_by
     ) VALUES (
         v_invitation.kouden_id,
         p_user_id,
         v_invitation.role_id,
+        v_invitation.id,
         v_invitation.created_by
-    );
+    )
+    ON CONFLICT (kouden_id, user_id) DO NOTHING
+    RETURNING id INTO v_inserted_id;
 
-    -- 招待のステータスを更新
-    UPDATE kouden_invitations
-    SET status = 'accepted'
-    WHERE invitation_token = p_invitation_token;
+    IF v_inserted_id IS NULL THEN
+        RAISE EXCEPTION 'already_member'
+            USING ERRCODE = '23505';
+    END IF;
 
-EXCEPTION
-    WHEN unique_violation THEN
-        RAISE EXCEPTION 'すでにメンバーとして登録されています';
+    v_new_used_count := v_invitation.used_count + 1;
+    v_is_exhausted := v_invitation.max_uses IS NOT NULL
+                      AND v_new_used_count >= v_invitation.max_uses;
+
+    UPDATE public.kouden_invitations
+    SET used_count = v_new_used_count,
+        status     = CASE WHEN v_is_exhausted THEN 'accepted'::invitation_status ELSE status END,
+        updated_at = now()
+    WHERE id = v_invitation.id;
 END;
-$$ LANGUAGE plpgsql; 
+$$;
+
+REVOKE ALL ON FUNCTION public.accept_invitation_atomic(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.accept_invitation_atomic(uuid, uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_invitation_atomic(uuid, uuid) TO service_role;

--- a/database/stored_procedures.sql
+++ b/database/stored_procedures.sql
@@ -5,6 +5,8 @@
 -- Server Action (acceptInvitation) は service-role 経由で本 RPC のみを呼び出す。
 -- select ... for update により同一トークンの並列受諾を直列化し、
 -- kouden_members INSERT と used_count 更新を 1 トランザクションで実行する。
+DROP FUNCTION IF EXISTS public.accept_invitation(uuid, uuid);
+
 CREATE OR REPLACE FUNCTION public.accept_invitation_atomic(
     p_token UUID,
     p_user_id UUID

--- a/src/app/_actions/__tests__/invitations-accept.test.ts
+++ b/src/app/_actions/__tests__/invitations-accept.test.ts
@@ -30,6 +30,7 @@ describe("acceptInvitation", () => {
 	let adminClientMock: MockAdminClient;
 
 	beforeEach(() => {
+		vi.clearAllMocks();
 		userClientMock = {
 			auth: {
 				getUser: vi.fn().mockResolvedValue({
@@ -64,6 +65,7 @@ describe("acceptInvitation", () => {
 			ok: false,
 			error: { code: ErrorCodes.NOT_FOUND },
 		});
+		expect(createClient).not.toHaveBeenCalled();
 		expect(adminClientMock.rpc).not.toHaveBeenCalled();
 	});
 

--- a/src/app/_actions/__tests__/invitations-accept.test.ts
+++ b/src/app/_actions/__tests__/invitations-accept.test.ts
@@ -15,11 +15,19 @@ vi.mock("@/lib/supabase/admin", () => ({
 
 const VALID_TOKEN = "11111111-1111-4111-8111-111111111111";
 
+interface MockUserClient {
+	auth: {
+		getUser: ReturnType<typeof vi.fn>;
+	};
+}
+
+interface MockAdminClient {
+	rpc: ReturnType<typeof vi.fn>;
+}
+
 describe("acceptInvitation", () => {
-	// biome-ignore lint/suspicious/noExplicitAny: supabase mock
-	let userClientMock: any;
-	// biome-ignore lint/suspicious/noExplicitAny: supabase mock
-	let adminClientMock: any;
+	let userClientMock: MockUserClient;
+	let adminClientMock: MockAdminClient;
 
 	beforeEach(() => {
 		userClientMock = {
@@ -33,10 +41,8 @@ describe("acceptInvitation", () => {
 			rpc: vi.fn().mockResolvedValue({ error: null }),
 		};
 
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createClient as any).mockResolvedValue(userClientMock);
-		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(createAdminClient as any).mockReturnValue(adminClientMock);
+		vi.mocked(createClient).mockResolvedValue(userClientMock as never);
+		vi.mocked(createAdminClient).mockReturnValue(adminClientMock as never);
 	});
 
 	it("未認証時に ok:false / UNAUTHORIZED を返す", async () => {
@@ -44,30 +50,30 @@ describe("acceptInvitation", () => {
 
 		const result = await acceptInvitation(VALID_TOKEN);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error.code).toBe(ErrorCodes.UNAUTHORIZED);
-		}
+		expect(result).toMatchObject({
+			ok: false,
+			error: { code: ErrorCodes.UNAUTHORIZED },
+		});
 		expect(adminClientMock.rpc).not.toHaveBeenCalled();
 	});
 
 	it("不正なトークン形式は ok:false / NOT_FOUND を返す", async () => {
 		const result = await acceptInvitation("not-a-uuid");
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error.code).toBe(ErrorCodes.NOT_FOUND);
-		}
+		expect(result).toMatchObject({
+			ok: false,
+			error: { code: ErrorCodes.NOT_FOUND },
+		});
 		expect(adminClientMock.rpc).not.toHaveBeenCalled();
 	});
 
 	it("RPC 成功時に ok:true を返す", async () => {
 		const result = await acceptInvitation(VALID_TOKEN);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data).toBeNull();
-		}
+		expect(result).toMatchObject({
+			ok: true,
+			data: null,
+		});
 		expect(adminClientMock.rpc).toHaveBeenCalledWith("accept_invitation_atomic", {
 			p_token: VALID_TOKEN,
 			p_user_id: "user-1",
@@ -75,22 +81,22 @@ describe("acceptInvitation", () => {
 	});
 
 	it.each([
-		["invitation_not_found", ErrorCodes.NOT_FOUND],
-		["invitation_not_pending", ErrorCodes.INVALID_OPERATION],
-		["invitation_expired", ErrorCodes.INVALID_OPERATION],
-		["invitation_max_uses_reached", ErrorCodes.INVALID_OPERATION],
-		["already_member", ErrorCodes.ALREADY_EXISTS],
-	])("RPC エラー %s を KoudenError にマップする", async (message, code) => {
+		["invitation_not_found", "P0002", ErrorCodes.NOT_FOUND],
+		["invitation_not_pending", "P0001", ErrorCodes.INVALID_OPERATION],
+		["invitation_expired", "P0001", ErrorCodes.INVALID_OPERATION],
+		["invitation_max_uses_reached", "P0001", ErrorCodes.INVALID_OPERATION],
+		["already_member", "23505", ErrorCodes.ALREADY_EXISTS],
+	])("RPC エラー %s (%s) を KoudenError にマップする", async (message, pgCode, code) => {
 		adminClientMock.rpc.mockResolvedValue({
-			error: { message, code: "P0001" },
+			error: { message, code: pgCode },
 		});
 
 		const result = await acceptInvitation(VALID_TOKEN);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error.code).toBe(code);
-		}
+		expect(result).toMatchObject({
+			ok: false,
+			error: { code },
+		});
 	});
 
 	it("想定外の RPC エラーは ok:false を返す", async () => {
@@ -100,9 +106,9 @@ describe("acceptInvitation", () => {
 
 		const result = await acceptInvitation(VALID_TOKEN);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error.code).toBe(ErrorCodes.DB_FETCH_ERROR);
-		}
+		expect(result).toMatchObject({
+			ok: false,
+			error: { code: ErrorCodes.DB_FETCH_ERROR },
+		});
 	});
 });

--- a/src/app/_actions/__tests__/invitations-accept.test.ts
+++ b/src/app/_actions/__tests__/invitations-accept.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="vitest" />
+import { acceptInvitation } from "@/app/_actions/invitations";
+import { ErrorCodes } from "@/lib/errors";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+	createAdminClient: vi.fn(),
+}));
+
+const VALID_TOKEN = "11111111-1111-4111-8111-111111111111";
+
+describe("acceptInvitation", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: supabase mock
+	let userClientMock: any;
+	// biome-ignore lint/suspicious/noExplicitAny: supabase mock
+	let adminClientMock: any;
+
+	beforeEach(() => {
+		userClientMock = {
+			auth: {
+				getUser: vi.fn().mockResolvedValue({
+					data: { user: { id: "user-1" } },
+				}),
+			},
+		};
+		adminClientMock = {
+			rpc: vi.fn().mockResolvedValue({ error: null }),
+		};
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createClient as any).mockResolvedValue(userClientMock);
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(createAdminClient as any).mockReturnValue(adminClientMock);
+	});
+
+	it("未認証時に ok:false / UNAUTHORIZED を返す", async () => {
+		userClientMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+
+		const result = await acceptInvitation(VALID_TOKEN);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe(ErrorCodes.UNAUTHORIZED);
+		}
+		expect(adminClientMock.rpc).not.toHaveBeenCalled();
+	});
+
+	it("不正なトークン形式は ok:false / NOT_FOUND を返す", async () => {
+		const result = await acceptInvitation("not-a-uuid");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe(ErrorCodes.NOT_FOUND);
+		}
+		expect(adminClientMock.rpc).not.toHaveBeenCalled();
+	});
+
+	it("RPC 成功時に ok:true を返す", async () => {
+		const result = await acceptInvitation(VALID_TOKEN);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toBeNull();
+		}
+		expect(adminClientMock.rpc).toHaveBeenCalledWith("accept_invitation_atomic", {
+			p_token: VALID_TOKEN,
+			p_user_id: "user-1",
+		});
+	});
+
+	it.each([
+		["invitation_not_found", ErrorCodes.NOT_FOUND],
+		["invitation_not_pending", ErrorCodes.INVALID_OPERATION],
+		["invitation_expired", ErrorCodes.INVALID_OPERATION],
+		["invitation_max_uses_reached", ErrorCodes.INVALID_OPERATION],
+		["already_member", ErrorCodes.ALREADY_EXISTS],
+	])("RPC エラー %s を KoudenError にマップする", async (message, code) => {
+		adminClientMock.rpc.mockResolvedValue({
+			error: { message, code: "P0001" },
+		});
+
+		const result = await acceptInvitation(VALID_TOKEN);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe(code);
+		}
+	});
+
+	it("想定外の RPC エラーは ok:false を返す", async () => {
+		adminClientMock.rpc.mockResolvedValue({
+			error: { message: "unexpected_db_error", code: "XX000" },
+		});
+
+		const result = await acceptInvitation(VALID_TOKEN);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe(ErrorCodes.DB_FETCH_ERROR);
+		}
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #113 のコア実装は PR #144 で main にマージ済みです。本 PR は残作業として以下を追加します。

- `acceptInvitation` Server Action の単体テスト（RPC 呼び出し・エラーマッピング）
- `database/stored_procedures.sql` を `accept_invitation_atomic` RPC 定義に同期

## 変更内容

### テスト (`src/app/_actions/__tests__/invitations-accept.test.ts`)

- 未認証 / 不正トークン / RPC 成功パス
- RPC が raise する 5 種類のエラートークン → `ErrorCodes` マッピング（実際の SQLSTATE を使用）
- 想定外 DB エラーのフォールバック
- `toMatchObject` による型安全なアサーション、interface ベースのモック型

### ドキュメント (`database/stored_procedures.sql`)

- 旧 `accept_invitation` を `DROP` してから `accept_invitation_atomic` を定義
- マイグレーション (`20260608000002`) と同等の内容

## DB マイグレーション

Supabase (Kouden プロジェクト) に `add_accept_invitation_atomic_rpc` マイグレーションを適用済みです。

## 関連

- Closes #113
- PR #144 (コア実装)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d95bd7-2542-44d5-baa3-b97460e04f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d95bd7-2542-44d5-baa3-b97460e04f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 招待承認処理を原子的に再設計し、並行競合・期限切れ・使用回数の境界での不整合を防止、安定性と一貫性を向上しました。
  * 実行権限と呼び出し制御を整理し、承認操作の安全性を強化しました。

* **Tests**
  * 招待承認フローの単体テストを追加し、未認証・入力エラー・各種DBエラー・成功時の振る舞いを網羅しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->