### PR TITLE
refactor(admin): withAdmin/withSuperAdmin の監査ログ処理を共通化

### DIFF
--- a/src/app/_actions/admin/middleware.ts
+++ b/src/app/_actions/admin/middleware.ts
@@ -5,6 +5,42 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { createAuditLog } from "./audit-logs";
 
+/**
+ * 管理者アクションのエラーを監査ログに記録する。
+ * `createAuditLog` は ActionResult を返すため `.catch` ではなく `result.ok` を確認する。
+ */
+async function recordAdminErrorAudit(userId: string, error: Error): Promise<void> {
+	try {
+		const auditResult = await createAuditLog({
+			action: "error",
+			target_type: "admin",
+			target_id: userId,
+			details: {
+				error: error.message,
+				stack: error.stack,
+			},
+		});
+		if (!auditResult.ok) {
+			logger.error(
+				{
+					error: auditResult.error.message,
+					code: auditResult.error.code,
+					userId,
+				},
+				"監査ログの記録に失敗",
+			);
+		}
+	} catch (auditErr) {
+		logger.error(
+			{
+				error: auditErr instanceof Error ? auditErr.message : String(auditErr),
+				userId,
+			},
+			"監査ログの記録に失敗",
+		);
+	}
+}
+
 export async function withAdmin<T>(action: () => Promise<T>): Promise<T> {
 	const { user } = await requireAdmin();
 
@@ -12,40 +48,8 @@ export async function withAdmin<T>(action: () => Promise<T>): Promise<T> {
 		const result = await action();
 		return result;
 	} catch (error) {
-		// エラーが発生した場合は監査ログに記録
 		if (error instanceof Error) {
-			// `createAuditLog` は ActionResult を返すため `.catch` ではなく
-			// `result.ok` を確認する。これがないと監査ログの書き込み失敗が
-			// サイレントに握りつぶされてしまう。
-			try {
-				const auditResult = await createAuditLog({
-					action: "error",
-					target_type: "admin",
-					target_id: user.id,
-					details: {
-						error: error.message,
-						stack: error.stack,
-					},
-				});
-				if (!auditResult.ok) {
-					logger.error(
-						{
-							error: auditResult.error.message,
-							code: auditResult.error.code,
-							userId: user.id,
-						},
-						"監査ログの記録に失敗",
-					);
-				}
-			} catch (auditErr) {
-				logger.error(
-					{
-						error: auditErr instanceof Error ? auditErr.message : String(auditErr),
-						userId: user.id,
-					},
-					"監査ログの記録に失敗",
-				);
-			}
+			await recordAdminErrorAudit(user.id, error);
 		}
 		throw error;
 	}
@@ -93,35 +97,7 @@ export async function withSuperAdmin<T>(action: () => Promise<T>): Promise<T> {
 		return result;
 	} catch (error) {
 		if (error instanceof Error) {
-			try {
-				const auditResult = await createAuditLog({
-					action: "error",
-					target_type: "admin",
-					target_id: user.id,
-					details: {
-						error: error.message,
-						stack: error.stack,
-					},
-				});
-				if (!auditResult.ok) {
-					logger.error(
-						{
-							error: auditResult.error.message,
-							code: auditResult.error.code,
-							userId: user.id,
-						},
-						"監査ログの記録に失敗",
-					);
-				}
-			} catch (auditErr) {
-				logger.error(
-					{
-						error: auditErr instanceof Error ? auditErr.message : String(auditErr),
-						userId: user.id,
-					},
-					"監査ログの記録に失敗",
-				);
-			}
+			await recordAdminErrorAudit(user.id, error);
 		}
 		throw error;
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Closes #137

`withAdmin` と `withSuperAdmin` に重複していたエラー時の監査ログ記録処理を、内部ヘルパー `recordAdminErrorAudit` に集約しました。

## 変更内容

- `recordAdminErrorAudit(userId, error)` を追加し、監査ログの作成・失敗時のログ出力を 1 箇所に集約
- `withAdmin` / `withSuperAdmin` の catch ブロックはヘルパー呼び出しのみに簡素化
- 挙動差分は権限チェック部分のみ（監査ログの内容・エラーハンドリングは同一）

## 完了条件

- [x] 監査ログ失敗ハンドリングが 1 箇所に集約されている
- [x] `withAdmin` / `withSuperAdmin` の挙動差分は権限チェック部分のみになっている

## テスト

- `bun run test -- --run src/app/_actions/admin/__tests__/middleware.test.ts` — 3 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0254a1c8-a417-43f0-8385-94cf4d5533e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0254a1c8-a417-43f0-8385-94cf4d5533e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

