### PR TITLE
feat(return-records): DBトリガで total_amount を原子化

### DIFF
--- a/src/app/_actions/return-records/return-record-items.ts
+++ b/src/app/_actions/return-records/return-record-items.ts
@@ -7,7 +7,6 @@
 
 import { requireKoudenEditor } from "@/app/_actions/permissions";
 import { type ActionResult, ErrorCodes, KoudenError, withActionResult } from "@/lib/errors";
-import logger from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
 import type {
 	CreateReturnRecordItemInput,
@@ -54,8 +53,9 @@ export async function createReturnRecordItem(
 			throw new KoudenError("返礼品詳細情報の作成に失敗しました", ErrorCodes.DB_INSERT_ERROR);
 		}
 
-		// 返礼情報の合計金額を更新
-		await updateReturnRecordTotalAmount(input.return_record_id);
+		// 親 return_entry_records の total_amount は DB トリガ
+		// (recalc_return_entry_record_total_amount_trigger) が同一トランザクション内で
+		// 再集計するため、アプリ層での更新は不要。
 
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
@@ -160,8 +160,8 @@ export async function updateReturnRecordItem(
 			throw new KoudenError("返礼品詳細情報の更新に失敗しました", ErrorCodes.DB_UPDATE_ERROR);
 		}
 
-		// 返礼情報の合計金額を更新
-		await updateReturnRecordTotalAmount(existingItem.return_record_id);
+		// 親 return_entry_records の total_amount は DB トリガが再集計するため
+		// アプリ層での更新は不要。
 
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
@@ -203,60 +203,11 @@ export async function deleteReturnRecordItem(
 			throw error;
 		}
 
-		// 返礼情報の合計金額を更新
-		await updateReturnRecordTotalAmount(existingItem.return_record_id);
+		// 親 return_entry_records の total_amount は DB トリガが再集計するため
+		// アプリ層での更新は不要。
 
 		// キャッシュの再検証
 		revalidatePath(`/koudens/${koudenId}`);
 		return null;
 	}, "返礼品詳細情報の削除");
-}
-
-/**
- * 返礼情報の合計金額を更新する（内部関数）
- *
- * `return_record_items` の `price * quantity` を集計し、親 `return_entry_records`
- * の `total_amount` を更新する。失敗時は呼び出し元の `withActionResult` に伝播。
- */
-async function updateReturnRecordTotalAmount(returnRecordId: string): Promise<void> {
-	const supabase = await createClient();
-
-	// 返礼品詳細の合計金額を計算
-	const { data: items, error: itemsError } = await supabase
-		.from("return_record_items")
-		.select("price, quantity")
-		.eq("return_record_id", returnRecordId);
-
-	if (itemsError) {
-		logger.error(
-			{
-				error: itemsError.message,
-				returnRecordId,
-			},
-			"返礼情報の合計金額更新エラー",
-		);
-		throw itemsError;
-	}
-
-	const totalAmount = (items ?? []).reduce(
-		(sum, item) => sum + Number(item.price ?? 0) * Number(item.quantity ?? 0),
-		0,
-	);
-
-	// 親レコード (return_entry_records) の total_amount を更新
-	const { error: updateError } = await supabase
-		.from("return_entry_records")
-		.update({ total_amount: totalAmount })
-		.eq("id", returnRecordId);
-
-	if (updateError) {
-		logger.error(
-			{
-				error: updateError.message,
-				returnRecordId,
-			},
-			"返礼情報の合計金額更新エラー",
-		);
-		throw updateError;
-	}
 }

--- a/supabase/migrations/20260616000000_atomize_return_entry_record_total_amount.sql
+++ b/supabase/migrations/20260616000000_atomize_return_entry_record_total_amount.sql
@@ -1,0 +1,97 @@
+-- 2026-06-16: return_entry_records.total_amount を DB 側で原子化する
+-- Issue: https://github.com/otomatty/kouden/issues/132 (関連: #128, #122)
+--
+-- 背景:
+--   返礼情報の合計金額 (`return_entry_records.total_amount`) は
+--   `return_record_items` の `price * quantity` の総和として算出される。
+--   従来はアプリ層の `updateReturnRecordTotalAmount`
+--   (src/app/_actions/return-records/return-record-items.ts) が
+--   item の CRUD 後に「items を SELECT → reduce → 親を UPDATE」という
+--   2 段 UPDATE で更新していた。
+--
+-- 問題:
+--   - item の CRUD と `total_amount` 更新が同一トランザクションではないため、
+--     途中失敗で親だけ古い合計のまま残る。
+--   - 管理画面・バッチ・別 RPC など別経路から item を触ると合計がズレる
+--     (#122 と同型のサイレント不整合)。
+--
+-- 解決:
+--   `return_record_items` の INSERT / UPDATE / DELETE 後に親を再集計する
+--   AFTER ROW トリガを導入する。経路に依存せず、item を変更した同一
+--   トランザクション内で必ず `total_amount` が再計算されるため、
+--   アプリ層に依存せず一貫性が保たれる。
+--
+-- セキュリティ設計:
+--   - `SECURITY DEFINER` + `SET search_path = public, pg_temp` を採用。
+--     合計金額の整合性はデータ不変条件であり、どのロール・経路から item を
+--     変更しても親の再集計は常に成立させる必要がある。親
+--     (`return_entry_records`) 側 RLS の有無に左右されず invariant を担保する。
+--   - 集計対象は `return_record_items` の price * quantity のみで、
+--     アプリ層 `updateReturnRecordTotalAmount` と同一セマンティクスを維持する
+--     (`additional_return_amount` 等の他カラムは含めない)。
+
+-- 再集計トリガ関数
+CREATE OR REPLACE FUNCTION public.recalc_return_entry_record_total_amount()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_record_id uuid;
+BEGIN
+    -- 対象の親レコード ID を決定
+    IF TG_OP = 'DELETE' THEN
+        v_record_id := OLD.return_record_id;
+    ELSE
+        v_record_id := NEW.return_record_id;
+    END IF;
+
+    -- 親 (return_entry_records) の total_amount を再集計
+    UPDATE public.return_entry_records r
+    SET total_amount = COALESCE((
+        SELECT SUM(i.price * i.quantity)
+        FROM public.return_record_items i
+        WHERE i.return_record_id = v_record_id
+    ), 0)
+    WHERE r.id = v_record_id;
+
+    -- UPDATE で親 (return_record_id) が付け替えられた場合は旧親も再集計
+    IF TG_OP = 'UPDATE'
+       AND NEW.return_record_id IS DISTINCT FROM OLD.return_record_id THEN
+        UPDATE public.return_entry_records r
+        SET total_amount = COALESCE((
+            SELECT SUM(i.price * i.quantity)
+            FROM public.return_record_items i
+            WHERE i.return_record_id = OLD.return_record_id
+        ), 0)
+        WHERE r.id = OLD.return_record_id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.recalc_return_entry_record_total_amount() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS recalc_return_entry_record_total_amount_trigger
+    ON public.return_record_items;
+
+CREATE TRIGGER recalc_return_entry_record_total_amount_trigger
+AFTER INSERT OR UPDATE OR DELETE ON public.return_record_items
+FOR EACH ROW
+EXECUTE FUNCTION public.recalc_return_entry_record_total_amount();
+
+-- 既存データのバックフィル: 過去の 2 段 UPDATE 失敗等で生じたズレを是正する。
+-- item を持たない返礼情報は 0 に揃える。差分のある行のみ更新する。
+UPDATE public.return_entry_records r
+SET total_amount = COALESCE((
+    SELECT SUM(i.price * i.quantity)
+    FROM public.return_record_items i
+    WHERE i.return_record_id = r.id
+), 0)
+WHERE r.total_amount IS DISTINCT FROM COALESCE((
+    SELECT SUM(i.price * i.quantity)
+    FROM public.return_record_items i
+    WHERE i.return_record_id = r.id
+), 0);


### PR DESCRIPTION
return_entry_records.total_amount を return_record_items の INSERT/
UPDATE/DELETE 後に再集計する AFTER ROW トリガを追加。経路に依存せず
同一トランザクション内で合計が更新されるため、アプリ層の 2 段 UPDATE
(updateReturnRecordTotalAmount) を削除し、DB を真実の源とする。

- 既存データのドリフトはマイグレーション内でバックフィル
- item 変更後のアプリ層合計更新呼び出しを削除

Closes #132

https://claude.ai/code/session_01NkQ9dp7C5AYBDgwnwNDJ8V