### PR TITLE
refactor(admin): 管理者権限チェックを permissions.ts に一本化

### DIFF
--- a/src/app/(system)/admin/koudens/[id]/entries/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/entries/page.tsx
@@ -1,5 +1,5 @@
 import { EntriesPageClient } from "@/app/(protected)/koudens/[id]/entries/entries-page-client";
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { getEntriesForAdmin } from "@/app/_actions/entries";
 import { getRelationshipsForAdmin } from "@/app/_actions/relationships";
 
@@ -28,7 +28,7 @@ export default async function AdminEntriesPage({
 	const { id: koudenId } = await params;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	const rawSearchParams = await searchParams;
 	const {

--- a/src/app/(system)/admin/koudens/[id]/layout.tsx
+++ b/src/app/(system)/admin/koudens/[id]/layout.tsx
@@ -1,6 +1,6 @@
 import { KoudenHeader } from "@/app/(protected)/koudens/[id]/_components/_common/kouden-header";
 import { TabNavigation } from "@/app/(protected)/koudens/[id]/_components/_common/tab-navigation";
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { getKoudenForAdmin, getKoudenWithPlanForAdmin } from "@/app/_actions/koudens/read";
 import { Button } from "@/components/ui/button";
 import type { Kouden } from "@/types/kouden";
@@ -50,7 +50,7 @@ export default async function AdminKoudenLayout({ params, children }: AdminKoude
 
 	try {
 		// 管理者権限チェック
-		const { adminRole } = await checkAdminPermission();
+		const { adminRole } = await requireAdmin();
 
 		// 香典帳データとプラン情報を取得（管理者用関数を使用）
 		const [koudenResult, planInfoResult] = await Promise.all([

--- a/src/app/(system)/admin/koudens/[id]/members/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/members/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { MemberView } from "@/app/(protected)/koudens/[id]/members/_components/member-view";
 import { getMembersForAdmin } from "@/app/_actions/members";
 import { getKoudenRolesForAdmin } from "@/app/_actions/roles";
@@ -11,7 +11,7 @@ export default async function AdminMembersPage({ params }: AdminMembersPageProps
 	const { id: koudenId } = await params;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	// 管理者用の権限オブジェクト（閲覧権限のみ）
 	const adminPermission = "viewer" as const;

--- a/src/app/(system)/admin/koudens/[id]/offerings/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/offerings/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { OfferingView } from "@/app/(protected)/koudens/[id]/offerings/_components";
 import { getOfferings } from "@/app/_actions/offerings";
 import { getEntriesForAdmin } from "@/app/_actions/entries";
@@ -17,7 +17,7 @@ export default async function AdminOfferingsPage({ params }: AdminOfferingsPageP
 	const { id: koudenId } = await params;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	// 供物情報とエントリー情報を取得
 	const [offeringsResult, entriesResult] = await Promise.all([

--- a/src/app/(system)/admin/koudens/[id]/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { getKoudenForAdmin } from "@/app/_actions/koudens/read";
 import { notFound, redirect, unstable_rethrow } from "next/navigation";
 
@@ -7,7 +7,7 @@ export default async function AdminKoudenPage({ params }: { params: Promise<{ id
 
 	try {
 		// 管理者権限チェック
-		await checkAdminPermission();
+		await requireAdmin();
 
 		// 香典帳取得（管理者用関数を使用）
 		const result = await getKoudenForAdmin(koudenId);

--- a/src/app/(system)/admin/koudens/[id]/return_records/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/return_records/page.tsx
@@ -1,5 +1,5 @@
 import { ReturnRecordsPageClient } from "@/app/(protected)/koudens/[id]/return_records/return-records-page-client";
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { getEntriesForAdmin } from "@/app/_actions/entries";
 import { getKoudenForAdmin } from "@/app/_actions/koudens/read";
 import { getRelationshipsForAdmin } from "@/app/_actions/relationships";
@@ -35,7 +35,7 @@ export default async function AdminReturnRecordsPage({
 	const { search, status } = await searchParams;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	// 香典帳の存在確認
 	const koudenResult = await getKoudenForAdmin(koudenId);

--- a/src/app/(system)/admin/koudens/[id]/settings/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/settings/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { getKoudenForAdmin } from "@/app/_actions/koudens/read";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -12,7 +12,7 @@ interface AdminSettingsPageProps {
 
 export default async function AdminSettingsPage({ params }: AdminSettingsPageProps) {
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	const { id: koudenId } = await params;
 	const koudenResult = await getKoudenForAdmin(koudenId);

--- a/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/statistics/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 
 import { KoudenStatistics } from "@/app/(protected)/koudens/[id]/statistics/_components";
 import { getEntriesForAdmin } from "@/app/_actions/entries";
@@ -117,7 +117,7 @@ export default async function AdminStatisticsPage({ params }: AdminStatisticsPag
 	const { id: koudenId } = await params;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	// 統計情報の計算のため、全エントリーを取得
 	const entriesResult = await getEntriesForAdmin(koudenId, 1, Number.MAX_SAFE_INTEGER);

--- a/src/app/(system)/admin/koudens/[id]/telegrams/page.tsx
+++ b/src/app/(system)/admin/koudens/[id]/telegrams/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { TelegramsView } from "@/app/(protected)/koudens/[id]/telegrams/_components";
 import { getTelegrams } from "@/app/_actions/telegrams";
 import { getEntriesForAdmin } from "@/app/_actions/entries";
@@ -17,7 +17,7 @@ export default async function AdminTelegramsPage({ params }: AdminTelegramsPageP
 	const { id: koudenId } = await params;
 
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	// 弔電情報とエントリー情報を取得
 	const [telegramsResult, entriesResult] = await Promise.all([

--- a/src/app/(system)/admin/koudens/page.tsx
+++ b/src/app/(system)/admin/koudens/page.tsx
@@ -1,4 +1,4 @@
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { type AdminKoudenListItem, getAllKoudens } from "@/app/_actions/admin/users";
 import { AdminKoudensClient } from "./_components/admin-koudens-client";
 
@@ -17,7 +17,7 @@ export default async function AdminKoudensPage({
 	}>;
 }) {
 	// 管理者権限チェック
-	await checkAdminPermission();
+	await requireAdmin();
 
 	const params = await searchParams;
 	const page = params.page ? Number.parseInt(params.page, 10) : 1;

--- a/src/app/(system)/admin/layout.tsx
+++ b/src/app/(system)/admin/layout.tsx
@@ -1,7 +1,6 @@
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { CSRFProvider } from "@/components/providers/csrf-provider";
 import { Container } from "@/components/ui/container";
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
 import { AdminHeader } from "./_components/admin-header";
 
 interface AdminLayoutProps {
@@ -9,27 +8,7 @@ interface AdminLayoutProps {
 }
 
 export default async function AdminLayout({ children }: AdminLayoutProps) {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) {
-		redirect("/auth/login");
-	}
-
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	// RPC エラーは権限不足ではなく DB エラーとして扱う (上位で 500 化)
-	if (rpcError) {
-		throw new Error(`管理者権限の確認に失敗しました: ${rpcError.message}`);
-	}
-
-	if (!isAdmin) {
-		redirect("/");
-	}
+	const { user } = await requireAdmin();
 
 	return (
 		<CSRFProvider>

--- a/src/app/(system)/admin/settings/2fa/setup/page.tsx
+++ b/src/app/(system)/admin/settings/2fa/setup/page.tsx
@@ -9,8 +9,8 @@ import {
 	getTwoFactorSetupMessage,
 	isTwoFactorRequired,
 } from "@/lib/security/admin-2fa-enforcement";
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { generateTwoFactorSetup, isTwoFactorEnabled } from "@/lib/security/two-factor-auth";
-import { createClient } from "@/lib/supabase/server";
 import { ShieldCheck, Smartphone } from "lucide-react";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -22,28 +22,7 @@ interface PageProps {
 
 export default async function TwoFactorSetupPage({ searchParams }: PageProps) {
 	const resolvedSearchParams = await searchParams;
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) {
-		redirect("/auth/login");
-	}
-
-	// 管理者かどうかを確認
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	// RPC エラーは権限不足ではなく DB エラーとして扱う
-	if (rpcError) {
-		throw new Error(`管理者権限の確認に失敗しました: ${rpcError.message}`);
-	}
-
-	if (!isAdmin) {
-		redirect("/");
-	}
+	const { user } = await requireAdmin();
 
 	// 既に2FAが設定済みの場合
 	const twoFactorEnabled = await isTwoFactorEnabled(user.id);

--- a/src/app/_actions/admin/__tests__/permissions.test.ts
+++ b/src/app/_actions/admin/__tests__/permissions.test.ts
@@ -129,6 +129,19 @@ describe("requireAdmin", () => {
 		expect(result.adminRole).toBe("admin");
 	});
 
+	it("未認証の場合は /auth/login にリダイレクトする", async () => {
+		supabaseMock = {
+			auth: {
+				getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+			},
+		};
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const error = await requireAdmin().catch((e) => e);
+		expect(error).toBeInstanceOf(RedirectError);
+		expect((error as RedirectError).url).toBe("/auth/login");
+	});
+
 	it("非管理者の場合は / にリダイレクトする", async () => {
 		supabaseMock = buildSupabase({ data: null, error: { code: "PGRST116" } });
 		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);

--- a/src/app/_actions/admin/__tests__/permissions.test.ts
+++ b/src/app/_actions/admin/__tests__/permissions.test.ts
@@ -1,7 +1,7 @@
 import { ErrorCodes, KoudenError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
-import { checkSuperAdminPermission } from "../permissions";
+import { assertAdminForAction, checkSuperAdminPermission, requireAdmin } from "../permissions";
 
 // next/navigation の redirect は呼ばれたら専用エラーを投げてフローを中断する挙動を再現する。
 // vi.mock ファクトリはホイストされるため、参照する RedirectError も vi.hoisted で巻き上げる。
@@ -27,6 +27,128 @@ vi.mock("next/navigation", async (importActual) => {
 			throw new RedirectError(url);
 		}),
 	};
+});
+
+describe("assertAdminForAction", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
+	let supabaseMock: any;
+
+	const buildSupabase = (adminUserResult: { data: unknown; error: unknown }) => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: { id: "user-1" } },
+				error: null,
+			}),
+		},
+		from: vi.fn().mockReturnValue({
+			select: () => ({
+				eq: () => ({
+					single: () => Promise.resolve(adminUserResult),
+				}),
+			}),
+		}),
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("管理者の場合は supabase/user/adminRole を返す", async () => {
+		supabaseMock = buildSupabase({ data: { role: "admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const result = await assertAdminForAction();
+		expect(result.user).toEqual({ id: "user-1" });
+		expect(result.adminRole).toBe("admin");
+	});
+
+	it("未認証の場合は UNAUTHORIZED を投げる", async () => {
+		supabaseMock = {
+			auth: {
+				getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+			},
+		};
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		await expect(assertAdminForAction()).rejects.toMatchObject({
+			code: ErrorCodes.UNAUTHORIZED,
+		});
+	});
+
+	it("管理者未登録の場合は FORBIDDEN を投げる", async () => {
+		supabaseMock = buildSupabase({ data: null, error: { code: "PGRST116" } });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		await expect(assertAdminForAction()).rejects.toMatchObject({
+			code: ErrorCodes.FORBIDDEN,
+		});
+	});
+
+	it("DB エラーの場合は DB_FETCH_ERROR を投げる", async () => {
+		supabaseMock = buildSupabase({
+			data: null,
+			error: { code: "57P01", message: "database connection lost" },
+		});
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const error = await assertAdminForAction().catch((e) => e);
+		expect(error).toBeInstanceOf(KoudenError);
+		expect((error as KoudenError).code).toBe(ErrorCodes.DB_FETCH_ERROR);
+	});
+});
+
+describe("requireAdmin", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用モック
+	let supabaseMock: any;
+
+	const buildSupabase = (adminUserResult: { data: unknown; error: unknown }) => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: { id: "user-1" } },
+				error: null,
+			}),
+		},
+		from: vi.fn().mockReturnValue({
+			select: () => ({
+				eq: () => ({
+					single: () => Promise.resolve(adminUserResult),
+				}),
+			}),
+		}),
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("管理者の場合は supabase/user/adminRole を返す", async () => {
+		supabaseMock = buildSupabase({ data: { role: "admin" }, error: null });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const result = await requireAdmin();
+		expect(result.adminRole).toBe("admin");
+	});
+
+	it("非管理者の場合は / にリダイレクトする", async () => {
+		supabaseMock = buildSupabase({ data: null, error: { code: "PGRST116" } });
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const error = await requireAdmin().catch((e) => e);
+		expect(error).toBeInstanceOf(RedirectError);
+		expect((error as RedirectError).url).toBe("/");
+	});
+
+	it("DB エラーの場合は DB_FETCH_ERROR を投げる", async () => {
+		supabaseMock = buildSupabase({
+			data: null,
+			error: { code: "57P01", message: "database connection lost" },
+		});
+		(createClient as unknown as Mock).mockResolvedValue(supabaseMock);
+
+		const error = await requireAdmin().catch((e) => e);
+		expect(error).toBeInstanceOf(KoudenError);
+		expect((error as KoudenError).code).toBe(ErrorCodes.DB_FETCH_ERROR);
+	});
 });
 
 describe("checkSuperAdminPermission", () => {

--- a/src/app/_actions/admin/admin-2fa.ts
+++ b/src/app/_actions/admin/admin-2fa.ts
@@ -5,6 +5,7 @@
 
 "use server";
 
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { logTwoFactorEventServerAction } from "@/lib/security/security-logger";
@@ -14,7 +15,6 @@ import {
 	saveTwoFactorSecret,
 	verifyTwoFactorToken,
 } from "@/lib/security/two-factor-auth";
-import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
 /**
@@ -25,27 +25,7 @@ export async function setupTwoFactorAuth(
 	verificationCode: string,
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
-		const {
-			data: { user },
-		} = await supabase.auth.getUser();
-
-		if (!user) {
-			throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-		}
-
-		// 管理者かどうかを確認
-		const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-			user_uid: user.id,
-		});
-
-		if (rpcError) {
-			throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-		}
-
-		if (!isAdmin) {
-			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-		}
+		const { user } = await assertAdminForAction();
 
 		// 既に2FAが設定済みかチェック
 		const isAlreadyEnabled = await isTwoFactorEnabled(user.id);
@@ -90,27 +70,7 @@ export async function setupTwoFactorAuth(
  */
 export async function disableTwoFactorAuth(): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
-		const {
-			data: { user },
-		} = await supabase.auth.getUser();
-
-		if (!user) {
-			throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-		}
-
-		// 管理者かどうかを確認
-		const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-			user_uid: user.id,
-		});
-
-		if (rpcError) {
-			throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-		}
-
-		if (!isAdmin) {
-			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-		}
+		const { user } = await assertAdminForAction();
 
 		// 本番環境では2FA無効化を制限
 		if (process.env.NODE_ENV === "production") {
@@ -144,27 +104,7 @@ export async function disableTwoFactorAuth(): Promise<ActionResult<null>> {
  */
 export async function verifyTwoFactorLogin(verificationCode: string): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const supabase = await createClient();
-		const {
-			data: { user },
-		} = await supabase.auth.getUser();
-
-		if (!user) {
-			throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-		}
-
-		// 管理者かどうかを確認
-		const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-			user_uid: user.id,
-		});
-
-		if (rpcError) {
-			throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-		}
-
-		if (!isAdmin) {
-			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-		}
+		const { supabase, user } = await assertAdminForAction();
 
 		// 2FAシークレットを取得 (PGRST116 = 0 行 → 未設定、それ以外 = DB エラーとして上位へ)
 		const { data: adminUser, error: adminError } = await supabase

--- a/src/app/_actions/admin/announcements.ts
+++ b/src/app/_actions/admin/announcements.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
 import { type ActionResult, withActionResult } from "@/lib/errors";
 import { revalidatePath } from "next/cache";
 
@@ -20,7 +20,7 @@ export type Announcement = {
 
 export async function getAnnouncements(): Promise<ActionResult<Announcement[]>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 		const { data, error } = await supabase
 			.from("system_announcements")
 			.select("*")
@@ -62,7 +62,7 @@ export async function createAnnouncement({
 	expiresAt?: string;
 }): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase, user } = await checkAdminPermission();
+		const { supabase, user } = await assertAdminForAction();
 
 		const requestData = {
 			title,
@@ -109,7 +109,7 @@ export async function updateAnnouncement(
 	},
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 		const { error } = await supabase
 			.from("system_announcements")
 			.update({
@@ -131,7 +131,7 @@ export async function updateAnnouncement(
 
 export async function deleteAnnouncement(id: string): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 		const { error } = await supabase.from("system_announcements").delete().eq("id", id);
 
 		if (error) throw error;

--- a/src/app/_actions/admin/campaign-applications.ts
+++ b/src/app/_actions/admin/campaign-applications.ts
@@ -1,40 +1,10 @@
 "use server";
 
-import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
-import { createClient } from "@/lib/supabase/server";
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
+import { type ActionResult, withActionResult } from "@/lib/errors";
 import type { Database } from "@/types/supabase";
 
 type CampaignApplicationRow = Database["public"]["Tables"]["campaign_hearing_applications"]["Row"];
-
-/**
- * 管理者権限チェック
- * `withActionResult` がエラーをクライアント向けの ActionResult に変換するため、
- * リダイレクトではなく KoudenError を throw する。
- */
-async function assertAdmin() {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) {
-		throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-	}
-
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	if (rpcError) {
-		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-	}
-
-	if (!isAdmin) {
-		throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-	}
-
-	return { supabase, user };
-}
 
 /**
  * キャンペーン申し込み一覧を取得
@@ -53,7 +23,7 @@ export async function getCampaignApplications(params?: {
 	}>
 > {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		let query = supabase
 			.from("campaign_hearing_applications")
@@ -94,7 +64,7 @@ export async function getCampaignApplication(
 	id: string,
 ): Promise<ActionResult<CampaignApplicationRow>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		const { data, error } = await supabase
 			.from("campaign_hearing_applications")
@@ -115,7 +85,7 @@ export async function updateCampaignApplicationStatus(
 	status: "submitted" | "confirmed" | "completed" | "cancelled",
 ): Promise<ActionResult<CampaignApplicationRow>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		const { data, error } = await supabase
 			.from("campaign_hearing_applications")
@@ -144,7 +114,7 @@ export async function getCampaignApplicationStats(): Promise<
 	}>
 > {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		// 全体の統計
 		const { data: totalData, error: totalError } = await supabase

--- a/src/app/_actions/admin/contact-requests.ts
+++ b/src/app/_actions/admin/contact-requests.ts
@@ -1,40 +1,10 @@
 "use server";
 
-import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
-import { createClient } from "@/lib/supabase/server";
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
+import { type ActionResult, withActionResult } from "@/lib/errors";
 import type { Database } from "@/types/supabase";
 
 type ContactRequestRow = Database["public"]["Tables"]["contact_requests"]["Row"];
-
-/**
- * 管理者権限チェック
- * `withActionResult` がエラーをクライアント向けの ActionResult に変換するため、
- * リダイレクトではなく KoudenError を throw する。
- */
-async function assertAdmin() {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) {
-		throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-	}
-
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	if (rpcError) {
-		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-	}
-
-	if (!isAdmin) {
-		throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-	}
-
-	return { supabase, user };
-}
 
 /**
  * お問い合わせ一覧を取得
@@ -54,7 +24,7 @@ export async function getContactRequests(params?: {
 	}>
 > {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		let query = supabase
 			.from("contact_requests")
@@ -98,7 +68,7 @@ export async function getContactRequestDetail(
 	requestId: string,
 ): Promise<ActionResult<ContactRequestRow & { contact_request_attachments: unknown[] }>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		const { data, error } = await supabase
 			.from("contact_requests")
@@ -127,7 +97,7 @@ export async function updateContactRequestStatus(
 	status: "new" | "in_progress" | "closed",
 ): Promise<ActionResult<ContactRequestRow>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		const { data, error } = await supabase
 			.from("contact_requests")
@@ -155,7 +125,7 @@ export async function getContactRequestStats(): Promise<
 	}>
 > {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		// 全体の統計
 		const { data: totalData, error: totalError } = await supabase

--- a/src/app/_actions/admin/middleware.ts
+++ b/src/app/_actions/admin/middleware.ts
@@ -1,3 +1,4 @@
+import { requireAdmin } from "@/app/_actions/admin/permissions";
 import { ErrorCodes, KoudenError } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
@@ -5,31 +6,7 @@ import { redirect } from "next/navigation";
 import { createAuditLog } from "./audit-logs";
 
 export async function withAdmin<T>(action: () => Promise<T>): Promise<T> {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user?.id) {
-		redirect("/auth/login");
-	}
-
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	// RPC 自体が失敗した場合は権限不足ではなく DB エラーとして扱う
-	if (rpcError) {
-		logger.error(
-			{ error: rpcError.message, code: rpcError.code, userId: user.id },
-			"is_admin RPC failed in withAdmin",
-		);
-		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-	}
-
-	if (!isAdmin) {
-		redirect("/");
-	}
+	const { user } = await requireAdmin();
 
 	try {
 		const result = await action();

--- a/src/app/_actions/admin/permissions.ts
+++ b/src/app/_actions/admin/permissions.ts
@@ -235,6 +235,9 @@ export async function isAdmin() {
 	if (!user) return false;
 
 	const membership = await fetchAdminMembership(supabase, user.id);
-	if (membership.status === "db_error") return false;
+	if (membership.status === "db_error") {
+		logAdminMembershipDbError(user.id, membership.error, "isAdmin check error");
+		return false;
+	}
 	return membership.status === "ok";
 }

--- a/src/app/_actions/admin/permissions.ts
+++ b/src/app/_actions/admin/permissions.ts
@@ -5,59 +5,162 @@ import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 
+type AdminMembership = { role: string };
+
+type FetchAdminMembershipResult =
+	| { status: "ok"; adminUser: AdminMembership }
+	| { status: "not_found" }
+	| { status: "db_error"; error: { message: string; code?: string; details?: string } };
+
+export type AdminContext = {
+	supabase: Awaited<ReturnType<typeof createClient>>;
+	user: NonNullable<Awaited<ReturnType<typeof getAuthenticatedUser>>["user"]>;
+	adminRole: string;
+};
+
 /**
- * 管理者権限をチェックする
- * 権限がない場合はエラーを投げる
+ * admin_users テーブルから管理者登録を取得する（単一実装経路）
  */
-export async function checkAdminPermission() {
+async function fetchAdminMembership(
+	supabase: Awaited<ReturnType<typeof createClient>>,
+	userId: string,
+): Promise<FetchAdminMembershipResult> {
+	const { data: adminUser, error } = await supabase
+		.from("admin_users")
+		.select("role")
+		.eq("user_id", userId)
+		.single();
+
+	if (error && error.code !== "PGRST116") {
+		return {
+			status: "db_error",
+			error: { message: error.message, code: error.code, details: error.details ?? undefined },
+		};
+	}
+
+	if (!adminUser) {
+		return { status: "not_found" };
+	}
+
+	return { status: "ok", adminUser };
+}
+
+async function getAuthenticatedUser() {
 	const supabase = await createClient();
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
+	return { supabase, user };
+}
+
+function logAdminMembershipDbError(
+	userId: string,
+	error: { message: string; code?: string; details?: string },
+	context: string,
+) {
+	logger.error(
+		{
+			error: error.message,
+			code: error.code,
+			details: error.details,
+			userId,
+		},
+		context,
+	);
+}
+
+function resolveAdminContext(
+	supabase: Awaited<ReturnType<typeof createClient>>,
+	user: NonNullable<Awaited<ReturnType<typeof getAuthenticatedUser>>["user"]>,
+	membership: FetchAdminMembershipResult,
+): AdminContext {
+	if (membership.status === "db_error") {
+		logAdminMembershipDbError(user.id, membership.error, "Admin permission check error");
+		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+	}
+
+	if (membership.status === "not_found") {
+		throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
+	}
+
+	return { supabase, user, adminRole: membership.adminUser.role };
+}
+
+/**
+ * Server Component / redirect 向けの管理者ゲート
+ * 未認証はログインへ、非管理者はトップへリダイレクトする
+ */
+export async function requireAdmin(): Promise<AdminContext> {
+	const { supabase, user } = await getAuthenticatedUser();
 
 	if (!user) {
 		redirect("/auth/login");
 	}
 
-	// admin_usersテーブルを直接チェック
-	const { data: adminUser, error } = await supabase
-		.from("admin_users")
-		.select("role")
-		.eq("user_id", user.id)
-		.single();
+	const membership = await fetchAdminMembership(supabase, user.id);
 
-	if (error && error.code !== "PGRST116") {
-		logger.error(
-			{
-				error: error.message,
-				code: error.code,
-				details: error.details,
-				userId: user.id,
-			},
-			"Admin permission check error",
-		);
+	if (membership.status === "db_error") {
+		logAdminMembershipDbError(user.id, membership.error, "Admin permission check error");
 		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
 	}
 
-	if (!adminUser) {
-		logger.warn(
-			{
-				userId: user.id,
-			},
-			`User ${user.id} is not registered as admin in admin_users table`,
-		);
+	if (membership.status === "not_found") {
+		logger.warn({ userId: user.id }, `User ${user.id} is not registered as admin in admin_users table`);
+		redirect("/");
+	}
+
+	logger.info(
+		{ userId: user.id, role: membership.adminUser.role },
+		`Admin access granted for user ${user.id} with role: ${membership.adminUser.role}`,
+	);
+
+	return { supabase, user, adminRole: membership.adminUser.role };
+}
+
+/**
+ * Server Action / ActionResult 向けの管理者ゲート
+ * リダイレクトではなく KoudenError を throw する
+ */
+export async function assertAdminForAction(): Promise<AdminContext> {
+	const { supabase, user } = await getAuthenticatedUser();
+
+	if (!user) {
+		throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
+	}
+
+	const membership = await fetchAdminMembership(supabase, user.id);
+	return resolveAdminContext(supabase, user, membership);
+}
+
+/**
+ * 管理者権限をチェックする
+ * @deprecated {@link requireAdmin} または {@link assertAdminForAction} を使用してください
+ */
+export async function checkAdminPermission(): Promise<AdminContext> {
+	const { supabase, user } = await getAuthenticatedUser();
+
+	if (!user) {
+		redirect("/auth/login");
+	}
+
+	const membership = await fetchAdminMembership(supabase, user.id);
+
+	if (membership.status === "db_error") {
+		logAdminMembershipDbError(user.id, membership.error, "Admin permission check error");
+		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
+	}
+
+	if (membership.status === "not_found") {
+		logger.warn({ userId: user.id }, `User ${user.id} is not registered as admin in admin_users table`);
 		throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
 	}
 
 	logger.info(
-		{
-			userId: user.id,
-			role: adminUser.role,
-		},
-		`Admin access granted for user ${user.id} with role: ${adminUser.role}`,
+		{ userId: user.id, role: membership.adminUser.role },
+		`Admin access granted for user ${user.id} with role: ${membership.adminUser.role}`,
 	);
 
-	return { supabase, user, adminRole: adminUser.role };
+	return { supabase, user, adminRole: membership.adminUser.role };
 }
 
 /**
@@ -74,30 +177,16 @@ export async function checkSuperAdminPermission() {
 		redirect("/auth/login");
 	}
 
-	const { data: adminUser, error } = await supabase
-		.from("admin_users")
-		.select("role")
-		.eq("user_id", user.id)
-		.single();
+	const membership = await fetchAdminMembership(supabase, user.id);
 
-	// PGRST116 (0 行) は「管理者未登録」= 権限不足。それ以外は DB エラーなので
-	// 権限不足ではなく DB_FETCH_ERROR として扱う (DB 障害を FORBIDDEN と誤分類しない)。
-	if (error && error.code !== "PGRST116") {
-		logger.error(
-			{
-				error: error.message,
-				code: error.code,
-				details: error.details,
-				userId: user.id,
-			},
-			"Super admin permission check error",
-		);
+	if (membership.status === "db_error") {
+		logAdminMembershipDbError(user.id, membership.error, "Super admin permission check error");
 		throw new KoudenError("スーパー管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR, {
-			cause: error,
+			cause: membership.error,
 		});
 	}
 
-	if (!adminUser || adminUser.role !== "super_admin") {
+	if (membership.status === "not_found" || membership.adminUser.role !== "super_admin") {
 		throw new KoudenError("スーパー管理者権限が必要です", ErrorCodes.FORBIDDEN);
 	}
 
@@ -117,14 +206,12 @@ export async function debugAdminStatus() {
 		return { error: "ユーザーが認証されていません" };
 	}
 
-	// admin_usersテーブルの状態を確認
 	const { data: adminUser, error } = await supabase
 		.from("admin_users")
 		.select("*")
 		.eq("user_id", user.id)
 		.single();
 
-	// 全ての管理者ユーザーも取得
 	const { data: allAdmins, error: allAdminsError } = await supabase.from("admin_users").select("*");
 
 	return {
@@ -141,22 +228,13 @@ export async function debugAdminStatus() {
 
 /**
  * 現在のユーザーが管理者かどうかをチェックする
- * 統一された管理者権限チェック関数
  */
 export async function isAdmin() {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+	const { supabase, user } = await getAuthenticatedUser();
 
 	if (!user) return false;
 
-	const { data: adminUser, error } = await supabase
-		.from("admin_users")
-		.select("role")
-		.eq("user_id", user.id)
-		.single();
-
-	if (error && error.code !== "PGRST116") return false;
-	return !!adminUser;
+	const membership = await fetchAdminMembership(supabase, user.id);
+	if (membership.status === "db_error") return false;
+	return membership.status === "ok";
 }

--- a/src/app/_actions/admin/tickets.ts
+++ b/src/app/_actions/admin/tickets.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { assertAdminForAction } from "@/app/_actions/admin/permissions";
 import { type ActionResult, withActionResult } from "@/lib/errors";
 import type { Ticket, TicketMessage } from "@/types/admin";

--- a/src/app/_actions/admin/tickets.ts
+++ b/src/app/_actions/admin/tickets.ts
@@ -1,42 +1,12 @@
-import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
-import { createClient } from "@/lib/supabase/server";
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
+import { type ActionResult, withActionResult } from "@/lib/errors";
 import type { Ticket, TicketMessage } from "@/types/admin";
 import { revalidatePath } from "next/cache";
 import { getAuthUsersByIds } from "./auth-users";
 
-/**
- * 管理者権限チェック
- * `withActionResult` がエラーをクライアント向けの ActionResult に変換するため、
- * `withAdmin` HOF（redirect使用）の代わりに KoudenError を throw する。
- */
-async function assertAdmin() {
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user?.id) {
-		throw new KoudenError("認証が必要です", ErrorCodes.UNAUTHORIZED);
-	}
-
-	const { data: isAdmin, error: rpcError } = await supabase.rpc("is_admin", {
-		user_uid: user.id,
-	});
-
-	if (rpcError) {
-		throw new KoudenError("管理者権限の確認に失敗しました", ErrorCodes.DB_FETCH_ERROR);
-	}
-
-	if (!isAdmin) {
-		throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-	}
-
-	return { supabase, user };
-}
-
 export async function getTickets(): Promise<ActionResult<Ticket[]>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		// チケット基本情報を取得
 		const { data: tickets, error: ticketsError } = await supabase
@@ -73,7 +43,7 @@ export async function updateTicketStatus(
 	status: Ticket["status"],
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 		const { error } = await supabase
 			.from("support_tickets")
 			.update({
@@ -93,7 +63,7 @@ export async function assignTicket(
 	adminId: string | null,
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 		const { error } = await supabase
 			.from("support_tickets")
 			.update({ assigned_to: adminId })
@@ -110,7 +80,7 @@ export async function updateTicketPriority(
 	priority: Ticket["priority"],
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 		const { error } = await supabase
 			.from("support_tickets")
 			.update({ priority })
@@ -124,7 +94,7 @@ export async function updateTicketPriority(
 
 export async function getTicketById(ticketId: string): Promise<ActionResult<Ticket>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		// チケット基本情報を取得
 		const { data: ticket, error: ticketError } = await supabase
@@ -152,7 +122,7 @@ export async function getTicketById(ticketId: string): Promise<ActionResult<Tick
 
 export async function getTicketMessages(ticketId: string): Promise<ActionResult<TicketMessage[]>> {
 	return withActionResult(async () => {
-		const { supabase } = await assertAdmin();
+		const { supabase } = await assertAdminForAction();
 
 		// メッセージを取得
 		const { data: messages, error: messagesError } = await supabase
@@ -183,7 +153,7 @@ export async function addTicketMessage(
 	content: string,
 ): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase, user } = await assertAdmin();
+		const { supabase, user } = await assertAdminForAction();
 
 		const { error } = await supabase.from("ticket_messages").insert({
 			ticket_id: ticketId,

--- a/src/app/_actions/admin/users/list.ts
+++ b/src/app/_actions/admin/users/list.ts
@@ -1,8 +1,8 @@
 "use server";
 
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
 import { escapeIlikePattern } from "@/lib/security/search-sanitize";
-import { createClient } from "@/lib/supabase/server";
 import { getAllUsersAuthInfo } from "./auth-info";
 import type { GetUsersParams, UserListItem } from "./types";
 
@@ -17,14 +17,7 @@ export async function getAllUsers(params: GetUsersParams = {}): Promise<
 	}>
 > {
 	return withActionResult(async () => {
-		// 管理者権限をチェック（入り口で1回だけ）
-		const { isAdmin: isAdminUser } = await import("@/app/_actions/admin/permissions");
-		const adminCheck = await isAdminUser();
-		if (!adminCheck) {
-			throw new KoudenError("管理者権限が必要です", ErrorCodes.FORBIDDEN);
-		}
-
-		const supabase = await createClient();
+		const { supabase } = await assertAdminForAction();
 		const {
 			page = 1,
 			limit = 20,

--- a/src/app/_actions/announcements.ts
+++ b/src/app/_actions/announcements.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { checkAdminPermission } from "@/app/_actions/admin/permissions";
+import { assertAdminForAction } from "@/app/_actions/admin/permissions";
 import { type ActionResult, withActionResult } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import type {
@@ -36,7 +36,7 @@ export async function getActiveAnnouncements(): Promise<ActionResult<Announcemen
  */
 export async function getAllAnnouncements(): Promise<ActionResult<Announcement[]>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 
 		const { data: announcements, error } = await supabase
 			.from("announcements")
@@ -57,7 +57,7 @@ export async function createAnnouncement(
 	input: CreateAnnouncementInput,
 ): Promise<ActionResult<Announcement>> {
 	return withActionResult(async () => {
-		const { supabase, user } = await checkAdminPermission();
+		const { supabase, user } = await assertAdminForAction();
 
 		const { data: announcement, error } = await supabase
 			.from("announcements")
@@ -82,7 +82,7 @@ export async function updateAnnouncement(
 	input: UpdateAnnouncementInput,
 ): Promise<ActionResult<Announcement>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 
 		const { id, ...updateData } = input;
 
@@ -107,7 +107,7 @@ export async function updateAnnouncement(
  */
 export async function deleteAnnouncement(id: string): Promise<ActionResult<null>> {
 	return withActionResult(async () => {
-		const { supabase } = await checkAdminPermission();
+		const { supabase } = await assertAdminForAction();
 
 		const { error } = await supabase.from("announcements").delete().eq("id", id);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #131 に対応し、分散していた管理者ゲートを `src/app/_actions/admin/permissions.ts` に集約しました。

## 変更内容

### 新しい正規 API

| API | 用途 | 挙動 |
|-----|------|------|
| `requireAdmin()` | Server Component / レイアウト | 未認証 → `/auth/login`、非管理者 → `/`、DB エラー → `DB_FETCH_ERROR` |
| `assertAdminForAction()` | Server Action / `ActionResult` | 未認証 → `UNAUTHORIZED`、非管理者 → `FORBIDDEN`、DB エラー → `DB_FETCH_ERROR` |

内部実装は **`admin_users` テーブル直読み** (`fetchAdminMembership`) に統一しています。

### 移行したファイル

- `contact-requests.ts` / `tickets.ts` / `campaign-applications.ts` — ファイル内 `assertAdmin` コピペを削除
- `middleware.ts` — `withAdmin` を `requireAdmin` 経由に変更
- `admin-2fa.ts` — `is_admin` RPC を `assertAdminForAction` に置換
- `announcements.ts` / `admin/announcements.ts` / `users/list.ts` — `assertAdminForAction` に移行
- `admin/layout.tsx` / `admin/settings/2fa/setup/page.tsx` / 管理画面 koudens 配下ページ — `requireAdmin` に移行

### 後方互換

- `checkAdminPermission()` は `@deprecated` として残し、既存の throw ベース挙動を維持
- `isAdmin()` は同一の `fetchAdminMembership` を利用

## 完了条件（Issue #131）

- [x] ファイル内の `assertAdmin` コピペが 0 になる
- [x] 管理者チェックの実装経路が 1 つに統一されている（`admin_users` 直読み）
- [x] RPC 失敗時は `DB_FETCH_ERROR`、権限なしは `FORBIDDEN` で一貫

## テスト

- `assertAdminForAction` / `requireAdmin` のユニットテストを追加
- 全 414 テストパス

Closes #131
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d58c613-47b2-4eda-9f7b-977ad96131f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d58c613-47b2-4eda-9f7b-977ad96131f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 管理画面全体で管理者権限チェックを共通化・統一し、認可フローを簡潔かつ堅牢にしました。各管理ページや管理向け操作（2FA設定含む）が一貫した権限処理を利用します。

* **Tests**
  * 管理者権限周りのテストケースを追加し、未認証／非管理者／DBエラー等の挙動を検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->