### PR TITLE
refactor(permissions): 重複・未使用 API を整理し権限チェックを統一

### DIFF
--- a/src/app/_actions/__tests__/koudens-delete.test.ts
+++ b/src/app/_actions/__tests__/koudens-delete.test.ts
@@ -1,12 +1,12 @@
 /// <reference types="vitest" />
-import { canDeleteKouden } from "@/app/_actions/permissions";
-import { ErrorCodes } from "@/lib/errors";
+import { requireKoudenOwner } from "@/app/_actions/permissions";
+import { ErrorCodes, KoudenError } from "@/lib/errors";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteKouden } from "../koudens/delete";
 
 vi.mock("@/app/_actions/permissions", () => ({
-	canDeleteKouden: vi.fn(),
+	requireKoudenOwner: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -33,13 +33,14 @@ describe("deleteKouden", () => {
 
 	it("権限不足時に ok:false / FORBIDDEN を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(canDeleteKouden as any).mockResolvedValue(false);
+		(requireKoudenOwner as any).mockRejectedValue(
+			new KoudenError("削除権限がありません", ErrorCodes.FORBIDDEN),
+		);
 
 		const result = await deleteKouden("kouden-1");
 
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
-			// FORBIDDEN は KoudenError の既定 userMessage（権限不足）にマップされる
 			expect(result.error.code).toBe(ErrorCodes.FORBIDDEN);
 			expect(result.error.message).toContain("権限");
 		}
@@ -48,21 +49,20 @@ describe("deleteKouden", () => {
 
 	it("DB エラー時に ok:false を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(canDeleteKouden as any).mockResolvedValue(true);
+		(requireKoudenOwner as any).mockResolvedValue(undefined);
 		supabaseMock.eq.mockResolvedValue({ error: { message: "boom", code: "23503" } });
 
 		const result = await deleteKouden("kouden-1");
 
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
-			// 外部キー制約 (23503) は DB_CONSTRAINT_ERROR にマップされる
 			expect(result.error.code).toBe(ErrorCodes.DB_CONSTRAINT_ERROR);
 		}
 	});
 
 	it("成功時に ok:true を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(canDeleteKouden as any).mockResolvedValue(true);
+		(requireKoudenOwner as any).mockResolvedValue(undefined);
 		supabaseMock.eq.mockResolvedValue({ error: null });
 
 		const result = await deleteKouden("kouden-1");
@@ -78,7 +78,7 @@ describe("deleteKouden", () => {
 
 	it("予期せぬ例外時にも ok:false を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(canDeleteKouden as any).mockRejectedValue(new Error("unexpected"));
+		(requireKoudenOwner as any).mockRejectedValue(new Error("unexpected"));
 
 		const result = await deleteKouden("kouden-1");
 

--- a/src/app/_actions/__tests__/koudens-delete.test.ts
+++ b/src/app/_actions/__tests__/koudens-delete.test.ts
@@ -1,12 +1,12 @@
 /// <reference types="vitest" />
-import { requireKoudenOwner } from "@/app/_actions/permissions";
+import { requireKoudenRecordOwner } from "@/app/_actions/permissions";
 import { ErrorCodes, KoudenError } from "@/lib/errors";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteKouden } from "../koudens/delete";
 
 vi.mock("@/app/_actions/permissions", () => ({
-	requireKoudenOwner: vi.fn(),
+	requireKoudenRecordOwner: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -33,7 +33,7 @@ describe("deleteKouden", () => {
 
 	it("権限不足時に ok:false / FORBIDDEN を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(requireKoudenOwner as any).mockRejectedValue(
+		(requireKoudenRecordOwner as any).mockRejectedValue(
 			new KoudenError("削除権限がありません", ErrorCodes.FORBIDDEN),
 		);
 
@@ -49,7 +49,7 @@ describe("deleteKouden", () => {
 
 	it("DB エラー時に ok:false を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(requireKoudenOwner as any).mockResolvedValue(undefined);
+		(requireKoudenRecordOwner as any).mockResolvedValue(undefined);
 		supabaseMock.eq.mockResolvedValue({ error: { message: "boom", code: "23503" } });
 
 		const result = await deleteKouden("kouden-1");
@@ -62,7 +62,7 @@ describe("deleteKouden", () => {
 
 	it("成功時に ok:true を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(requireKoudenOwner as any).mockResolvedValue(undefined);
+		(requireKoudenRecordOwner as any).mockResolvedValue(undefined);
 		supabaseMock.eq.mockResolvedValue({ error: null });
 
 		const result = await deleteKouden("kouden-1");
@@ -78,7 +78,7 @@ describe("deleteKouden", () => {
 
 	it("予期せぬ例外時にも ok:false を返す", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: mock
-		(requireKoudenOwner as any).mockRejectedValue(new Error("unexpected"));
+		(requireKoudenRecordOwner as any).mockRejectedValue(new Error("unexpected"));
 
 		const result = await deleteKouden("kouden-1");
 

--- a/src/app/_actions/__tests__/permissions.test.ts
+++ b/src/app/_actions/__tests__/permissions.test.ts
@@ -177,6 +177,15 @@ describe("permissions", () => {
 	});
 
 	describe("requireKoudenEditor", () => {
+		it("未認証の場合は UNAUTHORIZED を投げる", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(buildSupabase({ userId: null }));
+
+			await expect(requireKoudenEditor("kouden-1")).rejects.toMatchObject({
+				code: ErrorCodes.UNAUTHORIZED,
+			});
+		});
+
 		it("viewer は FORBIDDEN を投げる", async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: mock
 			(createClient as any).mockResolvedValue(
@@ -196,6 +205,23 @@ describe("permissions", () => {
 			);
 
 			await expect(requireKoudenEditor("kouden-1")).rejects.toBeInstanceOf(KoudenError);
+		});
+	});
+
+	describe("canDeleteKouden", () => {
+		it("created_by のみのユーザーは削除不可", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other-owner",
+						created_by: "user-1",
+						kouden_members: null,
+					},
+				}),
+			);
+
+			await expect(canDeleteKouden("kouden-1")).resolves.toBe(false);
 		});
 	});
 

--- a/src/app/_actions/__tests__/permissions.test.ts
+++ b/src/app/_actions/__tests__/permissions.test.ts
@@ -1,0 +1,226 @@
+/// <reference types="vitest" />
+import { ErrorCodes, KoudenError } from "@/lib/errors";
+import { createClient } from "@/lib/supabase/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	canDeleteKouden,
+	checkKoudenPermission,
+	getKoudenPermission,
+	hasEditPermission,
+	hasKoudenAccess,
+	isKoudenOwner,
+	requireKoudenEditor,
+	requireKoudenOwner,
+} from "../permissions";
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+type MemberRow = {
+	role_id: string;
+	user_id: string;
+	kouden_roles: { name: string } | null;
+};
+
+function buildSupabase({
+	userId = "user-1",
+	koudenRow,
+	error = null,
+}: {
+	userId?: string | null;
+	koudenRow?: {
+		owner_id: string;
+		created_by: string;
+		kouden_members: MemberRow[] | null;
+	} | null;
+	error?: { code: string; message: string } | null;
+}) {
+	return {
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: userId ? { id: userId } : null },
+				error: null,
+			}),
+		},
+		from: vi.fn().mockReturnValue({
+			select: vi.fn().mockReturnValue({
+				eq: vi.fn().mockReturnValue({
+					single: vi.fn().mockResolvedValue({
+						data: koudenRow ?? null,
+						error,
+					}),
+				}),
+			}),
+		}),
+	};
+}
+
+describe("permissions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+	});
+
+	describe("getKoudenPermission", () => {
+		it("owner_id が一致する場合は owner を返す", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "user-1",
+						created_by: "other",
+						kouden_members: null,
+					},
+				}),
+			);
+
+			await expect(getKoudenPermission("kouden-1")).resolves.toBe("owner");
+		});
+
+		it("editor メンバーは editor を返す", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [
+							{
+								role_id: "role-1",
+								user_id: "user-1",
+								kouden_roles: { name: "editor" },
+							},
+						],
+					},
+				}),
+			);
+
+			await expect(getKoudenPermission("kouden-1")).resolves.toBe("editor");
+		});
+
+		it("未認証の場合は null を返す", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(buildSupabase({ userId: null }));
+
+			await expect(getKoudenPermission("kouden-1")).resolves.toBeNull();
+		});
+
+		it("非メンバーは null を返す", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [],
+					},
+				}),
+			);
+
+			await expect(getKoudenPermission("kouden-1")).resolves.toBeNull();
+		});
+	});
+
+	describe("checkKoudenPermission", () => {
+		it("未認証の場合は UNAUTHORIZED を投げる", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(buildSupabase({ userId: null }));
+
+			await expect(checkKoudenPermission("kouden-1")).rejects.toMatchObject({
+				code: ErrorCodes.UNAUTHORIZED,
+			});
+		});
+
+		it("非メンバーは FORBIDDEN を投げる", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [],
+					},
+				}),
+			);
+
+			await expect(checkKoudenPermission("kouden-1")).rejects.toMatchObject({
+				code: ErrorCodes.FORBIDDEN,
+			});
+		});
+	});
+
+	describe("boolean helpers", () => {
+		it("hasKoudenAccess は viewer でも true", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [
+							{
+								role_id: "role-1",
+								user_id: "user-1",
+								kouden_roles: { name: "viewer" },
+							},
+						],
+					},
+				}),
+			);
+
+			await expect(hasKoudenAccess("kouden-1")).resolves.toBe(true);
+			await expect(hasEditPermission("kouden-1")).resolves.toBe(false);
+			await expect(isKoudenOwner("kouden-1")).resolves.toBe(false);
+			await expect(canDeleteKouden("kouden-1")).resolves.toBe(false);
+		});
+	});
+
+	describe("requireKoudenEditor", () => {
+		it("viewer は FORBIDDEN を投げる", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [
+							{
+								role_id: "role-1",
+								user_id: "user-1",
+								kouden_roles: { name: "viewer" },
+							},
+						],
+					},
+				}),
+			);
+
+			await expect(requireKoudenEditor("kouden-1")).rejects.toBeInstanceOf(KoudenError);
+		});
+	});
+
+	describe("requireKoudenOwner", () => {
+		it("editor は FORBIDDEN を投げる", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: mock
+			(createClient as any).mockResolvedValue(
+				buildSupabase({
+					koudenRow: {
+						owner_id: "other",
+						created_by: "other",
+						kouden_members: [
+							{
+								role_id: "role-1",
+								user_id: "user-1",
+								kouden_roles: { name: "editor" },
+							},
+						],
+					},
+				}),
+			);
+
+			await expect(requireKoudenOwner("kouden-1")).rejects.toMatchObject({
+				code: ErrorCodes.FORBIDDEN,
+			});
+		});
+	});
+});

--- a/src/app/_actions/koudens/delete.ts
+++ b/src/app/_actions/koudens/delete.ts
@@ -3,7 +3,7 @@
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidatePath } from "next/cache";
-import { canDeleteKouden } from "../permissions";
+import { requireKoudenOwner } from "../permissions";
 
 /**
  * 香典帳を削除する。
@@ -14,10 +14,7 @@ import { canDeleteKouden } from "../permissions";
 export async function deleteKouden(id: string): Promise<ActionResult<null>> {
 	try {
 		return await withActionResult(async () => {
-			const hasPermission = await canDeleteKouden(id);
-			if (!hasPermission) {
-				throw new KoudenError("削除権限がありません", ErrorCodes.FORBIDDEN);
-			}
+			await requireKoudenOwner(id, "削除権限がありません");
 
 			const supabase = createAdminClient();
 			const { error } = await supabase.from("koudens").delete().eq("id", id);

--- a/src/app/_actions/koudens/delete.ts
+++ b/src/app/_actions/koudens/delete.ts
@@ -3,7 +3,7 @@
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidatePath } from "next/cache";
-import { requireKoudenOwner } from "../permissions";
+import { requireKoudenRecordOwner } from "../permissions";
 
 /**
  * 香典帳を削除する。
@@ -14,7 +14,7 @@ import { requireKoudenOwner } from "../permissions";
 export async function deleteKouden(id: string): Promise<ActionResult<null>> {
 	try {
 		return await withActionResult(async () => {
-			await requireKoudenOwner(id, "削除権限がありません");
+			await requireKoudenRecordOwner(id, "削除権限がありません");
 
 			const supabase = createAdminClient();
 			const { error } = await supabase.from("koudens").delete().eq("id", id);

--- a/src/app/_actions/koudens/duplicate.ts
+++ b/src/app/_actions/koudens/duplicate.ts
@@ -4,7 +4,7 @@ import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/
 import { createClient } from "@/lib/supabase/server";
 import type { KoudenWithOwner } from "@/types/kouden";
 import { KOUDEN_ROLES } from "@/types/role";
-import { checkKoudenPermission } from "../permissions";
+import { requireKoudenEditor } from "../permissions";
 
 /**
  * 香典帳の複製（デフォルトで free プラン適用）
@@ -14,10 +14,7 @@ import { checkKoudenPermission } from "../permissions";
 export async function duplicateKouden(id: string): Promise<ActionResult<KoudenWithOwner>> {
 	return withActionResult(async () => {
 		const supabase = await createClient();
-		const role = await checkKoudenPermission(id);
-		if (!role || (role !== "owner" && role !== "editor")) {
-			throw new KoudenError("複製権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(id, "複製権限がありません");
 
 		const { data: authData, error: authError } = await supabase.auth.getUser();
 		const user = authData.user;

--- a/src/app/_actions/koudens/update.ts
+++ b/src/app/_actions/koudens/update.ts
@@ -5,7 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Kouden } from "@/types/kouden";
 import { KOUDEN_ROLES } from "@/types/role";
 import { revalidatePath } from "next/cache";
-import { canEditKouden, checkKoudenPermission } from "../permissions";
+import { requireKoudenEditor, requireKoudenOwner } from "../permissions";
 
 /**
  * 香典帳の更新
@@ -28,11 +28,7 @@ export async function updateKouden(
 			throw new KoudenError("説明は500文字以内で入力してください", ErrorCodes.VALIDATION_ERROR);
 		}
 
-		// 権限チェック（最適化版を使用）
-		const canEdit = await canEditKouden(id);
-		if (!canEdit) {
-			throw new KoudenError("この香典帳を編集する権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenEditor(id, "この香典帳を編集する権限がありません");
 
 		const supabase = await createClient();
 
@@ -57,11 +53,7 @@ export async function updateKouden(
 export async function shareKouden(id: string, userIds: string[]): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
 		const supabase = await createClient();
-		const role = await checkKoudenPermission(id);
-
-		if (role !== "owner") {
-			throw new KoudenError("共有権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenOwner(id, "共有権限がありません");
 
 		const {
 			data: { user },
@@ -107,11 +99,7 @@ export async function shareKouden(id: string, userIds: string[]): Promise<Action
 export async function archiveKouden(id: string): Promise<ActionResult<Kouden>> {
 	return withActionResult(async () => {
 		const supabase = await createClient();
-		const role = await checkKoudenPermission(id);
-
-		if (role !== "owner") {
-			throw new KoudenError("アーカイブ権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenOwner(id, "アーカイブ権限がありません");
 
 		const { data, error } = await supabase
 			.from("koudens")

--- a/src/app/_actions/permissions.ts
+++ b/src/app/_actions/permissions.ts
@@ -1,115 +1,61 @@
 "use server";
 
+/**
+ * 香典帳の権限チェック API
+ *
+ * ## 使い分け
+ *
+ * ### 読み取り用（boolean / role）
+ * - `getKoudenPermission` — ロール取得。アクセス不可は `null`
+ * - `hasKoudenAccess` — アクセス可能か
+ * - `hasEditPermission` — 編集可能か（owner / editor）
+ * - `isKoudenOwner` — オーナーか
+ * - `canDeleteKouden` — 削除可能か（オーナーのみ）
+ *
+ * ### 書き込み用（throw）
+ * - `requireKoudenAccess` — アクセス権必須（ロールを返す）
+ * - `requireKoudenEditor` — 編集権限必須
+ * - `requireKoudenOwner` — オーナー権限必須
+ *
+ * ### 後方互換
+ * - `checkKoudenPermission` — `requireKoudenAccess` のエイリアス
+ *
+ * すべての判定は `fetchKoudenAccess`（left join 1 クエリ）を共有する。
+ * RLS 無限再帰を避けるため、inner join は使用しない。
+ */
+
 import { ErrorCodes, KoudenError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import type { KoudenPermission } from "@/types/role";
 import { cache } from "react";
 
-// 権限チェック関数（キャッシュ対応）
-export const checkKoudenPermission = cache(async (koudenId: string): Promise<KoudenPermission> => {
+type KoudenMemberRow = {
+	role_id: string;
+	user_id: string;
+	kouden_roles: { name: string } | null;
+};
+
+type KoudenAccessRow = {
+	owner_id: string;
+	created_by: string;
+	kouden_members: KoudenMemberRow[] | null;
+};
+
+type KoudenAccessContext = {
+	userId: string;
+	row: KoudenAccessRow;
+};
+
+const fetchKoudenAccess = cache(async (koudenId: string): Promise<KoudenAccessContext | null> => {
 	const supabase = await createClient();
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
 
 	if (!user) {
-		throw new KoudenError("認証が必要です", "UNAUTHORIZED");
+		return null;
 	}
 
-	// オーナーチェックとメンバーロールチェックを1回のクエリで実行
-	const { data, error } = await supabase
-		.from("koudens")
-		.select(`
-			owner_id,
-			created_by,
-			members:kouden_members!inner(
-				role_id,
-				roles:kouden_roles!inner(
-					name
-				)
-			)
-		`)
-		.eq("id", koudenId)
-		.eq("kouden_members.user_id", user.id)
-		.single();
-
-	if (error) {
-		throw new KoudenError("権限の取得に失敗しました", "FETCH_PERMISSION_ERROR");
-	}
-
-	if (!data) {
-		throw new KoudenError("アクセス権限がありません", "FORBIDDEN");
-	}
-
-	// オーナーチェック
-	if (data.owner_id === user.id || data.created_by === user.id) {
-		return "owner";
-	}
-
-	// ロール名の変換
-	const roleName = data.members[0]?.roles?.name;
-	if (roleName === "editor") return "editor";
-	if (roleName === "viewer") return "viewer";
-
-	throw new KoudenError("不明な権限です", "UNKNOWN_PERMISSION");
-});
-
-/**
- * 香典帳の編集権限（owner / editor）を要求する
- * @param koudenId 香典帳ID
- * @param message 権限不足時のエラーメッセージ
- */
-export async function requireKoudenEditor(
-	koudenId: string,
-	message = "編集権限がありません",
-): Promise<void> {
-	// canEditKouden は left join で owner/created_by を考慮し、
-	// 非メンバーは false を返す（checkKoudenPermission の inner join は FETCH_PERMISSION_ERROR になる）
-	const canEdit = await canEditKouden(koudenId);
-	if (!canEdit) {
-		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
-	}
-}
-
-// 管理者権限チェック関数（キャッシュ対応）
-export const isKoudenOwner = cache(async (koudenId: string): Promise<boolean> => {
-	try {
-		const permission = await checkKoudenPermission(koudenId);
-		return permission === "owner";
-	} catch {
-		return false;
-	}
-});
-
-/**
- * 編集権限チェック関数（キャッシュ対応）
- * @param koudenId 香典帳ID
- * @returns 編集権限がある場合はtrue
- */
-export const hasEditPermission = cache(async (koudenId: string): Promise<boolean> => {
-	try {
-		const permission = await checkKoudenPermission(koudenId);
-		return permission === "owner" || permission === "editor";
-	} catch {
-		return false;
-	}
-});
-
-/**
- * ユーザーが香典帳を編集できるか確認（最適化版）
- * @param koudenId 香典帳ID
- * @returns 編集可能な場合はtrue
- */
-export async function canEditKouden(koudenId: string): Promise<boolean> {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) return false;
-
-	// 1回のクエリで所有者チェックとメンバーロールチェックを実行
-	// RLS無限再帰を避けるため、直接JOINして権限を確認
 	const { data, error } = await supabase
 		.from("koudens")
 		.select(`
@@ -126,126 +72,135 @@ export async function canEditKouden(koudenId: string): Promise<boolean> {
 		.eq("id", koudenId)
 		.single();
 
-	// PGRST116 (0 行) は香典帳未存在またはアクセス不可。それ以外は DB エラーとして扱う。
 	if (error) {
 		if (error.code === "PGRST116") {
-			return false;
+			return null;
 		}
 		throw new KoudenError("権限の取得に失敗しました", ErrorCodes.DB_FETCH_ERROR);
 	}
 
-	if (!data) return false;
-
-	// 所有者または作成者の場合は編集可能
-	if (data.owner_id === user.id || data.created_by === user.id) {
-		return true;
+	if (!data) {
+		return null;
 	}
 
-	// メンバーロールをチェック
-	const userMember = data.kouden_members?.find((member) => member.user_id === user.id);
+	return { userId: user.id, row: data };
+});
 
-	if (!userMember?.kouden_roles) {
-		return false;
+function resolveKoudenPermission(
+	userId: string,
+	row: KoudenAccessRow,
+): KoudenPermission | null {
+	if (row.owner_id === userId || row.created_by === userId) {
+		return "owner";
 	}
 
-	// editorロールの場合は編集可能
-	return userMember.kouden_roles.name === "editor";
+	const userMember = row.kouden_members?.find((member) => member.user_id === userId);
+	const roleName = userMember?.kouden_roles?.name;
+
+	if (roleName === "editor") return "editor";
+	if (roleName === "viewer") return "viewer";
+
+	return null;
 }
 
 /**
- * ユーザーが香典帳にアクセスできるか確認（最適化版）
- * @param koudenId 香典帳ID
- * @returns アクセス可能な場合はtrue
+ * ユーザーの香典帳に対するロールを取得する（読み取り用）
+ * @returns アクセス可能な場合はロール、それ以外は null
  */
-export async function canAccessKouden(koudenId: string): Promise<boolean> {
+export const getKoudenPermission = cache(
+	async (koudenId: string): Promise<KoudenPermission | null> => {
+		const access = await fetchKoudenAccess(koudenId);
+		if (!access) {
+			return null;
+		}
+
+		return resolveKoudenPermission(access.userId, access.row);
+	},
+);
+
+/**
+ * 香典帳へのアクセス権を要求する（書き込み用）
+ * @returns ユーザーのロール
+ */
+export async function requireKoudenAccess(
+	koudenId: string,
+	message = "アクセス権限がありません",
+): Promise<KoudenPermission> {
 	const supabase = await createClient();
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
 
-	if (!user) return false;
-
-	// 1回のクエリで所有者チェックとメンバーチェックを実行
-	const { data } = await supabase
-		.from("koudens")
-		.select(`
-			owner_id,
-			created_by,
-			kouden_members!left (
-				user_id
-			)
-		`)
-		.eq("id", koudenId)
-		.single();
-
-	if (!data) return false;
-
-	// 所有者または作成者の場合はアクセス可能
-	if (data.owner_id === user.id || data.created_by === user.id) {
-		return true;
+	if (!user) {
+		throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
 	}
 
-	// メンバーかどうかチェック
-	return !!data.kouden_members?.some((member) => member.user_id === user.id);
+	const permission = await getKoudenPermission(koudenId);
+	if (!permission) {
+		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
+	}
+
+	return permission;
 }
 
 /**
- * ユーザーが香典帳を削除できるか確認
- * @param koudenId 香典帳ID
- * @returns 削除可能な場合はtrue
+ * 香典帳へのアクセス権を要求する（後方互換エイリアス）
  */
-export async function canDeleteKouden(koudenId: string): Promise<boolean> {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+export const checkKoudenPermission = cache(requireKoudenAccess);
 
-	if (!user) return false;
+/**
+ * 香典帳にアクセスできるか（読み取り用）
+ */
+export const hasKoudenAccess = cache(async (koudenId: string): Promise<boolean> => {
+	const permission = await getKoudenPermission(koudenId);
+	return permission !== null;
+});
 
-	const { data: kouden } = await supabase
-		.from("koudens")
-		.select("owner_id")
-		.eq("id", koudenId)
-		.single();
-
-	return kouden?.owner_id === user.id;
+/**
+ * 香典帳の編集権限（owner / editor）を要求する（書き込み用）
+ */
+export async function requireKoudenEditor(
+	koudenId: string,
+	message = "編集権限がありません",
+): Promise<void> {
+	const permission = await getKoudenPermission(koudenId);
+	if (!permission || (permission !== "owner" && permission !== "editor")) {
+		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
+	}
 }
 
 /**
- * ユーザーの香典帳に対するロールを取得
- * @param koudenId 香典帳ID
- * @returns ロール名
+ * 香典帳のオーナー権限を要求する（書き込み用）
  */
-export async function getKoudenRole(koudenId: string): Promise<KoudenPermission | null> {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) return null;
-
-	const { data: kouden } = await supabase
-		.from("koudens")
-		.select("owner_id")
-		.eq("id", koudenId)
-		.single();
-
-	if (kouden?.owner_id === user.id) return "owner" as KoudenPermission;
-
-	const { data: member } = await supabase
-		.from("kouden_members")
-		.select("role_id")
-		.eq("kouden_id", koudenId)
-		.eq("user_id", user.id)
-		.single();
-
-	if (!member) return null;
-
-	const { data: role } = await supabase
-		.from("kouden_roles")
-		.select("name")
-		.eq("id", member.role_id)
-		.single();
-
-	return (role?.name as KoudenPermission) || null;
+export async function requireKoudenOwner(
+	koudenId: string,
+	message = "オーナー権限がありません",
+): Promise<void> {
+	const permission = await getKoudenPermission(koudenId);
+	if (permission !== "owner") {
+		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
+	}
 }
+
+/**
+ * オーナー権限があるか（読み取り用）
+ */
+export const isKoudenOwner = cache(async (koudenId: string): Promise<boolean> => {
+	const permission = await getKoudenPermission(koudenId);
+	return permission === "owner";
+});
+
+/**
+ * 編集権限があるか（読み取り用）
+ */
+export const hasEditPermission = cache(async (koudenId: string): Promise<boolean> => {
+	const permission = await getKoudenPermission(koudenId);
+	return permission === "owner" || permission === "editor";
+});
+
+/**
+ * 削除権限があるか（読み取り用、オーナーのみ）
+ */
+export const canDeleteKouden = cache(async (koudenId: string): Promise<boolean> => {
+	return isKoudenOwner(koudenId);
+});

--- a/src/app/_actions/permissions.ts
+++ b/src/app/_actions/permissions.ts
@@ -9,8 +9,8 @@
  * - `getKoudenPermission` — ロール取得。アクセス不可は `null`
  * - `hasKoudenAccess` — アクセス可能か
  * - `hasEditPermission` — 編集可能か（owner / editor）
- * - `isKoudenOwner` — オーナーか
- * - `canDeleteKouden` — 削除可能か（オーナーのみ）
+ * - `isKoudenOwner` — オーナー相当か（`owner_id` または `created_by`）
+ * - `canDeleteKouden` — 削除可能か（`owner_id` のみ。admin client 利用のため厳格化）
  *
  * ### 書き込み用（throw）
  * - `requireKoudenAccess` — アクセス権必須（ロールを返す）
@@ -85,6 +85,10 @@ const fetchKoudenAccess = cache(async (koudenId: string): Promise<KoudenAccessCo
 
 	return { userId: user.id, row: data };
 });
+
+function isRecordOwner(userId: string, row: KoudenAccessRow): boolean {
+	return row.owner_id === userId;
+}
 
 function resolveKoudenPermission(
 	userId: string,
@@ -163,21 +167,37 @@ export async function requireKoudenEditor(
 	koudenId: string,
 	message = "編集権限がありません",
 ): Promise<void> {
-	const permission = await getKoudenPermission(koudenId);
-	if (!permission || (permission !== "owner" && permission !== "editor")) {
+	const permission = await requireKoudenAccess(koudenId, message);
+	if (permission !== "owner" && permission !== "editor") {
 		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
 	}
 }
 
 /**
  * 香典帳のオーナー権限を要求する（書き込み用）
+ * `owner_id` または `created_by` をオーナー相当として扱う。
  */
 export async function requireKoudenOwner(
 	koudenId: string,
 	message = "オーナー権限がありません",
 ): Promise<void> {
-	const permission = await getKoudenPermission(koudenId);
+	const permission = await requireKoudenAccess(koudenId, message);
 	if (permission !== "owner") {
+		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
+	}
+}
+
+/**
+ * 香典帳レコードの `owner_id` を要求する（書き込み用）
+ * admin client 等 RLS をバイパスする削除では `created_by` を許可しない。
+ */
+export async function requireKoudenRecordOwner(
+	koudenId: string,
+	message = "オーナー権限がありません",
+): Promise<void> {
+	await requireKoudenAccess(koudenId, message);
+	const access = await fetchKoudenAccess(koudenId);
+	if (!access || !isRecordOwner(access.userId, access.row)) {
 		throw new KoudenError(message, ErrorCodes.FORBIDDEN);
 	}
 }
@@ -202,5 +222,9 @@ export const hasEditPermission = cache(async (koudenId: string): Promise<boolean
  * 削除権限があるか（読み取り用、オーナーのみ）
  */
 export const canDeleteKouden = cache(async (koudenId: string): Promise<boolean> => {
-	return isKoudenOwner(koudenId);
+	const access = await fetchKoudenAccess(koudenId);
+	if (!access) {
+		return false;
+	}
+	return isRecordOwner(access.userId, access.row);
 });

--- a/src/app/_actions/roles.ts
+++ b/src/app/_actions/roles.ts
@@ -5,7 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { KoudenRole } from "@/types/role";
 import { revalidatePath } from "next/cache";
 import { cache } from "react";
-import { isKoudenOwner } from "./permissions";
+import { requireKoudenOwner } from "./permissions";
 
 /**
  * 香典帳のロールを取得（キャッシュ対応）
@@ -77,11 +77,7 @@ export async function updateMemberRole(
 	return withActionResult(async () => {
 		const supabase = await createClient();
 
-		// 管理者権限のチェック
-		const isOwner = await isKoudenOwner(koudenId);
-		if (!isOwner) {
-			throw new KoudenError("権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenOwner(koudenId);
 
 		// オーナーのロールを変更しようとしていないかチェック
 		const { data: kouden } = await supabase
@@ -119,11 +115,7 @@ export async function removeMember(koudenId: string, userId: string): Promise<Ac
 	return withActionResult(async () => {
 		const supabase = await createClient();
 
-		// 管理者権限のチェック
-		const isOwner = await isKoudenOwner(koudenId);
-		if (!isOwner) {
-			throw new KoudenError("権限がありません", ErrorCodes.FORBIDDEN);
-		}
+		await requireKoudenOwner(koudenId);
 
 		// オーナーが自身を削除しようとしていないかチェック
 		const { data: kouden } = await supabase


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #136 に対応し、`src/app/_actions/permissions.ts` の権限チェック API を整理しました。

## 変更内容

### 単一の権限解決ロジック
- `fetchKoudenAccess`（left join 1 クエリ）を全判定の単一ソースに統合
- inner join による `FETCH_PERMISSION_ERROR` 問題を解消（オーナーが `kouden_members` に未登録でも正しく `owner` を返す）

### API の整理

**読み取り用（boolean / role）**
- `getKoudenPermission` — ロール取得（アクセス不可は `null`）
- `hasKoudenAccess` — アクセス可能か
- `hasEditPermission` — 編集可能か
- `isKoudenOwner` / `canDeleteKouden` — オーナー判定

**書き込み用（throw）**
- `requireKoudenAccess` — アクセス権必須
- `requireKoudenEditor` — 編集権限必須
- `requireKoudenOwner` — オーナー権限必須

**後方互換**
- `checkKoudenPermission` — `requireKoudenAccess` のエイリアス（既存ページ・レイアウトは変更不要）

### 削除した API
- `canEditKouden` → `hasEditPermission` / `requireKoudenEditor` に統合
- `canAccessKouden` → `hasKoudenAccess` / `getKoudenPermission` に統合
- `getKoudenRole` → `getKoudenPermission` に統合
- `withPermissionCheck` — 既に未使用のため対象外

### 呼び出し元の移行
- `koudens/update.ts` — `requireKoudenEditor` / `requireKoudenOwner`
- `koudens/delete.ts` — `requireKoudenOwner`
- `koudens/duplicate.ts` — `requireKoudenEditor`
- `roles.ts` — `requireKoudenOwner`

### テスト
- `permissions.test.ts` を新規追加（9 ケース）
- `koudens-delete.test.ts` を `requireKoudenOwner` モックに更新

## 完了条件（#136）

- [x] 権限チェックの正規 API が明確にドキュメント化されている（ファイル先頭 JSDoc）
- [x] 未使用の `withPermissionCheck` が削除または統合されている（既に存在せず）
- [x] `canEditKouden` と `checkKoudenPermission` の二重経路が解消されている

Closes #136
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2fc6b63-d17d-4a62-b6dd-548b6b63f1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2fc6b63-d17d-4a62-b6dd-548b6b63f1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 香典帳の権限チェックを統一・強化し、編集・複製・削除・共有・アーカイブ・メンバー操作で一貫した権限制御を適用しました。削除判定は記録オーナー基準を区別して扱います。権限取得は共通キャッシュに集約され挙動が安定しました。

* **Tests**
  * 権限周りの包括的なテスト群を追加・整理し、未認証／権限不足／DB制約／正常系などのケースを網羅しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->