### PR TITLE
refactor(permissions): 香典帳編集権限チェックを requireKoudenEditor に統一

### DIFF
--- a/src/app/_actions/permissions.ts
+++ b/src/app/_actions/permissions.ts
@@ -110,7 +110,7 @@ export async function canEditKouden(koudenId: string): Promise<boolean> {
 
 	// 1回のクエリで所有者チェックとメンバーロールチェックを実行
 	// RLS無限再帰を避けるため、直接JOINして権限を確認
-	const { data } = await supabase
+	const { data, error } = await supabase
 		.from("koudens")
 		.select(`
 			owner_id,
@@ -125,6 +125,14 @@ export async function canEditKouden(koudenId: string): Promise<boolean> {
 		`)
 		.eq("id", koudenId)
 		.single();
+
+	// PGRST116 (0 行) は香典帳未存在またはアクセス不可。それ以外は DB エラーとして扱う。
+	if (error) {
+		if (error.code === "PGRST116") {
+			return false;
+		}
+		throw new KoudenError("権限の取得に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+	}
 
 	if (!data) return false;
 

--- a/src/app/_actions/permissions.ts
+++ b/src/app/_actions/permissions.ts
@@ -1,27 +1,9 @@
 "use server";
 
-import { KoudenError } from "@/lib/errors";
+import { ErrorCodes, KoudenError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
-import type { KoudenPermission, KoudenRole } from "@/types/role";
+import type { KoudenPermission } from "@/types/role";
 import { cache } from "react";
-
-// 権限チェックのユーティリティ関数
-export const withPermissionCheck = async <T>(
-	koudenId: string,
-	requiredPermission: KoudenPermission,
-	action: () => Promise<T>,
-): Promise<T> => {
-	const permission = await checkKoudenPermission(koudenId);
-	const hasPermission =
-		permission === requiredPermission ||
-		permission === "owner" ||
-		(permission === "editor" && requiredPermission === "viewer");
-
-	if (!hasPermission) {
-		throw new KoudenError("権限がありません", "INSUFFICIENT_PERMISSION");
-	}
-	return action();
-};
 
 // 権限チェック関数（キャッシュ対応）
 export const checkKoudenPermission = cache(async (koudenId: string): Promise<KoudenPermission> => {
@@ -71,6 +53,21 @@ export const checkKoudenPermission = cache(async (koudenId: string): Promise<Kou
 
 	throw new KoudenError("不明な権限です", "UNKNOWN_PERMISSION");
 });
+
+/**
+ * 香典帳の編集権限（owner / editor）を要求する
+ * @param koudenId 香典帳ID
+ * @param message 権限不足時のエラーメッセージ
+ */
+export async function requireKoudenEditor(
+	koudenId: string,
+	message = "編集権限がありません",
+): Promise<void> {
+	const permission = await checkKoudenPermission(koudenId);
+	if (permission !== "owner" && permission !== "editor") {
+		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
+	}
+}
 
 // 管理者権限チェック関数（キャッシュ対応）
 export const isKoudenOwner = cache(async (koudenId: string): Promise<boolean> => {

--- a/src/app/_actions/permissions.ts
+++ b/src/app/_actions/permissions.ts
@@ -63,8 +63,10 @@ export async function requireKoudenEditor(
 	koudenId: string,
 	message = "編集権限がありません",
 ): Promise<void> {
-	const permission = await checkKoudenPermission(koudenId);
-	if (permission !== "owner" && permission !== "editor") {
+	// canEditKouden は left join で owner/created_by を考慮し、
+	// 非メンバーは false を返す（checkKoudenPermission の inner join は FETCH_PERMISSION_ERROR になる）
+	const canEdit = await canEditKouden(koudenId);
+	if (!canEdit) {
 		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
 	}
 }

--- a/src/app/_actions/return-records/return-items.ts
+++ b/src/app/_actions/return-records/return-items.ts
@@ -5,7 +5,7 @@
  * @module return-items
  */
 
-import { checkKoudenPermission } from "@/app/_actions/permissions";
+import { requireKoudenEditor } from "@/app/_actions/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
@@ -61,27 +61,7 @@ export async function createReturnItem(
 			created_by: user.id,
 		};
 
-		// 権限の確認
-		const { data: permission, error: permissionError } = await supabase
-			.from("kouden_members")
-			.select(`
-				kouden_roles (
-					name
-				)
-			`)
-			.eq("kouden_id", input.kouden_id)
-			.eq("user_id", user.id)
-			.single();
-
-		if (permissionError || !permission) {
-			throw new KoudenError("この香典帳に対する権限がありません", ErrorCodes.FORBIDDEN);
-		}
-
-		const roleName = permission.kouden_roles?.name;
-		const hasPermission = ["owner", "editor"].includes(roleName ?? "");
-		if (!hasPermission) {
-			throw new KoudenError("返礼品の作成権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(input.kouden_id, "返礼品の作成権限がありません");
 
 		const { error } = await supabase.from("return_items").insert(returnItemData);
 
@@ -157,11 +137,7 @@ export async function updateReturnItem(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(input.kouden_id);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼品マスター情報の更新権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(input.kouden_id, "返礼品マスター情報の更新権限がありません");
 
 		const { id, kouden_id, ...updateData } = input;
 
@@ -203,11 +179,7 @@ export async function deleteReturnItem(id: string, koudenId: string): Promise<Ac
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼品マスター情報の削除権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼品マスター情報の削除権限がありません");
 
 		const { error } = await supabase.from("return_items").delete().eq("id", id);
 

--- a/src/app/_actions/return-records/return-record-items.ts
+++ b/src/app/_actions/return-records/return-record-items.ts
@@ -5,7 +5,7 @@
  * @module return-record-items
  */
 
-import { checkKoudenPermission } from "@/app/_actions/permissions";
+import { requireKoudenEditor } from "@/app/_actions/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
@@ -35,11 +35,7 @@ export async function createReturnRecordItem(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼品詳細情報の作成権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼品詳細情報の作成権限がありません");
 
 		const { data, error } = await supabase
 			.from("return_record_items")
@@ -139,11 +135,7 @@ export async function updateReturnRecordItem(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼品詳細情報の更新権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼品詳細情報の更新権限がありません");
 
 		// 更新前の情報を取得して返礼情報IDを保持
 		const existingItem = await getReturnRecordItemInternal(input.id);
@@ -197,11 +189,7 @@ export async function deleteReturnRecordItem(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼品詳細情報の削除権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼品詳細情報の削除権限がありません");
 
 		// 削除前の情報を取得して返礼情報IDを保持
 		const existingItem = await getReturnRecordItemInternal(id);

--- a/src/app/_actions/return-records/return-record-selected-methods.ts
+++ b/src/app/_actions/return-records/return-record-selected-methods.ts
@@ -5,7 +5,7 @@
  * @module return-record-selected-methods
  */
 
-import { checkKoudenPermission } from "@/app/_actions/permissions";
+import { requireKoudenEditor } from "@/app/_actions/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import type {
@@ -31,11 +31,7 @@ export async function createReturnRecordSelectedMethod(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼方法選択の作成権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼方法選択の作成権限がありません");
 
 		const { data, error } = await supabase
 			.from("return_record_selected_methods")
@@ -116,11 +112,7 @@ export async function updateReturnRecordSelectedMethod(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼方法選択の更新権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼方法選択の更新権限がありません");
 
 		const { id, ...updateData } = input;
 		const { data, error } = await supabase
@@ -159,11 +151,7 @@ export async function deleteReturnRecordSelectedMethod(
 			throw new KoudenError("認証されていません", ErrorCodes.UNAUTHORIZED);
 		}
 
-		// 編集権限 (owner / editor) を確認
-		const permission = await checkKoudenPermission(koudenId);
-		if (!["owner", "editor"].includes(permission)) {
-			throw new KoudenError("返礼方法選択の削除権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(koudenId, "返礼方法選択の削除権限がありません");
 
 		const { error } = await supabase.from("return_record_selected_methods").delete().eq("id", id);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #130 に対応し、return-records 系 Server Actions の編集権限チェックを `requireKoudenEditor` に集約しました。

## 変更内容

- `src/app/_actions/permissions.ts`
  - `requireKoudenEditor(koudenId, message?)` を追加
  - 未使用の `withPermissionCheck` を削除
  - `canEditKouden`（left join）を内部で使用し、`owner_id` / `created_by` を考慮しつつ非メンバーには `FORBIDDEN` を返す
- `src/app/_actions/return-records/return-record-items.ts`
  - 3箇所の `["owner", "editor"].includes(...)` を `requireKoudenEditor` に置き換え
- `src/app/_actions/return-records/return-record-selected-methods.ts`
  - 3箇所のインライン権限チェックを `requireKoudenEditor` に置き換え
- `src/app/_actions/return-records/return-items.ts`
  - `createReturnItem` の独自 `kouden_members` クエリを `requireKoudenEditor` に置き換え
  - `updateReturnItem` / `deleteReturnItem` のインライン権限チェックも統一

## レビュー対応

Codex の指摘に対応: `checkKoudenPermission` の inner join は非メンバーで `FETCH_PERMISSION_ERROR`（500相当）になるため、`requireKoudenEditor` は `canEditKouden` を使用するよう変更しました。

## 完了条件

- [x] `["owner", "editor"].includes(...)` のインライン分岐が return-records から消える
- [x] `return-items.ts` の独自 `kouden_members` クエリが `requireKoudenEditor` に置き換わる
- [x] 未使用の `withPermissionCheck` を削除

## テスト

- `bun run test -- --run` — 391 passed, 1 skipped

Closes #130
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4953c903-1fb7-4f3c-9704-d830cf8124a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4953c903-1fb7-4f3c-9704-d830cf8124a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 編集権限（owner/editor相当）を要求する公開ヘルパーを追加しました。

* **バグ修正**
  * 権限不足時のエラーハンドリングを改善し、許可されていない操作が確実に拒否されるようにしました。
  * データ取得時のエラー判定を明確化しました。

* **Refactor**
  * 複数の返礼関連操作で権限チェックを統一し、作成・更新・削除の挙動を一貫化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->